### PR TITLE
fix(local-win): reject empty AUTH_TOKEN at config-load time

### DIFF
--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -222,11 +222,24 @@ def _probe_server(cfg: Config) -> tuple[bool, int]:
 def load_or_prompt_config() -> Config:
     env = _parse_env_file(ENV_FILE)
     needed = {"AUTH_TOKEN", "MONITOR_INDEX"}
-    if not needed.issubset(env) or not env["MONITOR_INDEX"].isdigit():
+    # Re-prompt if any field is missing OR present-but-empty/invalid.
+    # An `AUTH_TOKEN=` line in .env (empty value) used to pass issubset()
+    # and silently propagate an empty token to push_record, which sent
+    # `Authorization: ` and got bounced at Cloudflare's edge with an empty
+    # 400 — invisible in wrangler tail and impossible to diagnose without
+    # the request dump.
+    auth_token = env.get("AUTH_TOKEN", "").strip()
+    monitor_raw = env.get("MONITOR_INDEX", "").strip()
+    if (
+        not needed.issubset(env)
+        or not auth_token
+        or not monitor_raw.isdigit()
+        or int(monitor_raw) <= 0
+    ):
         return _prompt_config()
     return Config(
-        auth_token=env["AUTH_TOKEN"],
-        monitor_index=int(env["MONITOR_INDEX"]),
+        auth_token=auth_token,
+        monitor_index=int(monitor_raw),
     )
 
 


### PR DESCRIPTION
## Summary

A tester's tracker was POSTing with an empty \`Authorization: \` header on every push, getting bounced at Cloudflare's edge with a bare \`400\` (no body, no \`Server\` header) before our worker ever ran. \`wrangler tail\` showed zero \`/me/records\` events, masking the issue completely. The cause: their \`.env\` had \`AUTH_TOKEN=\` (empty value), and \`load_or_prompt_config\` only checked that keys were present, not that values were non-empty — so the empty token sailed through into \`push_record\`.

(The masked-token dump from #72 is what finally caught this — the request log showed \`'Authorization': '<redacted>'\`, and \`<redacted>\` is what \`_mask_token\` returns when \`len(token) <= 12\`. Without that we'd still be guessing.)

## Change

\`load_or_prompt_config\` now validates that:
- \`AUTH_TOKEN\` exists **and** is non-empty (after \`.strip()\`)
- \`MONITOR_INDEX\` exists **and** is a positive integer

Any failure re-runs \`_prompt_config\`, which already loops on empty input. No more silent empty-token pushes.

## Test plan

- [ ] Edit \`.env\` to \`AUTH_TOKEN=\` (empty value), re-run the tracker — should drop into the setup prompt instead of silently 400'ing on the next push.
- [ ] Same for \`MONITOR_INDEX=\` or \`MONITOR_INDEX=0\` or \`MONITOR_INDEX=foo\`.
- [ ] Normal happy-path \`.env\` still loads fine without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)