### PR TITLE
feat(ios,web): clearer goal control + database-style live indicator

### DIFF
--- a/packages/ios/Sources/SeasonSprint/Networking/SSEClient.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/SSEClient.swift
@@ -9,6 +9,14 @@ enum RecordEvent: Sendable {
     case bulkUpsert([APIRecord])
 }
 
+/// Live-link state for the connection indicator.
+/// `disconnected` means there is no link at all (indicator hidden).
+enum LiveStatus: Sendable {
+    case disconnected
+    case connecting
+    case connected
+}
+
 /// Connects to the server's live stream over a **WebSocket** (`GET /me/stream`, upgraded)
 /// and reconnects with a fresh stream token on drop. Replaces the old SSE client — the
 /// Durable Object terminates the socket with the Hibernation API.
@@ -21,8 +29,8 @@ final class SSEClient {
 
     /// Fired for each record event.
     var onEvent: ((RecordEvent) -> Void)?
-    /// Fired with true once a socket is actually receiving, false when it drops.
-    var onLiveChange: ((Bool) -> Void)?
+    /// Fired as the live link transitions between disconnected/connecting/connected.
+    var onStatusChange: ((LiveStatus) -> Void)?
 
     func start() {
         guard loopTask == nil else { return }
@@ -34,11 +42,13 @@ final class SSEClient {
         loopTask = nil
         socket?.cancel(with: .goingAway, reason: nil)
         socket = nil
-        onLiveChange?(false)
+        onStatusChange?(.disconnected)
     }
 
     private func runLoop() async {
         while !Task.isCancelled {
+            // Attempting a link: indicator shows the connecting state.
+            onStatusChange?(.connecting)
             guard let token = try? await APIClient.getStreamToken(),
                   let url = makeURL(token: token) else {
                 try? await Task.sleep(for: .seconds(5))
@@ -49,11 +59,11 @@ final class SSEClient {
             socket = ws
             ws.resume()
             // Confirm the connection is actually established (not just resumed) with a
-            // ping round-trip, so the "Live" indicator lights up at launch rather than
+            // ping round-trip, so the indicator lights up at launch rather than
             // waiting for the first data event. The server auto-pongs.
             ws.sendPing { [weak self] error in
                 guard error == nil else { return }
-                Task { @MainActor in self?.onLiveChange?(true) }
+                Task { @MainActor in self?.onStatusChange?(.connected) }
             }
             let ping = startPing(ws)
 
@@ -64,11 +74,12 @@ final class SSEClient {
             }
 
             ping.cancel()
-            onLiveChange?(false)
             ws.cancel(with: .goingAway, reason: nil)
             socket = nil
 
             if Task.isCancelled { break }
+            // Back to connecting while we wait to retry.
+            onStatusChange?(.connecting)
             try? await Task.sleep(for: .seconds(2))
         }
     }
@@ -79,7 +90,7 @@ final class SSEClient {
             let message = try await ws.receive()
             if !announcedLive {
                 announcedLive = true
-                onLiveChange?(true)
+                onStatusChange?(.connected)
             }
             switch message {
             case .string(let text):

--- a/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
@@ -12,7 +12,7 @@ final class DashboardStore {
     /// True once the first load attempt has finished (success or failure).
     private(set) var hasLoaded = false
     private(set) var errorMessage: String?
-    private(set) var isLive = false
+    private(set) var liveStatus: LiveStatus = .disconnected
     private(set) var season: Season?
 
     /// Custom goal override; nil means "use the default (next rank target)".
@@ -33,9 +33,9 @@ final class DashboardStore {
         sse.onEvent = { [weak self] event in
             self?.apply(event)
         }
-        // Drive the "Live" indicator from the real socket state, not optimistically.
-        sse.onLiveChange = { [weak self] live in
-            self?.isLive = live
+        // Drive the indicator from the real socket state, not optimistically.
+        sse.onStatusChange = { [weak self] status in
+            self?.liveStatus = status
         }
     }
 
@@ -123,7 +123,7 @@ final class DashboardStore {
 
     func stop() {
         sse.stop()
-        isLive = false
+        liveStatus = .disconnected
     }
 
     // MARK: Live event merge (mirrors upsertPoint in usePointsData.js)

--- a/packages/ios/Sources/SeasonSprint/Views/GoalControlView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/GoalControlView.swift
@@ -8,9 +8,14 @@ struct GoalControlView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Goal")
-                    .font(.headline)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Goal")
+                        .font(.headline)
+                    Text("Tap to change")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
                 Spacer()
                 Menu {
                     ForEach(store.thresholds.reversed(), id: \.points) { t in
@@ -22,8 +27,18 @@ struct GoalControlView: View {
                         editingCustom = true
                     }
                 } label: {
-                    Label("\(store.goal)", systemImage: "target")
-                        .font(.body.weight(.semibold))
+                    HStack(spacing: 6) {
+                        Image(systemName: "target")
+                        Text("\(store.goal)")
+                            .monospacedDigit()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .font(.body.weight(.semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .background(Color.accentColor, in: Capsule())
+                    .foregroundStyle(.white)
                 }
             }
 

--- a/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
@@ -11,7 +11,7 @@ struct GraphTabView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
-                    CompactSummary(rank: store.rank, isLive: store.isLive)
+                    CompactSummary(rank: store.rank, liveStatus: store.liveStatus)
 
                     PointsChartView(
                         points: store.seasonPoints.sorted { $0.date < $1.date },
@@ -46,7 +46,7 @@ struct GraphTabView: View {
 /// Compact rank header for the Graph tab.
 private struct CompactSummary: View {
     let rank: RankInfo
-    let isLive: Bool
+    let liveStatus: LiveStatus
 
     var body: some View {
         let accent = tierColor(rank.badge)
@@ -56,11 +56,7 @@ private struct CompactSummary: View {
                     Text(rank.badge)
                         .font(.title3.bold())
                         .foregroundStyle(accent)
-                    if isLive {
-                        Image(systemName: "dot.radiowaves.left.and.right")
-                            .font(.caption)
-                            .foregroundStyle(.green)
-                    }
+                    LiveIndicatorView(status: liveStatus)
                 }
                 Spacer()
                 Text("\(rank.points)")

--- a/packages/ios/Sources/SeasonSprint/Views/LiveIndicatorView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/LiveIndicatorView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Live-link status shown as a database symbol. Hidden when there is no link;
+/// amber and fading in/out while connecting; steady green once connected.
+struct LiveIndicatorView: View {
+    let status: LiveStatus
+    @State private var dim = false
+
+    var body: some View {
+        if status != .disconnected {
+            Image(systemName: "cylinder.split.1x2")
+                .font(.caption)
+                .foregroundStyle(status == .connected ? Color.green : Color.yellow)
+                .opacity(status == .connecting && dim ? 0.25 : 1)
+                .onAppear { syncAnimation() }
+                .onChange(of: status) { syncAnimation() }
+        }
+    }
+
+    private func syncAnimation() {
+        if status == .connecting {
+            dim = false
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                dim = true
+            }
+        } else {
+            withAnimation(.default) { dim = false }
+        }
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
@@ -26,7 +26,7 @@ struct MainTabView: View {
         }
         .task { await store.load() }
         .sheet(isPresented: $showSettings) {
-            SettingsSheet(settings: settings, isLive: store.isLive) {
+            SettingsSheet(settings: settings, liveStatus: store.liveStatus) {
                 store.stop()
                 try? await clerk.auth.signOut()
             }

--- a/packages/ios/Sources/SeasonSprint/Views/SettingsSheet.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/SettingsSheet.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// App-wide settings: graph display toggles + account. Opened from the toolbar gear.
 struct SettingsSheet: View {
     @Bindable var settings: AppSettings
-    let isLive: Bool
+    let liveStatus: LiveStatus
     let onSignOut: () async -> Void
     @Environment(\.dismiss) private var dismiss
 
@@ -26,8 +26,9 @@ struct SettingsSheet: View {
                     HStack {
                         Text("Live updates")
                         Spacer()
-                        Text(isLive ? "Connected" : "Off")
-                            .foregroundStyle(isLive ? .green : .secondary)
+                        LiveIndicatorView(status: liveStatus)
+                        Text(statusLabel)
+                            .foregroundStyle(statusColor)
                     }
                 } header: {
                     Text("Status")
@@ -51,6 +52,22 @@ struct SettingsSheet: View {
                     Button("Done") { dismiss() }
                 }
             }
+        }
+    }
+
+    private var statusLabel: String {
+        switch liveStatus {
+        case .connected: return "Connected"
+        case .connecting: return "Connecting…"
+        case .disconnected: return "Off"
+        }
+    }
+
+    private var statusColor: Color {
+        switch liveStatus {
+        case .connected: return .green
+        case .connecting: return .yellow
+        case .disconnected: return .secondary
         }
     }
 }

--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -42,11 +42,31 @@
           </template>
         </div>
         <div
-          v-if="isLive"
+          v-if="liveStatus !== 'disconnected'"
           class="live-indicator"
-          title="Connected to live updates"
+          :class="`live-${liveStatus}`"
+          :title="
+            liveStatus === 'connected'
+              ? 'Connected to live updates'
+              : 'Connecting to live updates…'
+          "
         >
-          <span class="live-dot"></span>Live
+          <svg
+            class="live-db"
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <ellipse cx="12" cy="5" rx="8" ry="3" />
+            <path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5" />
+            <path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" />
+          </svg>
         </div>
       </div>
 
@@ -455,7 +475,7 @@ const {
   isLoading,
   loadError,
   isAuthenticated,
-  isLive,
+  liveStatus,
   sortedPoints,
   sortedPointsReverse,
   currentWinPoints,
@@ -848,34 +868,30 @@ try {
 .live-indicator {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+}
+.live-db {
+  display: block;
+}
+/* Connected: steady green database. */
+.live-connected {
   color: #22c55e;
 }
-.live-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: #22c55e;
-  box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.6);
+/* Connecting: amber database, fading in and out. */
+.live-connecting {
+  color: #eab308;
 }
 @media (prefers-reduced-motion: no-preference) {
-  .live-dot {
-    animation: live-pulse 2s ease-out infinite;
+  .live-connecting .live-db {
+    animation: live-fade 1.2s ease-in-out infinite;
   }
 }
-@keyframes live-pulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
-  }
-  70% {
-    box-shadow: 0 0 0 6px rgba(34, 197, 94, 0);
-  }
+@keyframes live-fade {
+  0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
   }
 }
 .lg-gamemode {

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -24,7 +24,8 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   const isLoading = ref(false)
   const loadError = ref('')
   const isAuthenticated = ref(false)
-  const isLive = ref(false)
+  // 'disconnected' | 'connecting' | 'connected'
+  const liveStatus = ref('disconnected')
 
   const sortedPoints = computed(() =>
     [...points].sort((a, b) => dateToMs(a.date) - dateToMs(b.date))
@@ -69,8 +70,8 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     if (liveConnection) liveConnection.close()
     try {
       liveConnection = await connectLiveUpdates({
-        onLive(v) {
-          isLive.value = v
+        onStatus(s) {
+          liveStatus.value = s
         },
         onUpsert: upsertPoint,
         onDelete({ id }) {
@@ -92,7 +93,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   onScopeDispose(() => {
     liveConnection?.close()
     liveConnection = null
-    isLive.value = false
+    liveStatus.value = 'disconnected'
   })
 
   async function loadPointsFromAPI() {
@@ -280,7 +281,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     isLoading,
     loadError,
     isAuthenticated,
-    isLive,
+    liveStatus,
     sortedPoints,
     sortedPointsReverse,
     currentWinPoints,

--- a/packages/web/src/services/liveUpdates.js
+++ b/packages/web/src/services/liveUpdates.js
@@ -30,6 +30,7 @@ async function getStreamToken() {
  * reconnects with backoff on drop. Messages are JSON `{ event, data }`.
  *
  * @param {Object} handlers
+ * @param {(status: 'disconnected'|'connecting'|'connected') => void} handlers.onStatus
  * @param {(record: object) => void} handlers.onUpsert
  * @param {(payload: {id: string}) => void} handlers.onDelete
  * @param {() => void} handlers.onDeleteAll
@@ -72,7 +73,8 @@ export async function connectLiveUpdates(handlers) {
   }
 
   function scheduleReconnect() {
-    handlers.onLive?.(false);
+    // We immediately retry, so the link is "connecting", not gone.
+    handlers.onStatus?.("connecting");
     if (pingTimer) {
       clearInterval(pingTimer);
       pingTimer = null;
@@ -83,6 +85,7 @@ export async function connectLiveUpdates(handlers) {
 
   async function open() {
     if (closed) return;
+    handlers.onStatus?.("connecting");
 
     const token = await getStreamToken();
     if (!token) {
@@ -93,7 +96,7 @@ export async function connectLiveUpdates(handlers) {
     ws = new WebSocket(`${wsBase}/me/stream?token=${encodeURIComponent(token)}`);
 
     ws.onopen = () => {
-      handlers.onLive?.(true);
+      handlers.onStatus?.("connected");
       // Keep the socket warm; the server auto-responds "pong".
       pingTimer = setInterval(() => {
         try {
@@ -120,7 +123,7 @@ export async function connectLiveUpdates(handlers) {
   return {
     close() {
       closed = true;
-      handlers.onLive?.(false);
+      handlers.onStatus?.("disconnected");
       if (pingTimer) clearInterval(pingTimer);
       if (reconnectTimer) clearTimeout(reconnectTimer);
       if (ws) {


### PR DESCRIPTION
## Summary

Two UI-clarity improvements to the **iOS** and **web** clients.

### 1. Goal control reads as editable (iOS Details tab)
The goal value was plain text with a `target` icon — nothing signalled it opened a menu. It's now a tinted accent **capsule button** with a `chevron.up.chevron.down` glyph and a **"Tap to change"** subtitle.

### 2. Database-style live indicator (iOS + web)
Replaced the binary "live" dot with a three-state model — **disconnected / connecting / connected** — shown as a **database symbol**:

- **not rendered** when there's no live link
- **amber, fading in and out** while connecting (and while reconnecting after a drop)
- **steady green** once connected

**iOS:** new `LiveIndicatorView` (`cylinder.split.1x2` SF Symbol); `SSEClient` now emits a `LiveStatus` enum across its connect/receive/reconnect loop; the Settings sheet status row shows Connecting…/Connected/Off.

**web:** inline SVG database icon with an opacity-pulse animation (respects `prefers-reduced-motion`); the live-updates service callback changed from `onLive(bool)` to `onStatus('disconnected'|'connecting'|'connected')`.

## Testing
- web: `vue-cli-service lint` clean + production build passes
- iOS: compiles via `xtool dev build`

## Note
The equivalent Android changes are intentionally **not** in this PR — the Android package's parity work isn't on `main` yet, so those edits belong with the Android branch to avoid dragging unmerged work in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced connection status indicator with three states: disconnected, connecting, and connected (replacing simple on/off).
  * Added visual feedback animations during connection attempts.

* **Bug Fixes & Improvements**
  * Improved live status visibility across iOS and web interfaces.
  * Updated goal display UI with clearer styling and labels.
  * Better real-time synchronization state representation in settings and dashboard views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->