### PR TITLE
fix(server): harden getEmail against Clerk-SDK-on-Workers throws

### DIFF
--- a/packages/server/src/getEmail.ts
+++ b/packages/server/src/getEmail.ts
@@ -15,6 +15,19 @@ export default async function getEmail(
     return `${userId}@dev.local`;
   }
 
-  const user = await clerkClient.users.getUser(userId);
-  return user.emailAddresses[0]?.emailAddress ?? `${userId}@unknown.local`;
+  // @clerk/clerk-sdk-node is a Node SDK and is fragile inside Cloudflare
+  // Workers (V8 isolates, no Node runtime). It can throw at runtime — for
+  // example if a tester's User row has no cached email, we end up here, and
+  // an unhandled throw becomes a generic 500 with no body. Catch and fall
+  // back to a synthesized email so the caller's upsert path keeps working.
+  try {
+    const user = await clerkClient.users.getUser(userId);
+    return user.emailAddresses[0]?.emailAddress ?? `${userId}@unknown.local`;
+  } catch (err) {
+    console.warn(
+      `[getEmail] Clerk lookup failed for userId=${userId}, falling back to synthesized email:`,
+      err
+    );
+    return `${userId}@unknown.local`;
+  }
 }

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -39,7 +39,13 @@ export const resolveAuth: MiddlewareHandler<Env> = async (c, next) => {
     if (!user) {
       return c.text("Unauthorized", 401);
     }
-    c.set("auth", { userId: user.clerkUserId, email: user.email });
+    // Coerce empty/null email to undefined so getEmail's `if (cachedEmail)`
+    // check is unambiguous. We deliberately do NOT fall through to a Clerk
+    // lookup here — see getEmail.ts for the fallback chain.
+    c.set("auth", {
+      userId: user.clerkUserId,
+      email: user.email || undefined,
+    });
     return next();
   }
 


### PR DESCRIPTION
## Summary

Fixes a 500 on \`POST /me/records\` reproducible by some API-key-authed testers but not others. The split is by whether the user's \`User.email\` column in D1 is populated:

- Populated → \`getEmail\` returns the cached email immediately. Works.
- Empty / null → \`getEmail\` falls through to \`clerkClient.users.getUser(userId)\`, which is \`@clerk/clerk-sdk-node\` (a **Node SDK**) running in a Cloudflare Worker (V8 isolate, no Node runtime). It throws. Hono returns the generic \`Internal Server Error\` body with no Hono error handler firing. The route doesn't catch.

Two small changes:

1. **\`middleware/auth.ts\`** — API-key auth path coerces empty-string \`user.email\` to \`undefined\` so \`getEmail\`'s \`if (cachedEmail)\` short-circuit is unambiguous.
2. **\`getEmail.ts\`** — wraps the Clerk lookup in \`try/catch\`. On failure, logs to worker console and falls back to \`\${userId}@unknown.local\` — same synthesized-email shape the success path already uses when Clerk returns no addresses.

Combined effect: the route can no longer 500 just because \`getEmail\` throws on a Workers-incompatible SDK. The synthesized email is only written into the DB on the \`User\` upsert's create-clause, so for existing users (which all API-key-authed users are by construction) it never lands.

## Test plan

- [ ] Curl \`POST /me/records\` with a token whose \`User.email\` is empty. Was 500. Now 200.
- [ ] Curl with a token whose \`User.email\` is populated. Stays 200.
- [ ] Watch \`wrangler tail\` — Clerk-throw path now prints \`[getEmail] Clerk lookup failed ...\` instead of 500'ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email resolution robustness with fallback handling for authentication failures.
  * Enhanced email value normalization in authentication flows to ensure consistent data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->