### PR TITLE
fix(local-win): log response body on push failure

### DIFF
--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -367,6 +367,13 @@ def push_record(cfg: Config, win_points: int) -> bool:
         return False
     ok = r.status_code in (200, 201)
     print(f"[push] winPoints={win_points} date={today} HTTP {r.status_code} {'OK' if ok else 'FAIL'}")
+    if not ok:
+        # Include the response body (truncated) so the user can see why.
+        # 4xx usually carries a server message; 5xx is often empty or a
+        # generic Cloudflare page. Strip newlines so it stays one log line.
+        body = (r.text or "").strip().replace("\n", " ")[:500]
+        if body:
+            print(f"[push]   response body: {body}")
     return ok
 
 


### PR DESCRIPTION
## Summary

Diagnosing a real 400 from the server right now and `push_record` only logs the status code. Add the response body (truncated to 500 chars, newlines stripped) to the failure log so the user can self-diagnose.

## Test plan

- [ ] Hit `/me/records` with a deliberately bad body (e.g. `winPoints: "not a number"`) and confirm the new line appears in `tracker.log` / console.
- [ ] Confirm 200/201 path stays unchanged (no extra log line on success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)