### PR TITLE
chore(installer): bump AppVersion to 0.1.3

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -11,7 +11,7 @@
 ; Output: dist\SeasonSprintSetup.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.2"
+#define AppVersion    "0.1.3"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 


### PR DESCRIPTION
Aligns Inno installer version with the upcoming v0.1.3 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->