### PR TITLE
ci: ship installer as .zip alongside .exe on tag releases

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,15 +1,21 @@
 name: Build Windows installer
 
-# Builds the Inno Setup .exe whenever files under packages/local-win/ change
-# on any branch, or on manual dispatch. Uploads SeasonSprintSetup.exe as a
-# downloadable artifact on every run.
+# Builds the Inno Setup .exe whenever files under packages/local-win/ change,
+# on manual dispatch, or on a v* tag push. Every run uploads
+# SeasonSprintSetup.exe as a workflow artifact; tag pushes additionally
+# publish a GitHub Release with the installer attached.
 
 on:
   push:
     paths:
       - "packages/local-win/**"
       - ".github/workflows/build-windows-installer.yml"
+    tags:
+      - "v*"
   workflow_dispatch:
+
+permissions:
+  contents: write  # needed to create GitHub Releases on tag push
 
 jobs:
   build-installer:
@@ -32,9 +38,30 @@ jobs:
         run: |
           "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss
 
-      - name: Upload installer artifact
+      - name: Zip installer
+        # Browser download scanners (Chrome SafeBrowsing, Defender ML heuristics)
+        # aggressively flag unsigned .exe files. They generally don't unpack
+        # zips, so we ship a .zip alongside the .exe as an unblockable fallback.
+        shell: pwsh
+        working-directory: packages/local-win/dist
+        run: |
+          Compress-Archive -Path SeasonSprintSetup.exe -DestinationPath SeasonSprintSetup.zip -CompressionLevel Optimal -Force
+
+      - name: Upload installer artifacts
         uses: actions/upload-artifact@v4
         with:
           name: SeasonSprintSetup
-          path: packages/local-win/dist/SeasonSprintSetup.exe
+          path: |
+            packages/local-win/dist/SeasonSprintSetup.exe
+            packages/local-win/dist/SeasonSprintSetup.zip
           if-no-files-found: error
+
+      - name: Publish GitHub Release (on v* tag only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            packages/local-win/dist/SeasonSprintSetup.exe
+            packages/local-win/dist/SeasonSprintSetup.zip
+          draft: false
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
Two additions to the Windows installer workflow:
- Build step now also creates \`SeasonSprintSetup.zip\` alongside the \`.exe\`. Chrome SafeBrowsing and Windows Defender ML heuristics false-positive on unsigned \`.exe\` files; they don't unpack zips, so the zip is an unblockable fallback for testers.
- Triggers on \`v*\` tag push and publishes a GitHub Release with both \`.exe\` and \`.zip\` attached. Adds \`permissions: contents: write\` so the release action can create the release.

## Test plan
- [ ] Merge → verify normal branch CI still uploads both files as artifacts
- [ ] Push a \`v0.1.1\` tag → verify workflow publishes a release with both \`.exe\` and \`.zip\`
- [ ] In Chrome, downloading the \`.zip\` from the release URL completes without a virus warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)