### PR TITLE
chore(installer): bump AppVersion to 0.1.1

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -11,7 +11,7 @@
 ; Output: dist\SeasonSprintSetup.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.0"
+#define AppVersion    "0.1.1"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 


### PR DESCRIPTION
Pre-tag bump so installer metadata matches the v0.1.1 tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 0.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->