### PR TITLE
fix(local-win): harden installer deps phase + shrink download

### DIFF
--- a/packages/local-win/install-deps.bat
+++ b/packages/local-win/install-deps.bat
@@ -81,6 +81,21 @@ if not exist "%VENV_PY%" (
 
 REM ── 5. Install / upgrade dependencies (no-op if satisfied) ───────────────
 "%VENV_PY%" -m pip install --upgrade pip >nul
+
+REM EasyOCR depends on torch + torchvision. Installed straight from PyPI,
+REM pip can pull a CUDA-enabled torch wheel (~2GB) even though we run OCR on
+REM CPU (gpu=False). Pre-installing the CPU-only builds from PyTorch's own
+REM index pins the small wheels (~200MB total) so the subsequent
+REM `-r requirements.txt` sees torch/torchvision already satisfied and skips
+REM the CUDA download entirely. This is the single biggest factor in how long
+REM a cold install takes — and the most common point of failure on flaky
+REM connections. No-ops on a re-run once the wheels are present.
+"%VENV_PY%" -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+if errorlevel 1 (
+    echo ERROR: CPU torch install failed.
+    popd & endlocal & exit /b 1
+)
+
 "%VENV_PY%" -m pip install -r requirements.txt
 if errorlevel 1 (
     echo ERROR: pip install failed.

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -2,8 +2,13 @@
 ;
 ; Produces a single SeasonSprintSetup.exe that installs per-user (no UAC),
 ; copies the Python sources + a Steam-launch wrapper into
-; %LOCALAPPDATA%\Programs\SeasonSprint\, then runs setup.bat --install-only
-; to bootstrap Python + VC++ Redist + venv + deps + first-run config.
+; %LOCALAPPDATA%\Programs\SeasonSprint\, then runs two [Run] phases:
+;   1. install-deps.bat (hidden, logged to {app}\install.log) — bootstraps
+;      Python + VC++ Redist + venv + deps.
+;   2. season_tracker.py --setup-only (visible) — first-run config prompt.
+; Phase 2 is gated on Phase 1 actually producing the venv, so a failed
+; dependency install surfaces a clear message instead of an opaque
+; "file not found" on the venv python.
 ;
 ; Build (on Windows with Inno Setup 6 installed):
 ;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss
@@ -11,7 +16,7 @@
 ; Output: dist\SeasonSprintSetup.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.3"
+#define AppVersion    "0.1.5"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -59,28 +64,65 @@ Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 ; Runs hidden so the user sees Inno's progress bar with our StatusMsg
 ; instead of a raw cmd window. Takes 1-2 minutes on a cold install
 ; (PyTorch download dominates).
-Filename: "{app}\install-deps.bat"; WorkingDir: "{app}"; Flags: runhidden waituntilterminated; StatusMsg: "Installing Python, PyTorch, and EasyOCR (this takes 1-2 minutes on first install)..."
+;
+; Invoked via cmd /C so we can redirect all output to {app}\install.log.
+; Because the window is hidden, a pip/winget failure would otherwise leave
+; the user (and us) with nothing to diagnose; the log is the only record.
+; The doubled quotes are Inno escaping — the command cmd actually receives
+; is:  /C ""{app}\install-deps.bat" > install.log 2>&1"
+Filename: "{cmd}"; Parameters: "/C """"{app}\install-deps.bat"" > install.log 2>&1"""; WorkingDir: "{app}"; Flags: runhidden waituntilterminated; StatusMsg: "Installing Python, PyTorch, and EasyOCR (this takes 1-2 minutes on first install)..."
 
-; Phase 2 — interactive first-run config (prompts for SERVER_URL + AUTH_TOKEN).
+; Phase 2 — interactive first-run config (prompts for AUTH_TOKEN + monitor).
 ; Runs in a visible cmd window because the user has to type into it.
-; Quick — finishes as soon as the user fills in the three prompts.
-Filename: "{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe"; Parameters: """{app}\season_tracker.py"" --setup-only"; WorkingDir: "{app}"; Flags: runascurrentuser waituntilterminated; StatusMsg: "Configuring your Season Sprint account..."
+; Quick — finishes as soon as the user fills in the prompts.
+;
+; Check: VenvPythonExists — skip this phase entirely if Phase 1 failed to
+; produce the venv python, so we never invoke a non-existent exe (which
+; Inno reports as a confusing "system cannot find the file" error). The
+; finish page (see [Code]) then shows a deps-failed message instead.
+Filename: "{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe"; Parameters: """{app}\season_tracker.py"" --setup-only"; WorkingDir: "{app}"; Flags: runascurrentuser waituntilterminated; StatusMsg: "Configuring your Season Sprint account..."; Check: VenvPythonExists
 
 [UninstallDelete]
-; Tidy up venv + state + config on uninstall.
+; Tidy up venv + state + config + logs on uninstall.
 Type: filesandordirs; Name: "{%USERPROFILE}\.season-sprint"
 Type: files; Name: "{app}\.env"
 Type: files; Name: "{app}\.last-wtp"
+Type: files; Name: "{app}\.tracker-pid"
+Type: files; Name: "{app}\install.log"
+Type: files; Name: "{app}\tracker.log"
 
 [Code]
+// True once Phase 1 (install-deps.bat) has produced the venv python. Used
+// to gate Phase 2 and to branch the finish page between success and a
+// dependency-install failure.
+function VenvPythonExists: Boolean;
+begin
+  Result := FileExists(ExpandConstant('{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe'));
+end;
+
 procedure CurPageChanged(CurPageID: Integer);
 var
   LaunchLine: String;
 begin
   if CurPageID = wpFinished then begin
-    LaunchLine := '"' + ExpandConstant('{app}') + '\launch.bat" %command%';
     WizardForm.FinishedLabel.AutoSize := False;
     WizardForm.FinishedLabel.WordWrap := True;
+    if not VenvPythonExists then begin
+      // Phase 1 failed — Python/venv/deps never got installed. Point the
+      // user at the log and the re-runnable Start Menu shortcut rather than
+      // leaving them with a "complete" message for a broken install.
+      WizardForm.FinishedLabel.Caption :=
+        'Setup could not finish installing the tracker''s dependencies.' + #13#10 + #13#10 +
+        'A common cause is no internet connection, or "winget" being ' +
+        'unavailable on older Windows 10 builds (install Python 3.11+ from ' +
+        'python.org first, then re-run setup).' + #13#10 + #13#10 +
+        'Details were written to:' + #13#10 +
+        ExpandConstant('{app}') + '\install.log' + #13#10 + #13#10 +
+        'After fixing the cause, re-run via Start Menu > ' +
+        '"Season Sprint Tracker" > "Reconfigure tracker".';
+      exit;
+    end;
+    LaunchLine := '"' + ExpandConstant('{app}') + '\launch.bat" %command%';
     WizardForm.FinishedLabel.Caption :=
       'Installation complete.' + #13#10 + #13#10 +
       'In Steam: right-click your game > Properties > General > Launch Options,' + #13#10 +


### PR DESCRIPTION
## What

Hardens the Windows installer's dependency-bootstrap phase and shrinks the install-time download. No change to the installer's overall shape (single per-user exe → winget Python + venv + pip → first-run config → Steam launch wrapper).

## Changes

**`install-deps.bat` — CPU-only torch**
- Pre-installs `torch`/`torchvision` from `download.pytorch.org/whl/cpu` before `requirements.txt`. EasyOCR runs OCR on CPU (`gpu=False`), but installed straight from PyPI it can pull a CUDA torch wheel (~2GB). Pinning the CPU builds (~200MB) makes cold installs ~10x smaller and removes the most common failure point on flaky connections.

**`installer.iss` — robust deps phase**
- Phase 1 now runs via `cmd /C` with output redirected to `{app}\install.log`, so a *hidden* pip/winget failure is diagnosable instead of silent.
- Phase 2 (config) is gated with `Check: VenvPythonExists` — if deps failed, the config step is skipped rather than invoking a non-existent venv python (which Inno reports as a confusing "system cannot find the file").
- Finish page branches: success shows the Steam launch line as before; failure shows a clear message pointing at `install.log` and the re-runnable Start Menu "Reconfigure" shortcut.
- Tidies uninstall cleanup (install.log, tracker.log, .tracker-pid) and fixes a stale header comment.
- `AppVersion` 0.1.3 → **0.1.5** (0.1.4 was already used by the Android alpha release).

## Testing

Static review only — built/verified on Linux, can't run Inno/Windows locally. The `cmd /C` quote-escaping was hand-parsed through both the Inno and cmd layers. The real end-to-end build runs in the existing **Build Windows installer** GitHub Actions workflow (windows-latest + Inno), which this PR will trigger and which produces the actual `SeasonSprintSetup.exe` artifact.

## Release

Once merged, tag `v0.1.5` on main to publish the updated installer as a GitHub Release (the workflow publishes on `v*` tag push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.5.
  * Installation process now pre-installs PyTorch CPU dependencies with explicit error checking.
  * Enhanced installation diagnostics with improved logging for troubleshooting.
  * Expanded cleanup targets during uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->