### PR TITLE
feat(android): UI parity + clearer goal control + database-style live indicator

### DIFF
--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/MainActivity.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -26,7 +28,14 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             SeasonSprintTheme {
-                App()
+                // Surface provides the dark background + correct default content color
+                // (without it, unstyled Text falls back to black on the dark theme).
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
+                    App()
+                }
             }
         }
     }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/LiveUpdates.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/LiveUpdates.kt
@@ -28,14 +28,17 @@ import okio.ByteString
  *
  * OkHttp performs the upgrade from the https URL, so we pass the plain server URL.
  */
+/** Live-link state for the connection indicator. `Disconnected` means no link (hidden). */
+enum class LiveStatus { Disconnected, Connecting, Connected }
+
 class LiveUpdates(private val scope: CoroutineScope) {
     private val json = Json { ignoreUnknownKeys = true }
 
     private val _events = MutableSharedFlow<RecordEvent>(extraBufferCapacity = 64)
     val events = _events.asSharedFlow()
 
-    private val _isLive = MutableStateFlow(false)
-    val isLive = _isLive.asStateFlow()
+    private val _status = MutableStateFlow(LiveStatus.Disconnected)
+    val status = _status.asStateFlow()
 
     private var loopJob: Job? = null
 
@@ -48,11 +51,13 @@ class LiveUpdates(private val scope: CoroutineScope) {
     fun stop() {
         loopJob?.cancel()
         loopJob = null
-        _isLive.value = false
+        _status.value = LiveStatus.Disconnected
     }
 
     private suspend fun runLoop() {
         while (scope.isActive) {
+            // Attempting a link: indicator shows the connecting state.
+            _status.value = LiveStatus.Connecting
             val token = runCatching { ApiClient.getStreamToken() }.getOrNull()
             if (token == null) {
                 delay(5_000)
@@ -66,7 +71,7 @@ class LiveUpdates(private val scope: CoroutineScope) {
             val closed = CompletableDeferred<Unit>()
             val ws = ApiClient.httpClient.newWebSocket(request, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
-                    _isLive.value = true
+                    _status.value = LiveStatus.Connected
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) = handle(text)
@@ -97,9 +102,10 @@ class LiveUpdates(private val scope: CoroutineScope) {
             closed.await()
             pingJob.cancel()
             ws.cancel()
-            _isLive.value = false
 
             if (!scope.isActive) break
+            // Back to connecting while we wait to retry.
+            _status.value = LiveStatus.Connecting
             delay(2_000)
         }
     }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Pace.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Pace.kt
@@ -1,7 +1,9 @@
 package com.lcarthur.seasonsprint.domain
 
 import java.time.Instant
+import kotlin.math.abs
 import kotlin.math.roundToLong
+import kotlin.math.sqrt
 
 private const val SECONDS_PER_DAY = 86_400.0
 
@@ -59,4 +61,78 @@ fun computePace(
         isFromLastDefined = isFromLastDefined,
         requiredPerDayFromLast = requiredPerDayFromLast,
     )
+}
+
+// MARK: - Chart overlay helpers (ported from iOS Pace.swift / web utils/chart.js)
+
+/** A dated value for the pace sub-graph. */
+data class PaceSeriesPoint(val instant: Instant, val value: Double)
+
+/** Through-origin least-squares slope (points/day): Σ(x·y)/Σ(x²), x = day offset from start. */
+private fun throughOriginSlope(seasonPoints: List<Point>, start: Instant): Double? {
+    var sumXX = 0.0
+    var sumXY = 0.0
+    for (p in seasonPoints) {
+        val x = (p.instant.epochSecond - start.epochSecond) / SECONDS_PER_DAY
+        val y = p.winPoints.toDouble()
+        sumXX += x * x
+        sumXY += x * y
+    }
+    return if (sumXX == 0.0) null else sumXY / sumXX
+}
+
+/** Average-pace value projected to season end: slope · totalDays. */
+fun averagePaceProjectedEnd(seasonPoints: List<Point>, start: Instant, end: Instant): Double? {
+    if (seasonPoints.isEmpty()) return null
+    val slope = throughOriginSlope(seasonPoints, start) ?: return null
+    val totalDays = (end.epochSecond - start.epochSecond) / SECONDS_PER_DAY
+    return slope * totalDays
+}
+
+/** Deviation half-width at season end for the confidence wedge. */
+fun deviationAtEnd(seasonPoints: List<Point>, start: Instant, end: Instant): Double? {
+    if (seasonPoints.size < 2) return null
+    val slope = throughOriginSlope(seasonPoints, start) ?: return null
+
+    var sumResidualSq = 0.0
+    for (p in seasonPoints) {
+        val x = (p.instant.epochSecond - start.epochSecond) / SECONDS_PER_DAY
+        val residual = p.winPoints - slope * x
+        sumResidualSq += residual * residual
+    }
+    val n = seasonPoints.size
+    val stdDev = if (n > 1) sqrt(sumResidualSq / (n - 1)) else sqrt(sumResidualSq)
+    val tFactor = when {
+        n <= 2 -> 4.303
+        n <= 3 -> 3.182
+        n <= 5 -> 2.776
+        n <= 10 -> 2.228
+        else -> 1.96
+    }
+    val totalDays = (end.epochSecond - start.epochSecond) / SECONDS_PER_DAY
+    val projectedMag = abs(slope * totalDays)
+    val minDeviation = when {
+        n <= 3 -> projectedMag * 0.3
+        n <= 6 -> projectedMag * 0.15
+        else -> projectedMag * 0.05
+    }
+    return maxOf(stdDev * tFactor, minDeviation)
+}
+
+/** Required points/day to hit the goal, per point: (goal - winPoints)/daysRemaining. Skips end. */
+fun requiredPaceSeries(seasonPoints: List<Point>, goal: Int, end: Instant): List<PaceSeriesPoint> =
+    seasonPoints.sortedBy { it.instant }.mapNotNull { p ->
+        val daysRemaining = (end.epochSecond - p.instant.epochSecond) / SECONDS_PER_DAY
+        if (daysRemaining <= 0) null
+        else PaceSeriesPoint(p.instant, (goal - p.winPoints) / daysRemaining)
+    }
+
+/** Points earned per entry: delta of the cumulative total. */
+fun earnedPaceSeries(seasonPoints: List<Point>): List<PaceSeriesPoint> {
+    var prev = 0
+    return seasonPoints.sortedBy { it.instant }.map { p ->
+        val delta = p.winPoints - prev
+        prev = p.winPoints
+        PaceSeriesPoint(p.instant, delta.toDouble())
+    }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.lcarthur.seasonsprint.data.ApiClient
 import com.lcarthur.seasonsprint.data.ApiRecord
+import com.lcarthur.seasonsprint.data.LiveStatus
 import com.lcarthur.seasonsprint.data.LiveUpdates
 import com.lcarthur.seasonsprint.data.RecordEvent
 import com.lcarthur.seasonsprint.domain.PaceStats
@@ -31,7 +32,7 @@ data class DashboardState(
     val hasLoaded: Boolean = false,
     val isWriting: Boolean = false,
     val error: String? = null,
-    val isLive: Boolean = false,
+    val liveStatus: LiveStatus = LiveStatus.Disconnected,
     val goalOverride: Int? = null,
 ) {
     val sortedPoints: List<Point> get() = points.sortedBy { it.instant }
@@ -79,7 +80,7 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
 
     init {
         viewModelScope.launch { live.events.collect(::applyEvent) }
-        viewModelScope.launch { live.isLive.collect { l -> _state.update { it.copy(isLive = l) } } }
+        viewModelScope.launch { live.status.collect { s -> _state.update { it.copy(liveStatus = s) } } }
     }
 
     fun load() {

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/SettingsViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/SettingsViewModel.kt
@@ -1,0 +1,54 @@
+package com.lcarthur.seasonsprint.state
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/** Graph display toggles, mirroring iOS AppSettings (persisted in SharedPreferences). */
+data class AppSettingsState(
+    val showRankOverlay: Boolean = true,
+    val showAveragePace: Boolean = false,
+    val showDeviationWedge: Boolean = false,
+    val showPaceGraph: Boolean = false,
+)
+
+class SettingsViewModel(app: Application) : AndroidViewModel(app) {
+    private val prefs = app.getSharedPreferences("settings", Context.MODE_PRIVATE)
+
+    private val _state = MutableStateFlow(
+        AppSettingsState(
+            showRankOverlay = prefs.getBoolean(K_RANK, true),
+            showAveragePace = prefs.getBoolean(K_AVG, false),
+            showDeviationWedge = prefs.getBoolean(K_DEV, false),
+            showPaceGraph = prefs.getBoolean(K_PACE, false),
+        ),
+    )
+    val state = _state.asStateFlow()
+
+    fun setRankOverlay(value: Boolean) = put(K_RANK) { it.copy(showRankOverlay = value) }
+    fun setAveragePace(value: Boolean) = put(K_AVG) { it.copy(showAveragePace = value) }
+    fun setDeviationWedge(value: Boolean) = put(K_DEV) { it.copy(showDeviationWedge = value) }
+    fun setPaceGraph(value: Boolean) = put(K_PACE) { it.copy(showPaceGraph = value) }
+
+    private fun put(key: String, transform: (AppSettingsState) -> AppSettingsState) {
+        val next = transform(_state.value)
+        val value = when (key) {
+            K_RANK -> next.showRankOverlay
+            K_AVG -> next.showAveragePace
+            K_DEV -> next.showDeviationWedge
+            else -> next.showPaceGraph
+        }
+        prefs.edit().putBoolean(key, value).apply()
+        _state.update { next }
+    }
+
+    private companion object {
+        const val K_RANK = "settings.showRankOverlay"
+        const val K_AVG = "settings.showAveragePace"
+        const val K_DEV = "settings.showDeviationWedge"
+        const val K_PACE = "settings.showPaceGraph"
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/BrandedLoadingScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/BrandedLoadingScreen.kt
@@ -1,0 +1,50 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.lcarthur.seasonsprint.R
+
+/** Centered branded splash shown while initial data loads. Port of iOS BrandedLoadingView. */
+@Composable
+fun BrandedLoadingScreen(message: String? = null) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(18.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.logo),
+            contentDescription = null,
+            modifier = Modifier
+                .size(104.dp)
+                .clip(RoundedCornerShape(22.dp)),
+        )
+        Text(
+            "Season Sprint",
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        if (message != null) {
+            Text(
+                message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        CircularProgressIndicator()
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DashboardScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DashboardScreen.kt
@@ -21,16 +21,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.state.AppSettingsState
 import com.lcarthur.seasonsprint.state.DashboardState
 import com.lcarthur.seasonsprint.state.DashboardViewModel
-import com.lcarthur.seasonsprint.ui.theme.RankEmerald
 import com.lcarthur.seasonsprint.ui.theme.rankColor
 
-/** Graph tab: compact rank summary + cumulative points chart + pace figures. */
+/** Graph tab: compact rank summary + cumulative points chart + optional pace sub-graph. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel,
+    settings: AppSettingsState,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -48,9 +49,20 @@ fun DashboardScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             RankSummaryCard(state)
-            LiveIndicator(isLive = state.isLive)
-            PointsChart(points = state.seasonPoints, goal = state.goal, season = state.season)
-            PaceCard(state)
+            PointsChart(
+                points = state.seasonPoints,
+                goal = state.goal,
+                season = state.season,
+                rank = state.rank,
+                pace = state.pace,
+                todayGain = state.todayGain,
+                showRankOverlay = settings.showRankOverlay,
+                showAveragePace = settings.showAveragePace,
+                showDeviationWedge = settings.showDeviationWedge,
+            )
+            if (settings.showPaceGraph) {
+                PaceChart(points = state.seasonPoints, goal = state.goal, season = state.season)
+            }
             if (state.error != null) {
                 Text(
                     state.error!!,
@@ -63,20 +75,9 @@ fun DashboardScreen(
 }
 
 @Composable
-private fun LiveIndicator(isLive: Boolean) {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(if (isLive) "●" else "○", color = if (isLive) RankEmerald else MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(
-            if (isLive) "Live" else "Offline",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}
-
-@Composable
 private fun RankSummaryCard(state: DashboardState) {
     val rank = state.rank
+    val accent = rankColor(rank.badge)
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(
@@ -84,12 +85,15 @@ private fun RankSummaryCard(state: DashboardState) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    rank.badge,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = rankColor(rank.badge),
-                )
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        rank.badge,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = accent,
+                    )
+                    LiveIndicator(state.liveStatus)
+                }
                 Column(horizontalAlignment = Alignment.End) {
                     Text("${state.currentPoints} pts", style = MaterialTheme.typography.titleMedium)
                     state.todayGain?.let { gain ->
@@ -104,36 +108,11 @@ private fun RankSummaryCard(state: DashboardState) {
             LinearProgressIndicator(
                 progress = { rank.progressFraction },
                 modifier = Modifier.fillMaxWidth(),
-                color = rankColor(rank.nextBadge ?: rank.badge),
+                color = accent,
             )
-            val toNextText = rank.nextTarget?.let { "${rank.toNext} pts to ${rank.nextBadge}" }
+            val toNextText = rank.nextTarget?.let { "${rank.toNext} pts to ${rank.nextBadge}  ·  ${rank.points}/$it" }
                 ?: "Top rank reached"
             Text(toNextText, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
-    }
-}
-
-@Composable
-private fun PaceCard(state: DashboardState) {
-    val pace = state.pace ?: return
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            Text("Pace to goal ${state.goal}", style = MaterialTheme.typography.titleSmall)
-            Text(
-                "Required/day (zero → goal): ${"%.1f".format(pace.requiredPerDayZero)}",
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            if (pace.isFromLastDefined) {
-                Text(
-                    "Required/day (last → goal): ${"%.1f".format(pace.requiredPerDayFromLast)}",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-            Text(
-                "${pace.daysRemaining} days remaining",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
         }
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DetailsScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DetailsScreen.kt
@@ -1,0 +1,320 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Adjust
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.domain.Season
+import com.lcarthur.seasonsprint.domain.worldTourCheatsheet
+import com.lcarthur.seasonsprint.domain.worldTourThresholds
+import com.lcarthur.seasonsprint.state.DashboardState
+import com.lcarthur.seasonsprint.state.DashboardViewModel
+import com.lcarthur.seasonsprint.ui.theme.FinalsGold
+import com.lcarthur.seasonsprint.ui.theme.GainNegative
+import com.lcarthur.seasonsprint.ui.theme.GainPositive
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.math.max
+import kotlin.math.roundToLong
+
+/** Details tab: season banner, stats grid, goal control, and collapsible references. Ported from iOS DetailsTabView. */
+@Composable
+fun DetailsScreen(
+    viewModel: DashboardViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        state.season?.let { SeasonBanner(it) }
+        StatsGrid(state)
+        GoalControl(state, viewModel)
+        RankReference(state)
+        Cheatsheet()
+        if (state.error != null) {
+            Text(
+                state.error!!,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+    }
+}
+
+private val monthDayFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM d")
+
+@Composable
+private fun SeasonBanner(season: Season) {
+    val end = season.end.atZone(ZoneId.systemDefault())
+    val endLabel = end.format(monthDayFormatter)
+    val daysLeft = max(0L, ((season.end.epochSecond - Instant.now().epochSecond) / 86400.0).roundToLong())
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(season.name, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold)
+            Text(
+                "  · ends $endLabel",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                "$daysLeft days left",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatsGrid(state: DashboardState) {
+    val gain = state.todayGain
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            StatCard(
+                label = "Current win points",
+                value = "${state.currentPoints}",
+                accent = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            StatCard(
+                label = "Today",
+                value = when {
+                    gain == null -> "—"
+                    gain >= 0 -> "+$gain"
+                    else -> "$gain"
+                },
+                accent = when {
+                    gain == null -> MaterialTheme.colorScheme.onSurfaceVariant
+                    gain >= 0 -> GainPositive
+                    else -> GainNegative
+                },
+                modifier = Modifier.weight(1f),
+            )
+        }
+        state.pace?.let { pace ->
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                StatCard(
+                    label = "Required/day (zero → goal)",
+                    value = String.format("%.2f", pace.requiredPerDayZero),
+                    accent = MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier.weight(1f),
+                )
+                StatCard(
+                    label = "Required/day (last → goal)",
+                    value = if (pace.isFromLastDefined) String.format("%.2f", pace.requiredPerDayFromLast) else "—",
+                    accent = if (pace.isFromLastDefined) GainPositive else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatCard(label: String, value: String, accent: Color, modifier: Modifier = Modifier) {
+    Card(modifier = modifier) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+            )
+            Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = accent)
+        }
+    }
+}
+
+@Composable
+private fun GoalControl(state: DashboardState, viewModel: DashboardViewModel) {
+    var expanded by remember { mutableStateOf(false) }
+    var editingCustom by remember { mutableStateOf(false) }
+    var customText by remember { mutableStateOf("") }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                Column {
+                    Text("Goal", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Tap to change",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                Box {
+                    FilledTonalButton(onClick = { expanded = true }) {
+                        Icon(Icons.Filled.Adjust, contentDescription = null)
+                        Spacer(Modifier.width(6.dp))
+                        Text("${state.goal}")
+                        Spacer(Modifier.width(4.dp))
+                        Icon(Icons.Filled.ExpandMore, contentDescription = null)
+                    }
+                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                        worldTourThresholds.reversed().forEach { t ->
+                            DropdownMenuItem(
+                                text = { Text("${t.badge} — ${t.points}") },
+                                onClick = {
+                                    viewModel.setGoal(t.points)
+                                    expanded = false
+                                },
+                            )
+                        }
+                        HorizontalDivider()
+                        DropdownMenuItem(
+                            text = { Text("Custom…") },
+                            onClick = {
+                                customText = state.goal.toString()
+                                editingCustom = true
+                                expanded = false
+                            },
+                        )
+                    }
+                }
+            }
+            if (editingCustom) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OutlinedTextField(
+                        value = customText,
+                        onValueChange = { input -> customText = input.filter { it.isDigit() } },
+                        label = { Text("Custom goal") },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier.weight(1f),
+                    )
+                    Button(onClick = {
+                        val v = customText.trim().toIntOrNull()
+                        if (v != null && v > 0) {
+                            viewModel.setGoal(v)
+                            editingCustom = false
+                        }
+                    }) { Text("Set") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RankReference(state: DashboardState) {
+    ExpandableCard(title = "Rank thresholds") {
+        worldTourThresholds.reversed().forEach { t ->
+            val isCurrent = t.points == state.rank.currentFloor && state.rank.badge == t.badge
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(6.dp))
+                    .then(if (isCurrent) Modifier.background(FinalsGold.copy(alpha = 0.15f)) else Modifier)
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(t.badge, fontWeight = if (isCurrent) FontWeight.Bold else FontWeight.Normal)
+                Spacer(Modifier.weight(1f))
+                Text("${t.points}", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Cheatsheet() {
+    ExpandableCard(title = "World Tour win points") {
+        worldTourCheatsheet.forEach { row ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(row.label)
+                Spacer(Modifier.weight(1f))
+                Text("+${row.value}", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+/** Collapsible card with a clickable header row and chevron, used by the rank and cheatsheet sections. */
+@Composable
+private fun ExpandableCard(title: String, content: @Composable () -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(title, style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.weight(1f))
+                Icon(
+                    if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                    contentDescription = if (expanded) "Collapse" else "Expand",
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column(modifier = Modifier.padding(top = 8.dp)) { content() }
+            }
+        }
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/EditPointSheet.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/EditPointSheet.kt
@@ -52,18 +52,28 @@ fun EditPointSheet(
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onDismiss) { Text("Cancel") }
-                Button(
-                    enabled = parsedValue != null,
-                    onClick = {
-                        parsedValue?.let {
-                            viewModel.updatePoint(point, DateKey.dayStringFromUtcMillis(dateMillis), it)
-                            onDismiss()
-                        }
-                    },
-                ) { Text("Save") }
+                // Destructive delete lives here so the records list can lead with "Edit".
+                TextButton(onClick = {
+                    viewModel.deletePoint(point)
+                    onDismiss()
+                }) {
+                    Text("Delete", color = androidx.compose.material3.MaterialTheme.colorScheme.error)
+                }
+                Row {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    Button(
+                        enabled = parsedValue != null,
+                        onClick = {
+                            parsedValue?.let {
+                                viewModel.updatePoint(point, DateKey.dayStringFromUtcMillis(dateMillis), it)
+                                onDismiss()
+                            }
+                        },
+                    ) { Text("Save") }
+                }
             }
         }
     }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/FormFields.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/FormFields.kt
@@ -1,24 +1,35 @@
 package com.lcarthur.seasonsprint.ui
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import com.lcarthur.seasonsprint.domain.DateKey
 
 /** A read-only field that shows the selected day and opens a date picker when tapped. */
 @Composable
 fun DateField(label: String, dateMillis: Long, onClick: () -> Unit) {
-    OutlinedButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+    val scheme = MaterialTheme.colorScheme
+    OutlinedButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        border = BorderStroke(1.dp, scheme.onSurfaceVariant),
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = scheme.onSurface),
+    ) {
         Text("$label: ${DateKey.dayStringFromUtcMillis(dateMillis)}")
     }
 }
@@ -26,6 +37,7 @@ fun DateField(label: String, dateMillis: Long, onClick: () -> Unit) {
 /** Numeric win-points input (digits only). */
 @Composable
 fun WinPointsField(value: String, onValueChange: (String) -> Unit) {
+    val scheme = MaterialTheme.colorScheme
     OutlinedTextField(
         value = value,
         onValueChange = { input -> onValueChange(input.filter { it.isDigit() }) },
@@ -33,6 +45,15 @@ fun WinPointsField(value: String, onValueChange: (String) -> Unit) {
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         modifier = Modifier.fillMaxWidth(),
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedBorderColor = scheme.primary,
+            unfocusedBorderColor = scheme.onSurfaceVariant,
+            focusedLabelColor = scheme.primary,
+            unfocusedLabelColor = scheme.onSurfaceVariant,
+            focusedTextColor = scheme.onSurface,
+            unfocusedTextColor = scheme.onSurface,
+            cursorColor = scheme.primary,
+        ),
     )
 }
 

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/LiveIndicator.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/LiveIndicator.kt
@@ -1,0 +1,52 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.lcarthur.seasonsprint.data.LiveStatus
+import com.lcarthur.seasonsprint.ui.theme.FinalsGold
+import com.lcarthur.seasonsprint.ui.theme.FinalsMint
+
+/**
+ * Live-link status as a database symbol. Renders nothing when there is no link;
+ * amber and fading in/out while connecting; steady green once connected.
+ */
+@Composable
+fun LiveIndicator(status: LiveStatus, modifier: Modifier = Modifier) {
+    if (status == LiveStatus.Disconnected) return
+
+    val alpha = if (status == LiveStatus.Connecting) {
+        val transition = rememberInfiniteTransition(label = "live")
+        val value by transition.animateFloat(
+            initialValue = 0.25f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 900, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+            label = "live-alpha",
+        )
+        value
+    } else {
+        1f
+    }
+
+    val color = if (status == LiveStatus.Connected) FinalsMint else FinalsGold
+    Icon(
+        imageVector = Icons.Filled.Storage,
+        contentDescription = if (status == LiveStatus.Connected) "Live updates connected" else "Connecting to live updates",
+        tint = color.copy(alpha = alpha),
+        modifier = modifier.size(16.dp),
+    )
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/LogScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/LogScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -52,7 +53,10 @@ fun LogScreen(
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item {
-            Card(modifier = Modifier.fillMaxWidth()) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -93,11 +97,7 @@ fun LogScreen(
             }
         } else {
             items(recordsNewestFirst, key = { it.remoteId }) { point ->
-                RecordRow(
-                    point = point,
-                    onEdit = { editing = point },
-                    onDelete = { viewModel.deletePoint(point) },
-                )
+                RecordRow(point = point, onEdit = { editing = point })
                 HorizontalDivider()
             }
         }
@@ -117,7 +117,7 @@ fun LogScreen(
 }
 
 @Composable
-private fun RecordRow(point: Point, onEdit: () -> Unit, onDelete: () -> Unit) {
+private fun RecordRow(point: Point, onEdit: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -134,7 +134,7 @@ private fun RecordRow(point: Point, onEdit: () -> Unit, onDelete: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.End,
             )
-            TextButton(onClick = onDelete) { Text("Delete") }
+            TextButton(onClick = onEdit) { Text("Edit") }
         }
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
@@ -3,8 +3,9 @@ package com.lcarthur.seasonsprint.ui
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.automirrored.filled.ListAlt
 import androidx.compose.material.icons.filled.EditNote
-import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -14,38 +15,53 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lcarthur.seasonsprint.state.DashboardViewModel
+import com.lcarthur.seasonsprint.state.SettingsViewModel
 
 private enum class Tab(val label: String, val icon: ImageVector) {
     Graph("Graph", Icons.AutoMirrored.Filled.ShowChart),
     Log("Log", Icons.Filled.EditNote),
+    Details("Details", Icons.AutoMirrored.Filled.ListAlt),
 }
 
-/** Signed-in shell: top bar with sign-out + bottom nav between the Graph and Log tabs. */
+/**
+ * Signed-in shell: branded loading until the first fetch completes, then a 3-tab layout
+ * (Graph / Log / Details) with an app-wide Settings sheet behind the toolbar gear.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     onSignOut: () -> Unit,
     dashboardViewModel: DashboardViewModel = viewModel(),
+    settingsViewModel: SettingsViewModel = viewModel(),
 ) {
     LaunchedEffect(Unit) { dashboardViewModel.load() }
+    val state by dashboardViewModel.state.collectAsStateWithLifecycle()
+    val settings by settingsViewModel.state.collectAsStateWithLifecycle()
     var selected by remember { mutableStateOf(Tab.Graph) }
+    var showSettings by remember { mutableStateOf(false) }
+
+    if (!state.hasLoaded) {
+        BrandedLoadingScreen(message = "Loading your season…")
+        return
+    }
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Season Sprint") },
                 actions = {
-                    IconButton(onClick = onSignOut) {
-                        Icon(Icons.Filled.Logout, contentDescription = "Sign out")
+                    IconButton(onClick = { showSettings = true }) {
+                        Icon(Icons.Filled.Settings, contentDescription = "Settings")
                     }
                 },
             )
@@ -65,8 +81,18 @@ fun MainScreen(
     ) { innerPadding ->
         val contentModifier = Modifier.padding(innerPadding)
         when (selected) {
-            Tab.Graph -> DashboardScreen(viewModel = dashboardViewModel, modifier = contentModifier)
-            Tab.Log -> LogScreen(viewModel = dashboardViewModel, modifier = contentModifier)
+            Tab.Graph -> DashboardScreen(dashboardViewModel, settings, contentModifier)
+            Tab.Log -> LogScreen(dashboardViewModel, contentModifier)
+            Tab.Details -> DetailsScreen(dashboardViewModel, contentModifier)
         }
+    }
+
+    if (showSettings) {
+        SettingsSheet(
+            settingsViewModel = settingsViewModel,
+            liveStatus = state.liveStatus,
+            onSignOut = onSignOut,
+            onDismiss = { showSettings = false },
+        )
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PaceChart.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PaceChart.kt
@@ -1,0 +1,148 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.lcarthur.seasonsprint.domain.Point
+import com.lcarthur.seasonsprint.domain.Season
+import com.lcarthur.seasonsprint.domain.earnedPaceSeries
+import com.lcarthur.seasonsprint.domain.requiredPaceSeries
+import com.lcarthur.seasonsprint.ui.theme.ChartRequired
+import java.time.Instant
+
+/**
+ * Secondary mini-chart: required points/day to hit the goal (line) vs points earned each
+ * day (bars). Shares the main chart's season x-domain. Ports iOS PaceChartView.
+ */
+@Composable
+fun PaceChart(
+    points: List<Point>,
+    goal: Int,
+    season: Season?,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Daily pace", style = MaterialTheme.typography.titleMedium)
+
+            if (season == null) {
+                Placeholder("Season data needed.")
+                return@Column
+            }
+
+            val required = requiredPaceSeries(points, goal, season.end)
+            val earned = earnedPaceSeries(points)
+            if (required.isEmpty() && earned.isEmpty()) {
+                Placeholder("No pace data yet.")
+                return@Column
+            }
+
+            val barColor = MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f) // cyan bars
+            val lineColor = ChartRequired // amber required-pace line
+            val axisColor = MaterialTheme.colorScheme.outlineVariant
+
+            val startSec = season.start.epochSecond.toDouble()
+            val endSec = season.end.epochSecond.toDouble()
+            val xSpan = (endSec - startSec).coerceAtLeast(1.0)
+            val maxVal = (required.maxOfOrNull { it.value } ?: 0.0)
+                .coerceAtLeast(earned.maxOfOrNull { it.value } ?: 0.0)
+                .coerceAtLeast(1.0)
+
+            Canvas(modifier = Modifier.fillMaxWidth().height(130.dp)) {
+                val padLeft = 8.dp.toPx()
+                val padRight = 8.dp.toPx()
+                val padTop = 8.dp.toPx()
+                val padBottom = 8.dp.toPx()
+                val plotW = size.width - padLeft - padRight
+                val plotH = size.height - padTop - padBottom
+
+                fun xOf(instant: Instant): Float {
+                    val f = ((instant.epochSecond.toDouble() - startSec) / xSpan).coerceIn(0.0, 1.0)
+                    return padLeft + (f * plotW).toFloat()
+                }
+                fun yOf(value: Double): Float {
+                    val f = (value / maxVal).coerceIn(0.0, 1.0)
+                    return padTop + ((1.0 - f) * plotH).toFloat()
+                }
+
+                val baseY = yOf(0.0)
+                drawLine(axisColor, Offset(padLeft, baseY), Offset(padLeft + plotW, baseY), strokeWidth = 1.dp.toPx())
+
+                // Earned/day bars — width adapts to the tightest day-to-day spacing so dense
+                // seasons don't overlap (with a small gap), capped so sparse data isn't blocky.
+                val xs = earned.map { xOf(it.instant) }.sorted()
+                val minGap = xs.zipWithNext { a, b -> b - a }.filter { it > 0f }.minOrNull() ?: plotW
+                val barW = (minGap * 0.8f).coerceIn(1.5.dp.toPx(), 6.dp.toPx())
+                for (p in earned) {
+                    if (p.value <= 0) continue
+                    val x = xOf(p.instant)
+                    val top = yOf(p.value)
+                    drawRect(
+                        color = barColor,
+                        topLeft = Offset(x - barW / 2, top),
+                        size = androidx.compose.ui.geometry.Size(barW, baseY - top),
+                    )
+                }
+
+                // Required/day line.
+                var prev: Offset? = null
+                for (p in required) {
+                    val o = Offset(xOf(p.instant), yOf(p.value))
+                    prev?.let { drawLine(lineColor, it, o, strokeWidth = 2.dp.toPx()) }
+                    prev = o
+                }
+                // If the goal isn't reached yet (last required value > 0), extend the line flat
+                // to the right edge at that last value, so the current pace reads to season end.
+                val lastReq = required.lastOrNull()
+                if (lastReq != null && lastReq.value > 0) {
+                    val y = yOf(lastReq.value)
+                    drawLine(
+                        color = lineColor,
+                        start = Offset(xOf(lastReq.instant), y),
+                        end = Offset(padLeft + plotW, y),
+                        strokeWidth = 2.dp.toPx(),
+                    )
+                }
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                LegendSwatch(ChartRequired, "Required/day")
+                LegendSwatch(MaterialTheme.colorScheme.secondary.copy(alpha = 0.6f), "Earned/day")
+            }
+        }
+    }
+}
+
+@Composable
+private fun Placeholder(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.fillMaxWidth().height(120.dp).padding(top = 48.dp),
+    )
+}
+
+@Composable
+private fun LegendSwatch(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Canvas(Modifier.size(width = 14.dp, height = 3.dp)) {
+            drawLine(color, Offset(0f, size.height / 2), Offset(size.width, size.height / 2), strokeWidth = size.height)
+        }
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
@@ -1,10 +1,15 @@
 package com.lcarthur.seasonsprint.ui
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,138 +17,295 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.lcarthur.seasonsprint.domain.PaceStats
 import com.lcarthur.seasonsprint.domain.Point
+import com.lcarthur.seasonsprint.domain.RankInfo
 import com.lcarthur.seasonsprint.domain.Season
+import com.lcarthur.seasonsprint.domain.averagePaceProjectedEnd
+import com.lcarthur.seasonsprint.domain.deviationAtEnd
+import com.lcarthur.seasonsprint.domain.worldTourThresholds
+import com.lcarthur.seasonsprint.ui.theme.ChartAvgPace
+import com.lcarthur.seasonsprint.ui.theme.GainNegative
+import com.lcarthur.seasonsprint.ui.theme.GainPositive
+import com.lcarthur.seasonsprint.ui.theme.rankColor
 import java.time.Instant
 
 /**
- * Cumulative win-points chart with goal projections, mirroring iOS PointsChartView:
- *   - solid line + dots: cumulative points over time
- *   - gray dashed: zero → goal projection (the required pace)
- *   - green dashed: latest point → goal projection
+ * The hero chart: cumulative points over time with optional rank overlay, goal line,
+ * pace projections, average-pace line, and deviation wedge. Ports iOS PointsChartView.
  */
 @Composable
 fun PointsChart(
     points: List<Point>,
     goal: Int,
     season: Season?,
+    rank: RankInfo,
+    pace: PaceStats?,
+    todayGain: Int?,
+    showRankOverlay: Boolean,
+    showAveragePace: Boolean,
+    showDeviationWedge: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val sorted = points.sortedBy { it.instant }
-    if (sorted.isEmpty()) {
-        Box(
-            modifier = modifier
-                .fillMaxWidth()
-                .height(280.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                "No points yet — add your first in the Log tab.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        return
-    }
 
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (sorted.isEmpty()) {
+                Text(
+                    "No records this season yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.fillMaxWidth().height(280.dp).padding(top = 120.dp),
+                )
+                return@Column
+            }
+
+            ChartCanvas(
+                sorted = sorted,
+                goal = goal,
+                season = season,
+                showRankOverlay = showRankOverlay,
+                showAveragePace = showAveragePace,
+                showDeviationWedge = showDeviationWedge,
+                isFromLastDefined = pace?.isFromLastDefined == true,
+                todayGain = todayGain,
+            )
+            Legend(showAveragePace = showAveragePace, showLast = pace?.isFromLastDefined == true)
+        }
+    }
+}
+
+@Composable
+private fun ChartCanvas(
+    sorted: List<Point>,
+    goal: Int,
+    season: Season?,
+    showRankOverlay: Boolean,
+    showAveragePace: Boolean,
+    showDeviationWedge: Boolean,
+    isFromLastDefined: Boolean,
+    todayGain: Int?,
+) {
     // X domain: the season window if known, else first→last point.
     val startSec = (season?.start ?: sorted.first().instant).epochSecond.toDouble()
     val endSec = (season?.end ?: sorted.last().instant).epochSecond.toDouble()
     val xSpan = (endSec - startSec).coerceAtLeast(1.0)
 
-    // Y domain: 0 → max(goal, highest point) with 8% headroom.
-    val maxPoint = sorted.maxOf { it.winPoints }
-    val yMax = (maxOf(goal, maxPoint).toDouble() * 1.08).coerceAtLeast(1.0)
+    // Y domain: cap at the goal unless the data exceeds it (then 5% headroom).
+    val maxPoint = sorted.maxOf { it.winPoints }.toDouble()
+    val yMax = if (maxPoint > goal) maxOf(1.0, maxPoint * 1.05) else maxOf(1.0, goal.toDouble())
 
-    val lineColor = MaterialTheme.colorScheme.secondary // electric cyan
+    val lineColor = MaterialTheme.colorScheme.secondary       // cyan
     val lastProjectionColor = MaterialTheme.colorScheme.tertiary // mint
     val projectionColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
     val axisColor = MaterialTheme.colorScheme.outlineVariant
     val labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val avgColor = ChartAvgPace
 
-    Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(280.dp),
-    ) {
-        val padLeft = 8.dp.toPx()
-        val padRight = 8.dp.toPx()
-        val padTop = 12.dp.toPx()
-        val padBottom = 22.dp.toPx()
-        val plotW = size.width - padLeft - padRight
-        val plotH = size.height - padTop - padBottom
+    Box {
+        Canvas(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+            val padLeft = 8.dp.toPx()
+            val padRight = 8.dp.toPx()
+            val padTop = 12.dp.toPx()
+            val padBottom = 22.dp.toPx()
+            val plotW = size.width - padLeft - padRight
+            val plotH = size.height - padTop - padBottom
 
-        fun xOf(instant: Instant): Float {
-            val f = ((instant.epochSecond.toDouble() - startSec) / xSpan).coerceIn(0.0, 1.0)
-            return padLeft + (f * plotW).toFloat()
-        }
-        fun xOfSec(sec: Double): Float {
-            val f = ((sec - startSec) / xSpan).coerceIn(0.0, 1.0)
-            return padLeft + (f * plotW).toFloat()
-        }
-        fun yOf(value: Double): Float {
-            val f = (value / yMax).coerceIn(0.0, 1.0)
-            return padTop + ((1.0 - f) * plotH).toFloat()
-        }
+            fun xOf(instant: Instant): Float {
+                val f = ((instant.epochSecond.toDouble() - startSec) / xSpan).coerceIn(0.0, 1.0)
+                return padLeft + (f * plotW).toFloat()
+            }
+            fun xAtFrac(f: Double): Float = padLeft + (f.coerceIn(0.0, 1.0) * plotW).toFloat()
+            fun yOf(value: Double): Float {
+                val f = (value / yMax).coerceIn(0.0, 1.0)
+                return padTop + ((1.0 - f) * plotH).toFloat()
+            }
 
-        // Baseline (y = 0).
-        drawLine(axisColor, Offset(padLeft, yOf(0.0)), Offset(padLeft + plotW, yOf(0.0)), strokeWidth = 1.dp.toPx())
+            // --- Rank overlay bands (back layer) ---
+            if (showRankOverlay) {
+                var lower = 0
+                for (t in worldTourThresholds) {
+                    if (lower < yMax) {
+                        val upper = minOf(t.points.toDouble(), yMax)
+                        val top = yOf(upper)
+                        val bottom = yOf(lower.toDouble())
+                        drawRect(
+                            color = rankColor(t.badge).copy(alpha = 0.22f),
+                            topLeft = Offset(padLeft, top),
+                            size = androidx.compose.ui.geometry.Size(plotW, bottom - top),
+                        )
+                    }
+                    lower = t.points
+                }
+                // Faint tier-zone labels at each grouped tier's vertical midpoint (right-aligned).
+                for (zone in tierZones(yMax)) {
+                    drawZoneLabel(zone.first, padLeft + plotW, yOf(zone.second) + 4.dp.toPx(), rankColor(zone.third).copy(alpha = 0.18f).toArgb())
+                }
+            }
 
-        val dash = PathEffect.dashPathEffect(floatArrayOf(10f, 8f))
+            // --- Deviation wedge ---
+            if (showAveragePace && showDeviationWedge && season != null) {
+                val proj = averagePaceProjectedEnd(sorted, season.start, season.end)
+                val dev = deviationAtEnd(sorted, season.start, season.end)
+                if (proj != null && dev != null) {
+                    val steps = 24
+                    val path = Path()
+                    for (i in 0..steps) {
+                        val f = i.toDouble() / steps
+                        val x = xAtFrac(f)
+                        val hi = yOf(minOf(yMax, f * (proj + dev)))
+                        if (i == 0) path.moveTo(x, hi) else path.lineTo(x, hi)
+                    }
+                    for (i in steps downTo 0) {
+                        val f = i.toDouble() / steps
+                        val x = xAtFrac(f)
+                        val lo = yOf(minOf(yMax, maxOf(0.0, f * (proj - dev))))
+                        path.lineTo(x, lo)
+                    }
+                    path.close()
+                    drawPath(path, color = avgColor.copy(alpha = 0.12f), style = Fill)
+                }
+            }
 
-        // Zero → goal projection.
-        drawLine(
-            color = projectionColor,
-            start = Offset(xOfSec(startSec), yOf(0.0)),
-            end = Offset(xOfSec(endSec), yOf(goal.toDouble())),
-            strokeWidth = 1.5.dp.toPx(),
-            pathEffect = dash,
-        )
+            val dash = PathEffect.dashPathEffect(floatArrayOf(10f, 8f))
 
-        // Latest point → goal projection (only if the latest point predates season end).
-        val last = sorted.last()
-        if (last.instant.epochSecond.toDouble() < endSec) {
+            // --- Average pace line ---
+            if (showAveragePace && season != null) {
+                val proj = averagePaceProjectedEnd(sorted, season.start, season.end)
+                if (proj != null && proj > 0) {
+                    val endFrac = if (proj > yMax) yMax / proj else 1.0
+                    val endVal = if (proj > yMax) yMax else proj
+                    drawLine(
+                        color = avgColor,
+                        start = Offset(xAtFrac(0.0), yOf(0.0)),
+                        end = Offset(xAtFrac(endFrac), yOf(endVal)),
+                        strokeWidth = 1.5.dp.toPx(),
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f)),
+                    )
+                }
+            }
+
+            // Baseline (y = 0).
+            drawLine(axisColor, Offset(padLeft, yOf(0.0)), Offset(padLeft + plotW, yOf(0.0)), strokeWidth = 1.dp.toPx())
+
+            // --- Zero → goal projection ---
             drawLine(
-                color = lastProjectionColor,
-                start = Offset(xOf(last.instant), yOf(last.winPoints.toDouble())),
-                end = Offset(xOfSec(endSec), yOf(goal.toDouble())),
+                color = projectionColor,
+                start = Offset(xAtFrac(0.0), yOf(0.0)),
+                end = Offset(xAtFrac(1.0), yOf(goal.toDouble())),
                 strokeWidth = 1.5.dp.toPx(),
                 pathEffect = dash,
             )
+
+            // --- Last → goal projection ---
+            val last = sorted.last()
+            if (isFromLastDefined && last.instant.epochSecond.toDouble() < endSec) {
+                drawLine(
+                    color = lastProjectionColor,
+                    start = Offset(xOf(last.instant), yOf(last.winPoints.toDouble())),
+                    end = Offset(xAtFrac(1.0), yOf(goal.toDouble())),
+                    strokeWidth = 1.5.dp.toPx(),
+                    pathEffect = dash,
+                )
+            }
+
+            // --- Cumulative line + dots ---
+            // Seed at the graph origin (x-start, 0) so the first point connects back to zero-zero.
+            var prev: Offset? = Offset(xAtFrac(0.0), yOf(0.0))
+            for (p in sorted) {
+                val o = Offset(xOf(p.instant), yOf(p.winPoints.toDouble()))
+                prev?.let { drawLine(lineColor, it, o, strokeWidth = 2.5.dp.toPx()) }
+                prev = o
+            }
+            for (p in sorted) {
+                drawCircle(lineColor, radius = 3.dp.toPx(), center = Offset(xOf(p.instant), yOf(p.winPoints.toDouble())))
+            }
+
+            // Goal / zero labels.
+            drawZoneLabelRight("Goal $goal", padLeft + plotW, yOf(goal.toDouble()) - 4.dp.toPx(), labelColor.toArgb())
+            drawZoneLabelLeft("0", padLeft, yOf(0.0) + 14.dp.toPx(), labelColor.toArgb())
         }
 
-        // Cumulative line + dots.
-        var prev: Offset? = null
-        for (p in sorted) {
-            val o = Offset(xOf(p.instant), yOf(p.winPoints.toDouble()))
-            prev?.let { drawLine(lineColor, it, o, strokeWidth = 2.5.dp.toPx()) }
-            prev = o
+        // Today badge (top-left overlay).
+        if (todayGain != null) {
+            Column(modifier = Modifier.padding(6.dp)) {
+                Text("Today", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(
+                    (if (todayGain >= 0) "+$todayGain" else "$todayGain"),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = if (todayGain >= 0) GainPositive else GainNegative,
+                )
+            }
         }
-        for (p in sorted) {
-            drawCircle(lineColor, radius = 3.dp.toPx(), center = Offset(xOf(p.instant), yOf(p.winPoints.toDouble())))
-        }
-
-        // Goal label at the top-right.
-        drawAxisLabel("Goal $goal", padLeft + plotW, yOf(goal.toDouble()) - 4.dp.toPx(), labelColor.toArgb(), alignRight = true)
-        drawAxisLabel("0", padLeft, yOf(0.0) + 14.dp.toPx(), labelColor.toArgb(), alignRight = false)
     }
 }
 
-private fun DrawScope.drawAxisLabel(text: String, x: Float, y: Float, color: Int, alignRight: Boolean) {
-    drawContext.canvas.nativeCanvas.apply {
-        val paint = android.graphics.Paint().apply {
+@Composable
+private fun Legend(showAveragePace: Boolean, showLast: Boolean) {
+    Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        LegendItem(MaterialTheme.colorScheme.onSurfaceVariant, "Zero → goal")
+        if (showLast) LegendItem(MaterialTheme.colorScheme.tertiary, "Last → goal")
+        if (showAveragePace) LegendItem(ChartAvgPace, "Avg pace")
+    }
+}
+
+@Composable
+private fun LegendItem(color: Color, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Canvas(Modifier.size(width = 14.dp, height = 3.dp)) {
+            drawLine(color, Offset(0f, size.height / 2), Offset(size.width, size.height / 2), strokeWidth = size.height)
+        }
+        Text(label, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+/** One label per grouped tier (adjacent same-tier sub-tiers merge), at the band midpoint. */
+private fun tierZones(yMax: Double): List<Triple<String, Double, String>> {
+    val zones = mutableListOf<Triple<String, Double, String>>()
+    val t = worldTourThresholds
+    var lower = 0
+    var i = 0
+    while (i < t.size) {
+        val tier = t[i].badge.substringBefore(' ')
+        var j = i
+        while (j + 1 < t.size && t[j + 1].badge.substringBefore(' ') == tier) j++
+        val upper = t[j].points
+        val mid = (lower + upper) / 2.0
+        if (mid < yMax) zones.add(Triple(tier, mid, t[i].badge))
+        lower = upper
+        i = j + 1
+    }
+    return zones
+}
+
+private fun DrawScope.drawZoneLabel(text: String, x: Float, y: Float, color: Int) =
+    drawText(text, x, y, color, android.graphics.Paint.Align.RIGHT)
+
+private fun DrawScope.drawZoneLabelRight(text: String, x: Float, y: Float, color: Int) =
+    drawText(text, x, y, color, android.graphics.Paint.Align.RIGHT)
+
+private fun DrawScope.drawZoneLabelLeft(text: String, x: Float, y: Float, color: Int) =
+    drawText(text, x, y, color, android.graphics.Paint.Align.LEFT)
+
+private fun DrawScope.drawText(text: String, x: Float, y: Float, color: Int, align: android.graphics.Paint.Align) {
+    drawContext.canvas.nativeCanvas.drawText(
+        text, x, y,
+        android.graphics.Paint().apply {
             this.color = color
             textSize = 11.sp.toPx()
             isAntiAlias = true
-            textAlign = if (alignRight) android.graphics.Paint.Align.RIGHT else android.graphics.Paint.Align.LEFT
-        }
-        drawText(text, x, y, paint)
-    }
+            textAlign = align
+        },
+    )
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SettingsSheet.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SettingsSheet.kt
@@ -1,0 +1,161 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.state.SettingsViewModel
+import com.lcarthur.seasonsprint.data.LiveStatus
+import com.lcarthur.seasonsprint.ui.theme.FinalsGold
+import com.lcarthur.seasonsprint.ui.theme.FinalsMint
+
+/** Bottom sheet for graph display toggles + live status + sign out. Port of iOS SettingsSheet. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsSheet(
+    settingsViewModel: SettingsViewModel,
+    liveStatus: LiveStatus,
+    onSignOut: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val settings by settingsViewModel.state.collectAsStateWithLifecycle()
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Settings", style = MaterialTheme.typography.titleLarge)
+
+            Text(
+                "Graph",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            SettingRow(
+                label = "Rank overlay",
+                checked = settings.showRankOverlay,
+                onChange = settingsViewModel::setRankOverlay,
+            )
+            SettingRow(
+                label = "Average pace line",
+                checked = settings.showAveragePace,
+                onChange = settingsViewModel::setAveragePace,
+            )
+            SettingRow(
+                label = "Deviation wedge",
+                checked = settings.showDeviationWedge,
+                enabled = settings.showAveragePace,
+                onChange = settingsViewModel::setDeviationWedge,
+            )
+            SettingRow(
+                label = "Pace sub-graph",
+                checked = settings.showPaceGraph,
+                onChange = settingsViewModel::setPaceGraph,
+            )
+
+            Text(
+                "Rank overlay shades threshold bands. Average pace projects your points/day " +
+                    "to season end; the deviation wedge adds a confidence band. The pace " +
+                    "sub-graph compares required vs earned points per day.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            HorizontalDivider()
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Live updates")
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    LiveIndicator(liveStatus)
+                    Text(
+                        when (liveStatus) {
+                            LiveStatus.Connected -> "Connected"
+                            LiveStatus.Connecting -> "Connecting…"
+                            LiveStatus.Disconnected -> "Off"
+                        },
+                        color = when (liveStatus) {
+                            LiveStatus.Connected -> FinalsMint
+                            LiveStatus.Connecting -> FinalsGold
+                            LiveStatus.Disconnected -> MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            TextButton(
+                onClick = {
+                    onSignOut()
+                    onDismiss()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Sign out", color = MaterialTheme.colorScheme.error)
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingRow(
+    label: String,
+    checked: Boolean,
+    enabled: Boolean = true,
+    onChange: (Boolean) -> Unit,
+) {
+    val scheme = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Dim the label when disabled so a disabled row reads differently from an off-but-active one.
+        Text(label, color = if (enabled) scheme.onSurface else scheme.onSurface.copy(alpha = 0.38f))
+        Switch(
+            checked = checked,
+            enabled = enabled,
+            onCheckedChange = onChange,
+            colors = SwitchDefaults.colors(
+                // ON: gold track, dark thumb.
+                checkedThumbColor = scheme.onPrimary,
+                checkedTrackColor = scheme.primary,
+                checkedBorderColor = scheme.primary,
+                // OFF (enabled): bright thumb + visible border so it clearly reads as interactive.
+                uncheckedThumbColor = scheme.onSurface,
+                uncheckedTrackColor = scheme.surfaceVariant,
+                uncheckedBorderColor = scheme.onSurfaceVariant,
+                // DISABLED: noticeably faded thumb/track, distinct from a plain "off".
+                disabledCheckedThumbColor = scheme.onSurface.copy(alpha = 0.38f),
+                disabledCheckedTrackColor = scheme.onSurface.copy(alpha = 0.12f),
+                disabledCheckedBorderColor = scheme.onSurface.copy(alpha = 0.12f),
+                disabledUncheckedThumbColor = scheme.onSurface.copy(alpha = 0.30f),
+                disabledUncheckedTrackColor = scheme.surfaceVariant.copy(alpha = 0.40f),
+                disabledUncheckedBorderColor = scheme.outline.copy(alpha = 0.30f),
+            ),
+        )
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/theme/Color.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/theme/Color.kt
@@ -19,6 +19,12 @@ val FinalsMint = Color(0xFF22D3A3)           // success
 val FinalsDanger = Color(0xFFFF3D7F)         // errors / points
 val BrandRed = Color(0xFFCE2C30)             // logo background
 
+// Chart overlay accents (match iOS PointsChartView / PaceChartView).
+val ChartAvgPace = Color(0xFF9F7AEA)         // average-pace line + deviation wedge (purple)
+val ChartRequired = Color(0xFFF59E0B)        // required/day pace line (amber)
+val GainPositive = Color(0xFF22D3A3)         // +today (mint)
+val GainNegative = Color(0xFFFF3D7F)         // -today (magenta)
+
 // Rank tier palette — ported from packages/ios .../Views/RankBadgeView.swift.
 val RankBronze = Color(0xFFCC8033)
 val RankSilver = Color(0xFFBFBFCC)


### PR DESCRIPTION
## Summary

Brings the native **Android** client to parity with the iOS/web apps and adds the two UI-clarity changes that shipped for those clients in #79. The debug APK attached to release **v0.1.4** was built from this source.

### Parity with iOS/web
- Branded loading screen
- Settings sheet with graph display toggles (`SettingsViewModel`)
- Details tab: season banner, stats grid, goal control, collapsible rank/cheatsheet tables
- Points chart with rank-overlay bands + zero/last/avg-pace projections and the deviation wedge
- Pace sub-graph (`PaceChart`); `Pace` domain logic ported
- Edit-point sheet, log screen, and form-field refinements

### Goal control reads as editable
Filled-tonal button with a dropdown chevron + a **"Tap to change"** subtitle, instead of plain text.

### Database-style live indicator
Three-state link model — **disconnected / connecting / connected** — shown as a database symbol:
- not rendered when there's no live link
- amber, fading in and out, while connecting (and reconnecting)
- steady green once connected

`LiveUpdates` now exposes a `LiveStatus` flow; the dashboard header and the settings row reflect it.

## Testing
`:app:assembleDebug` and `:app:testDebugUnitTest` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
