### PR TITLE
feat(local-win): make launch.bat self-explain when run without Steam …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Windows shell scripts must ship with CRLF line endings — the cmd.exe
+# parser reads scripts in 512-byte chunks and can mis-split LF-only lines
+# at the boundary, occasionally truncating commands or labels in ways
+# that are hard to reproduce.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Inno Setup scripts are compiled by ISCC.exe on Windows; treat them the
+# same way for consistency.
+*.iss text eol=crlf

--- a/packages/local-win/launch.bat
+++ b/packages/local-win/launch.bat
@@ -55,7 +55,7 @@ REM Run the game and wait for it to exit. %* is the game exe + its args.
 
 REM Game exited — stop the tracker by its PID if the file is present.
 if exist "%~dp0.tracker-pid" (
-    for /f %%P in (%~dp0.tracker-pid) do taskkill /F /PID %%P >nul 2>&1
+    for /f "usebackq" %%P in ("%~dp0.tracker-pid") do taskkill /F /PID %%P >nul 2>&1
     del "%~dp0.tracker-pid" >nul 2>&1
 )
 

--- a/packages/local-win/launch.bat
+++ b/packages/local-win/launch.bat
@@ -5,11 +5,47 @@ REM Steam invokes this as: "launch.bat" %command%
 REM Effect: start the tracker headless (pythonw.exe, no console window),
 REM run the game synchronously, then stop the tracker by PID when the game
 REM exits. The tracker writes .tracker-pid on startup; we consume it here.
+REM
+REM If invoked with no args (e.g. double-clicked), this is a misuse —
+REM print a helpful message and offer to run the tracker in foreground
+REM with a visible console so the user can verify the install.
 
 setlocal
 pushd "%~dp0"
 
-set "VENV_PYW=%USERPROFILE%\.season-sprint\venv\Scripts\pythonw.exe"
+set "VENV_DIR=%USERPROFILE%\.season-sprint\venv"
+set "VENV_PY=%VENV_DIR%\Scripts\python.exe"
+set "VENV_PYW=%VENV_DIR%\Scripts\pythonw.exe"
+
+if not exist "%VENV_PY%" (
+    echo.
+    echo ERROR: Tracker venv not found at:
+    echo   %VENV_DIR%
+    echo.
+    echo Run setup.bat first to install Python + dependencies.
+    echo.
+    pause
+    popd & endlocal & exit /b 1
+)
+
+REM No game args = not invoked by Steam. Run the tracker in foreground
+REM so the user can see output, then exit.
+if "%~1"=="" (
+    echo.
+    echo This file is a Steam launch wrapper, not a standalone launcher.
+    echo Steam invokes it as: "launch.bat" %%command%%
+    echo.
+    echo To use it with a game, paste this into Steam ^> Properties ^>
+    echo Launch Options:
+    echo.
+    echo     "%~dp0launch.bat" %%command%%
+    echo.
+    echo Running the tracker now in this window so you can verify the
+    echo install. Press Ctrl+C to stop.
+    echo.
+    "%VENV_PY%" "%~dp0season_tracker.py"
+    popd & endlocal & exit /b 0
+)
 
 REM Start the tracker headless in the background.
 start "" /B "%VENV_PYW%" "%~dp0season_tracker.py"


### PR DESCRIPTION
…args

Previously, double-clicking launch.bat (or running it outside Steam) flashed a window: it spawned the tracker via pythonw.exe (no console), then immediately fell through the empty %* and the kill block, leaving the user with no visible feedback and no way to tell whether the install worked.

Now, when invoked without args:
  - verifies the venv exists and tells the user to run setup.bat if not
  - prints the Steam Launch Options line they need to paste
  - runs the tracker in the foreground via python.exe (visible console) so they can verify the install and see OCR output

Steam-invoked path (with %command% supplying game args) is unchanged.

Also relocates launch.bat from packages/local-win/installer/ to packages/local-win/ to match the path installer.iss already references (..\\launch.bat).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced launcher script with improved error handling and validation for better reliability and clearer setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->