### PR TITLE
feat(local-win): live log tail for in-game verification

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: packages/local-win
         run: |
           Compress-Archive `
-            -Path setup.bat, install-deps.bat, launch.bat, season_tracker.py, test_ocr.py, requirements.txt, .env.example `
+            -Path setup.bat, install-deps.bat, launch.bat, watch-tracker.bat, season_tracker.py, test_ocr.py, requirements.txt, .env.example `
             -DestinationPath dist/SeasonSprintTracker-source.zip `
             -CompressionLevel Optimal `
             -Force

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,11 @@ packages/local/bench_c
 packages/local/bench_ocr.py
 packages/local/bench_pipeline.py
 
-# Windows tracker (Python) — venv, state, bytecode, installer output
+# Windows tracker (Python) — venv, state, bytecode, installer output, logs
 packages/local-win/.venv/
 packages/local-win/.last-wtp
 packages/local-win/.tracker-pid
+packages/local-win/tracker.log
 packages/local-win/__pycache__/
 packages/local-win/**/__pycache__/
 packages/local-win/dist/

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -11,7 +11,7 @@
 ; Output: dist\SeasonSprintSetup.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.1"
+#define AppVersion    "0.1.2"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -48,6 +48,7 @@ Source: "..\test_ocr.py";       DestDir: "{app}"; Flags: ignoreversion
 Source: "..\setup.bat";         DestDir: "{app}"; Flags: ignoreversion
 Source: "..\install-deps.bat";  DestDir: "{app}"; Flags: ignoreversion
 Source: "..\launch.bat";        DestDir: "{app}"; Flags: ignoreversion
+Source: "..\watch-tracker.bat"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\Reconfigure tracker";  Filename: "{app}\setup.bat"; Parameters: "--install-only"; WorkingDir: "{app}"

--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -49,11 +49,50 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 ENV_FILE = SCRIPT_DIR / ".env"
 STATE_FILE = SCRIPT_DIR / ".last-wtp"
 PID_FILE = SCRIPT_DIR / ".tracker-pid"
+LOG_FILE = SCRIPT_DIR / "tracker.log"
 
 POLL_INTERVAL_SECS = 3
 COOLDOWN_SECS = 300  # 5 min after a confirmed read
 CONFIRM_READS = 2    # how many identical reads in a row count as "confirmed"
 HTTP_TIMEOUT = 10
+
+
+# ── Tee stdout/stderr to a log file ───────────────────────────────────────────
+#
+# When launched headlessly via pythonw.exe (no console window), all print()
+# output would otherwise vanish. Tee'ing to tracker.log gives testers a way
+# to verify the tracker is working — they can live-tail it from
+# watch-tracker.bat while the game runs.
+
+class _Tee:
+    def __init__(self, *streams):
+        # pythonw.exe sets sys.__stdout__ to None; filter those out.
+        self.streams = [s for s in streams if s is not None]
+
+    def write(self, data):
+        for s in self.streams:
+            try:
+                s.write(data)
+            except Exception:
+                pass
+        self.flush()
+
+    def flush(self):
+        for s in self.streams:
+            try:
+                s.flush()
+            except Exception:
+                pass
+
+try:
+    _log_handle = open(LOG_FILE, "a", buffering=1, encoding="utf-8")
+    sys.stdout = _Tee(sys.__stdout__, _log_handle)
+    sys.stderr = _Tee(sys.__stderr__, _log_handle)
+    print(f"\n=== Tracker started {dt.datetime.now().isoformat(timespec='seconds')} ===")
+except OSError:
+    # Couldn't open the log file (read-only install dir, etc.) — fall back to
+    # whatever stdout the runtime gave us.
+    pass
 
 
 # ── Config ────────────────────────────────────────────────────────────────────

--- a/packages/local-win/watch-tracker.bat
+++ b/packages/local-win/watch-tracker.bat
@@ -1,0 +1,33 @@
+@echo off
+REM Live tail of tracker.log so you can verify the tracker is working
+REM while the game runs.
+REM
+REM Usage: double-click after launching the game via Steam (with the
+REM        launch.bat option set). A window opens and prints each new
+REM        log line as it arrives — you should see [ocr Xms] lines
+REM        repeating every few seconds, and "Pushed winPoints=N" when
+REM        the tracker detects a new score.
+REM
+REM Close the window when you're done watching; the tracker keeps running
+REM regardless.
+
+title Season Sprint Tracker - Live Log
+pushd "%~dp0"
+
+if not exist "tracker.log" (
+    echo.
+    echo No tracker.log yet.
+    echo.
+    echo Launch the game through Steam first ^(with the launch.bat Steam
+    echo Launch Option set^), then re-run this file. The log appears as
+    echo soon as the tracker starts polling.
+    echo.
+    pause
+    popd & exit /b 0
+)
+
+echo Tailing tracker.log. Press Ctrl+C or close this window to stop watching.
+echo.
+powershell -NoProfile -Command "Get-Content -Path .\tracker.log -Wait -Tail 100"
+
+popd


### PR DESCRIPTION
## Summary
Headless \`pythonw.exe\` launches via Steam currently produce no visible output — testers can't tell if the tracker is actually working without checking the server. Adds a tee-to-logfile + a live-tail .bat helper.

### Changes
- **season_tracker.py**: tees stdout/stderr to \`tracker.log\` next to the script, filtering out \`None\` streams (pythonw.exe sets \`sys.__stdout__\` to None). Adds a session-start header per launch.
- **watch-tracker.bat** (new): PowerShell \`Get-Content -Wait\` window that live-tails the log. Tester double-clicks during gameplay, alt-tabs between game and log to verify OCR is firing.
- **installer.iss**: adds watch-tracker.bat to [Files] so the .exe installer ships it. \`AppVersion\` bumped to 0.1.2.
- **CI workflow**: focused tracker source zip now also includes watch-tracker.bat.
- **.gitignore**: excludes tracker.log for dev hygiene.

## Test plan
- [ ] Tag v0.1.2 after merge → CI builds installer with new file → install in VM
- [ ] Launch the (real) game with the Steam Launch Option set
- [ ] Double-click watch-tracker.bat → PowerShell window shows live \`[ocr Xms]\` lines
- [ ] Verify a confirmed-read \`Pushed winPoints=N\` line appears when WTP changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)