### PR TITLE
fix(local-win): three small hardening fixes from security review

### DIFF
--- a/packages/local-win/launch.bat
+++ b/packages/local-win/launch.bat
@@ -54,8 +54,10 @@ REM Run the game and wait for it to exit. %* is the game exe + its args.
 %*
 
 REM Game exited — stop the tracker by its PID if the file is present.
+REM Filter on IMAGENAME=pythonw.exe so a stale .tracker-pid pointing at a
+REM reused PID can't accidentally kill an unrelated process the user owns.
 if exist "%~dp0.tracker-pid" (
-    for /f "usebackq" %%P in ("%~dp0.tracker-pid") do taskkill /F /PID %%P >nul 2>&1
+    for /f "usebackq" %%P in ("%~dp0.tracker-pid") do taskkill /F /FI "IMAGENAME eq pythonw.exe" /FI "PID eq %%P" >nul 2>&1
     del "%~dp0.tracker-pid" >nul 2>&1
 )
 

--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -98,19 +98,44 @@ except OSError:
 # ── Config ────────────────────────────────────────────────────────────────────
 
 
-@dataclass
+@dataclass(repr=False)
 class Config:
     server_url: str
     auth_token: str
     monitor_index: int  # mss convention: 0 = all, 1 = primary, 2+ = others
 
+    def __repr__(self) -> str:
+        # Redact auth_token. Everything printed by this script is tee'd to
+        # tracker.log (see _Tee below), which watch-tracker.bat happily
+        # tails — a stray `print(cfg)` or an exception whose repr includes
+        # the Config would otherwise leak the token to a file the user can
+        # easily share. Never log self.auth_token directly anywhere else.
+        t = self.auth_token
+        masked = (t[:5] + "…" + t[-4:]) if len(t) > 12 else "<redacted>"
+        return (
+            f"Config(server_url={self.server_url!r}, "
+            f"auth_token={masked!r}, monitor_index={self.monitor_index})"
+        )
+
 
 def _normalize_server_url(raw: str) -> str:
     """Strip whitespace / trailing slash, and add https:// if no scheme was
     supplied. Users routinely paste bare hostnames like
-    `my-worker.workers.dev`, which `requests` rejects with MissingSchema."""
+    `my-worker.workers.dev`, which `requests` rejects with MissingSchema.
+
+    Rejects http:// outright — every request from this script carries the
+    AUTH_TOKEN in the Authorization header, so plain HTTP would expose it
+    on the wire."""
     raw = raw.strip().rstrip("/")
-    if raw and not raw.startswith(("http://", "https://")):
+    if not raw:
+        return raw
+    if raw.startswith("http://"):
+        raise ValueError(
+            "SERVER_URL must use https:// — sending your AUTH_TOKEN over "
+            "plain HTTP would expose it on the network. For a local dev "
+            "server, front it with cloudflared / ngrok or use https://localhost."
+        )
+    if not raw.startswith("https://"):
         raw = "https://" + raw
     return raw
 
@@ -152,12 +177,19 @@ def _prompt_config() -> Config:
 
     print("═══ Season Sprint Tracker — Setup ═══\n")
 
-    server_url = _normalize_server_url(existing.get("SERVER_URL", ""))
+    try:
+        server_url = _normalize_server_url(existing.get("SERVER_URL", ""))
+    except ValueError as e:
+        print(f"  Existing SERVER_URL rejected: {e}\n")
+        server_url = ""
     if not server_url:
         print("SERVER_URL — your Season Sprint API URL")
         print("  (e.g. https://your-worker.workers.dev)")
         while not server_url:
-            server_url = _normalize_server_url(input("SERVER_URL: "))
+            try:
+                server_url = _normalize_server_url(input("SERVER_URL: "))
+            except ValueError as e:
+                print(f"  ERROR: {e}\n")
 
     auth_token = existing.get("AUTH_TOKEN", "")
     if not auth_token:
@@ -221,8 +253,14 @@ def load_or_prompt_config() -> Config:
     needed = {"SERVER_URL", "AUTH_TOKEN", "MONITOR_INDEX"}
     if not needed.issubset(env) or not env["MONITOR_INDEX"].isdigit():
         return _prompt_config()
+    try:
+        server_url = _normalize_server_url(env["SERVER_URL"])
+    except ValueError as e:
+        print(f"[config] {e}")
+        print("[config] re-running setup to fix SERVER_URL ...\n")
+        return _prompt_config()
     return Config(
-        server_url=_normalize_server_url(env["SERVER_URL"]),
+        server_url=server_url,
         auth_token=env["AUTH_TOKEN"],
         monitor_index=int(env["MONITOR_INDEX"]),
     )


### PR DESCRIPTION
## Summary

Three small, scoped fixes from the security review of `packages/local-win/` — the high-value items that don't require dependency or infra changes.

- **`_normalize_server_url` rejects `http://`** — every request carries the AUTH_TOKEN in the Authorization header, so plain HTTP would expose it. Bare hostnames still get auto-prefixed with `https://`. Interactive prompt re-asks on bad input; .env-load path falls back to re-running setup.
- **`launch.bat` taskkill adds `IMAGENAME=pythonw.exe` filter** — Windows PID reuse is rare but real. A stale `.tracker-pid` pointing at a recycled PID would otherwise force-kill an unrelated user-owned process. With the filter, the taskkill no-ops if the PID has been reused.
- **`Config` gets a redacting `__repr__`** — stdout/stderr is tee'd to `tracker.log` (which `watch-tracker.bat` tails for testers). A future `print(cfg)` or an exception whose repr includes a Config would otherwise leak the token to a file the user can easily share. The override is explicit via `dataclass(repr=False)`.

Skipped from the review (need separate decisions):
- requirements.txt version pinning (#2) — bigger change, needs `pip-compile`
- DPAPI for AUTH_TOKEN (#3) — Windows-specific, probably overkill for a personal API key
- Code-signing the installer (#5) — procurement
- SHA-pin GitHub Actions (#6) — separate PR

## Test plan

- [ ] Run `setup.bat` with `http://example.com` pasted at the SERVER_URL prompt — should print the rejection error and re-ask.
- [ ] Run `setup.bat` with `example.workers.dev` — should auto-prefix `https://` and accept.
- [ ] Edit existing `.env` to use `http://...` and re-run the tracker — should print the warning and re-prompt for SERVER_URL.
- [ ] `python -c "from season_tracker import Config; print(Config('https://x', 'sk_secret_token_xyz', 1))"` — token should be masked in the output.
- [ ] Steam-launch the game with the new `launch.bat`, exit the game, confirm `pythonw.exe` is gone from Task Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process shutdown logic to verify process identity before termination, reducing risk of unintended kills.
  * Enhanced security by rejecting unencrypted server connections and redacting authentication tokens from log output.
  * Added URL validation during setup to prevent credential exposure and ensure proper configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->