### PR TITLE
feat(ios): add/edit/delete points (Log tab) + graph polish

### DIFF
--- a/packages/ios/Sources/SeasonSprint/Networking/APIClient.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/APIClient.swift
@@ -29,6 +29,45 @@ enum APIClient {
         return try JSONDecoder().decode([APIRecord].self, from: data)
     }
 
+    /// `POST /me/records` — upsert a record by date; returns the saved record.
+    @MainActor
+    static func upsertRecord(date: String, winPoints: Int) async throws -> APIRecord {
+        guard let auth = await authorizationHeader() else { throw APIError.notAuthenticated }
+        var req = URLRequest(url: Config.serverURL.appendingPathComponent("me/records"))
+        req.httpMethod = "POST"
+        req.setValue(auth, forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(RecordWrite(date: date, winPoints: winPoints))
+        let (data, response) = try await URLSession.shared.data(for: req)
+        try check(response)
+        return try JSONDecoder().decode(UpsertResponse.self, from: data).record
+    }
+
+    /// `PUT /me/records/:id` — edit a record in place; returns the updated record.
+    @MainActor
+    static func updateRecord(id: String, date: String, winPoints: Int) async throws -> APIRecord {
+        guard let auth = await authorizationHeader() else { throw APIError.notAuthenticated }
+        var req = URLRequest(url: Config.serverURL.appendingPathComponent("me/records/\(id)"))
+        req.httpMethod = "PUT"
+        req.setValue(auth, forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONEncoder().encode(RecordWrite(date: date, winPoints: winPoints))
+        let (data, response) = try await URLSession.shared.data(for: req)
+        try check(response)
+        return try JSONDecoder().decode(APIRecord.self, from: data)
+    }
+
+    /// `DELETE /me/records/:id`
+    @MainActor
+    static func deleteRecord(id: String) async throws {
+        guard let auth = await authorizationHeader() else { throw APIError.notAuthenticated }
+        var req = URLRequest(url: Config.serverURL.appendingPathComponent("me/records/\(id)"))
+        req.httpMethod = "DELETE"
+        req.setValue(auth, forHTTPHeaderField: "Authorization")
+        let (_, response) = try await URLSession.shared.data(for: req)
+        try check(response)
+    }
+
     /// `GET /seasons` — public (no auth); returns the current season window, or nil.
     static func getSeasons() async throws -> Season? {
         let req = URLRequest(url: Config.serverURL.appendingPathComponent("seasons"))

--- a/packages/ios/Sources/SeasonSprint/Networking/Models.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/Models.swift
@@ -26,6 +26,17 @@ struct SeasonsResponse: Codable, Sendable {
     let currentSeason: Season?
 }
 
+/// Request body for creating/updating a record.
+struct RecordWrite: Encodable, Sendable {
+    let date: String
+    let winPoints: Int
+}
+
+/// Response from `POST /me/records`.
+struct UpsertResponse: Decodable, Sendable {
+    let record: APIRecord
+}
+
 /// A normalized point for the dashboard: one cumulative win-points value per day.
 /// Mirrors the `{ remoteId, date, y }` shape used in the web app's usePointsData.js.
 struct Point: Identifiable, Sendable, Equatable {
@@ -63,10 +74,24 @@ enum DateKey {
 
     /// Today's local day key (matches the web app, which keys "today" by local date).
     static func today() -> String {
-        let local = DateFormatter()
-        local.calendar = Calendar(identifier: .gregorian)
-        local.locale = Locale(identifier: "en_US_POSIX")
-        local.dateFormat = "yyyy-MM-dd"
-        return local.string(from: Date())
+        dayString(from: Date())
+    }
+
+    private static let localDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// Local `yyyy-MM-dd` day key for an arbitrary date (for the entry DatePicker).
+    static func dayString(from date: Date) -> String {
+        localDayFormatter.string(from: date)
+    }
+
+    /// Parse a `yyyy-MM-dd` day key into a local-midnight Date (to seed a DatePicker).
+    static func localDate(from day: String) -> Date? {
+        localDayFormatter.date(from: day)
     }
 }

--- a/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
@@ -139,6 +139,50 @@ final class DashboardStore {
         }
     }
 
+    // MARK: Writes
+
+    private(set) var isWriting = false
+
+    /// Add or overwrite the record for a day (`POST /me/records`).
+    func addOrSet(date: String, winPoints: Int) async {
+        isWriting = true
+        defer { isWriting = false }
+        do {
+            let record = try await APIClient.upsertRecord(date: date, winPoints: winPoints)
+            upsert(record)
+        } catch {
+            errorMessage = "Couldn't save that point."
+        }
+    }
+
+    /// Edit an existing record in place (`PUT /me/records/:id`). Handles a date change by
+    /// dropping the old day entry once the server confirms.
+    func updatePoint(_ point: Point, date: String, winPoints: Int) async {
+        isWriting = true
+        defer { isWriting = false }
+        do {
+            let updated = try await APIClient.updateRecord(id: point.remoteId, date: date, winPoints: winPoints)
+            if point.day != String(updated.date.prefix(10)) {
+                points.removeAll { $0.remoteId == point.remoteId }
+            }
+            upsert(updated)
+        } catch {
+            errorMessage = "Couldn't update that point."
+            await load()
+        }
+    }
+
+    /// Delete a record (`DELETE /me/records/:id`), optimistically removing it locally.
+    func deletePoint(_ point: Point) async {
+        points.removeAll { $0.remoteId == point.remoteId }
+        do {
+            try await APIClient.deleteRecord(id: point.remoteId)
+        } catch {
+            errorMessage = "Couldn't delete that point."
+            await load()
+        }
+    }
+
     private func upsert(_ record: APIRecord) {
         let point = Point(record: record)
         if let idx = points.firstIndex(where: { $0.remoteId == point.remoteId || $0.day == point.day }) {

--- a/packages/ios/Sources/SeasonSprint/Views/EditPointSheet.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/EditPointSheet.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Edit an existing record's date and value (`PUT /me/records/:id`).
+struct EditPointSheet: View {
+    let store: DashboardStore
+    let point: Point
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var date: Date
+    @State private var valueText: String
+
+    init(store: DashboardStore, point: Point) {
+        self.store = store
+        self.point = point
+        _date = State(initialValue: DateKey.localDate(from: point.day) ?? Date())
+        _valueText = State(initialValue: "\(point.winPoints)")
+    }
+
+    private var parsedValue: Int? {
+        Int(valueText.trimmingCharacters(in: .whitespaces))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                DatePicker("Date", selection: $date, displayedComponents: .date)
+                TextField("Win points", text: $valueText)
+                    .keyboardType(.numberPad)
+            }
+            .navigationTitle("Edit point")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") {
+                        guard let value = parsedValue else { return }
+                        Task {
+                            await store.updatePoint(point, date: DateKey.dayString(from: date), winPoints: value)
+                            dismiss()
+                        }
+                    }
+                    .disabled(parsedValue == nil)
+                }
+            }
+        }
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
@@ -19,6 +19,7 @@ struct GraphTabView: View {
                         goal: store.goal,
                         rank: store.rank,
                         pace: store.pace,
+                        todayGain: store.todayGain,
                         showRankOverlay: settings.showRankOverlay,
                         showAveragePace: settings.showAveragePace,
                         showDeviationWedge: settings.showDeviationWedge
@@ -50,14 +51,16 @@ private struct CompactSummary: View {
     var body: some View {
         let accent = tierColor(rank.badge)
         VStack(spacing: 8) {
-            HStack(alignment: .firstTextBaseline) {
-                Text(rank.badge)
-                    .font(.title3.bold())
-                    .foregroundStyle(accent)
-                if isLive {
-                    Image(systemName: "dot.radiowaves.left.and.right")
-                        .font(.caption2)
-                        .foregroundStyle(.green)
+            HStack(alignment: .center) {
+                HStack(alignment: .center, spacing: 6) {
+                    Text(rank.badge)
+                        .font(.title3.bold())
+                        .foregroundStyle(accent)
+                    if isLive {
+                        Image(systemName: "dot.radiowaves.left.and.right")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                    }
                 }
                 Spacer()
                 Text("\(rank.points)")

--- a/packages/ios/Sources/SeasonSprint/Views/LogTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/LogTabView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Log tab: add/overwrite a point for a date, and an editable list of all records.
+struct LogTabView: View {
+    let store: DashboardStore
+    @Binding var showSettings: Bool
+
+    @State private var newDate = Date()
+    @State private var newValueText = ""
+    @State private var editing: Point?
+
+    private var parsedNewValue: Int? {
+        Int(newValueText.trimmingCharacters(in: .whitespaces))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    DatePicker("Date", selection: $newDate, displayedComponents: .date)
+                    TextField("Win points", text: $newValueText)
+                        .keyboardType(.numberPad)
+                    Button {
+                        guard let value = parsedNewValue else { return }
+                        Task {
+                            await store.addOrSet(date: DateKey.dayString(from: newDate), winPoints: value)
+                            newValueText = ""
+                        }
+                    } label: {
+                        if store.isWriting {
+                            ProgressView()
+                        } else {
+                            Text("Save point")
+                        }
+                    }
+                    .disabled(parsedNewValue == nil || store.isWriting)
+                } header: {
+                    Text("Add point")
+                } footer: {
+                    Text("Points are your cumulative season total. Saving a date that already exists overwrites it.")
+                }
+
+                Section("Records") {
+                    if store.points.isEmpty {
+                        Text("No records yet.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(recordsNewestFirst) { point in
+                            Button {
+                                editing = point
+                            } label: {
+                                HStack {
+                                    Text(point.date, format: .dateTime.year().month().day())
+                                        .foregroundStyle(.primary)
+                                    Spacer()
+                                    Text("\(point.winPoints)")
+                                        .monospacedDigit()
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .swipeActions {
+                                Button(role: .destructive) {
+                                    Task { await store.deletePoint(point) }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Log")
+            .toolbar { settingsButton(showSettings: $showSettings) }
+            .sheet(item: $editing) { point in
+                EditPointSheet(store: store, point: point)
+            }
+        }
+    }
+
+    private var recordsNewestFirst: [Point] {
+        store.points.sorted { $0.date > $1.date }
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
@@ -13,6 +13,8 @@ struct MainTabView: View {
         TabView {
             GraphTabView(store: store, showSettings: $showSettings)
                 .tabItem { Label("Graph", systemImage: "chart.xyaxis.line") }
+            LogTabView(store: store, showSettings: $showSettings)
+                .tabItem { Label("Log", systemImage: "square.and.pencil") }
             DetailsTabView(store: store, showSettings: $showSettings)
                 .tabItem { Label("Details", systemImage: "list.bullet") }
         }

--- a/packages/ios/Sources/SeasonSprint/Views/PointsChartView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/PointsChartView.swift
@@ -33,6 +33,7 @@ struct PointsChartView: View {
     let goal: Int
     let rank: RankInfo
     let pace: PaceStats?
+    var todayGain: Int? = nil
     var showRankOverlay = false
     var showAveragePace = false
     var showDeviationWedge = false
@@ -123,6 +124,22 @@ struct PointsChartView: View {
         .modifier(XScale(domain: xDomain))
         .frame(height: 300)
         .clipped()
+        .overlay(alignment: .topLeading) { todayBadge }
+    }
+
+    @ViewBuilder private var todayBadge: some View {
+        if let todayGain {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Today")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("\(todayGain >= 0 ? "+" : "")\(todayGain)")
+                    .font(.headline.bold())
+                    .monospacedDigit()
+                    .foregroundStyle(todayGain >= 0 ? .green : .red)
+            }
+            .padding(6)
+        }
     }
 
     private var legend: some View {


### PR DESCRIPTION
## Summary
Adds **data entry** to the iOS app and a couple of graph refinements. Builds on #74.

### New "Log" tab — create/modify/delete records
- **Add point:** pick a date (default today) + value → `POST /me/records` (upsert by date; saving an existing date overwrites it).
- **Edit:** tap a record to change its date and/or value → `PUT /me/records/:id` (true edit; a date change moves the point rather than duplicating it).
- **Delete:** swipe a record → `DELETE /me/records/:id`.
- Adds `upsertRecord`/`updateRecord`/`deleteRecord` to `APIClient` and `addOrSet`/`updatePoint`/`deletePoint` to `DashboardStore`. Writes broadcast over the WebSocket, so they reflect live on the Graph/Details tabs (and the web app).

### Graph polish
- Show **today's earned points** as a badge in the top-left of the chart.
- Fix vertical centering of the green "Live" indicator next to the rank badge.

## Test plan
- Log tab: add a point for today → appears on the Graph instantly; add a past date → lands correctly.
- Edit value + date → chart updates and the old day is gone after a date change.
- Swipe-delete → removed everywhere; pull-to-refresh confirms persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
