### PR TITLE
feat(local-win): collect installer config inside the wizard window

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -2,13 +2,23 @@
 ;
 ; Produces a single SeasonSprintSetup.exe that installs per-user (no UAC),
 ; copies the Python sources + a Steam-launch wrapper into
-; %LOCALAPPDATA%\Programs\SeasonSprint\, then runs two [Run] phases:
-;   1. install-deps.bat (hidden, logged to {app}\install.log) — bootstraps
-;      Python + VC++ Redist + venv + deps.
-;   2. season_tracker.py --setup-only (visible) — first-run config prompt.
-; Phase 2 is gated on Phase 1 actually producing the venv, so a failed
-; dependency install surfaces a clear message instead of an opaque
-; "file not found" on the venv python.
+; %LOCALAPPDATA%\Programs\SeasonSprint\, and collects all first-run config
+; inside the wizard itself (no separate cmd window):
+;
+;   Welcome
+;     -> Choose install location
+;     -> Enter API key            (native wizard page)
+;     -> Installing dependencies   (progress; runs install-deps.bat from a
+;                                   temp copy, logged to .season-sprint\install.log)
+;     -> Pick game monitor         (native page, populated from the real
+;                                   tracker via `season_tracker.py --list-monitors`;
+;                                   auto-skipped when there is only one monitor)
+;     -> Install (copies files, writes .env)
+;     -> Finish (shows the Steam launch line, or a deps-failure message)
+;
+; Dependencies are installed mid-wizard (on the API-key page's Next) so the
+; monitor picker can be enumerated by mss exactly as the tracker sees it. The
+; finish page branches on whether the venv python actually got produced.
 ;
 ; Build (on Windows with Inno Setup 6 installed):
 ;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss
@@ -16,7 +26,7 @@
 ; Output: dist\SeasonSprintSetup.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.5"
+#define AppVersion    "0.1.6"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -55,49 +65,199 @@ Source: "..\install-deps.bat";  DestDir: "{app}"; Flags: ignoreversion
 Source: "..\launch.bat";        DestDir: "{app}"; Flags: ignoreversion
 Source: "..\watch-tracker.bat"; DestDir: "{app}"; Flags: ignoreversion
 
+; Temp-extractable copies (dontcopy) used DURING the wizard, before the files
+; above are installed to {app}: install-deps.bat + requirements.txt run the
+; dependency bootstrap, and season_tracker.py enumerates monitors. Extracted to
+; {tmp} via ExtractTemporaryFile in [Code].
+Source: "..\install-deps.bat";  Flags: dontcopy
+Source: "..\requirements.txt";  Flags: dontcopy
+Source: "..\season_tracker.py"; Flags: dontcopy
+
 [Icons]
 Name: "{group}\Reconfigure tracker";  Filename: "{app}\setup.bat"; Parameters: "--install-only"; WorkingDir: "{app}"
 Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 
-[Run]
-; Phase 1 — heavy lifting (Python + VCRedist + venv + pip).
-; Runs hidden so the user sees Inno's progress bar with our StatusMsg
-; instead of a raw cmd window. Takes 1-2 minutes on a cold install
-; (PyTorch download dominates).
-;
-; Invoked via cmd /C so we can redirect all output to {app}\install.log.
-; Because the window is hidden, a pip/winget failure would otherwise leave
-; the user (and us) with nothing to diagnose; the log is the only record.
-; The doubled quotes are Inno escaping — the command cmd actually receives
-; is:  /C ""{app}\install-deps.bat" > install.log 2>&1"
-Filename: "{cmd}"; Parameters: "/C """"{app}\install-deps.bat"" > install.log 2>&1"""; WorkingDir: "{app}"; Flags: runhidden waituntilterminated; StatusMsg: "Installing Python, PyTorch, and EasyOCR (this takes 1-2 minutes on first install)..."
-
-; Phase 2 — interactive first-run config (prompts for AUTH_TOKEN + monitor).
-; Runs in a visible cmd window because the user has to type into it.
-; Quick — finishes as soon as the user fills in the prompts.
-;
-; Check: VenvPythonExists — skip this phase entirely if Phase 1 failed to
-; produce the venv python, so we never invoke a non-existent exe (which
-; Inno reports as a confusing "system cannot find the file" error). The
-; finish page (see [Code]) then shows a deps-failed message instead.
-Filename: "{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe"; Parameters: """{app}\season_tracker.py"" --setup-only"; WorkingDir: "{app}"; Flags: runascurrentuser waituntilterminated; StatusMsg: "Configuring your Season Sprint account..."; Check: VenvPythonExists
-
 [UninstallDelete]
-; Tidy up venv + state + config + logs on uninstall.
+; Tidy up venv + state + config + logs on uninstall. The whole .season-sprint
+; dir (venv + install.log) goes via filesandordirs.
 Type: filesandordirs; Name: "{%USERPROFILE}\.season-sprint"
 Type: files; Name: "{app}\.env"
 Type: files; Name: "{app}\.last-wtp"
 Type: files; Name: "{app}\.tracker-pid"
-Type: files; Name: "{app}\install.log"
 Type: files; Name: "{app}\tracker.log"
 
 [Code]
-// True once Phase 1 (install-deps.bat) has produced the venv python. Used
-// to gate Phase 2 and to branch the finish page between success and a
-// dependency-install failure.
+var
+  TokenPage: TInputQueryWizardPage;
+  MonitorPage: TInputOptionWizardPage;
+  MonitorIndices: array of Integer;  // option index -> mss MONITOR_INDEX
+  DepsOK: Boolean;                   // venv python produced by install-deps
+  DepsAttempted: Boolean;            // guard so Back/Next doesn't re-run deps
+
+// True once install-deps.bat has produced the venv python. Drives the monitor
+// page skip and the finish-page success/failure branch.
 function VenvPythonExists: Boolean;
 begin
   Result := FileExists(ExpandConstant('{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe'));
+end;
+
+// Mirror of _API_KEY_RE in season_tracker.py: "sk_" + 64 lowercase hex chars.
+function IsValidApiKey(const S: String): Boolean;
+var
+  i: Integer;
+  c: Char;
+begin
+  Result := False;
+  if Length(S) <> 67 then exit;
+  if Copy(S, 1, 3) <> 'sk_' then exit;
+  for i := 4 to 67 do begin
+    c := S[i];
+    if not (((c >= '0') and (c <= '9')) or ((c >= 'a') and (c <= 'f'))) then exit;
+  end;
+  Result := True;
+end;
+
+procedure InitializeWizard;
+begin
+  DepsOK := False;
+  DepsAttempted := False;
+  SetArrayLength(MonitorIndices, 0);
+
+  TokenPage := CreateInputQueryPage(wpSelectDir,
+    'Season Sprint account',
+    'Enter your personal API key',
+    'Paste the key from the web app''s "API Keys" banner (the full key in the green banner, not the truncated prefix). It starts with "sk_" and is 67 characters long. Clicking Next sets up Python and dependencies, which takes 1-2 minutes on the first install.');
+  TokenPage.Add('API key:', True);
+
+  MonitorPage := CreateInputOptionPage(TokenPage.ID,
+    'Game monitor',
+    'Choose the monitor that runs The Finals',
+    'The tracker reads the World Tour Points from the bottom-centre of this screen.',
+    True, False);
+end;
+
+// Run install-deps.bat from a temp copy (logged), then, if it produced the
+// venv, enumerate monitors via the tracker and populate the picker page.
+procedure RunDepsAndEnumerate;
+var
+  Progress: TOutputProgressWizardPage;
+  rc, i, p1, p2, idx: Integer;
+  TmpBat, TmpScript, LogPath, MonFile, VenvPy: String;
+  Lines: TArrayOfString;
+  line, rest, rest2, idxStr, resStr, posStr: String;
+begin
+  ForceDirectories(ExpandConstant('{%USERPROFILE}\.season-sprint'));
+  ExtractTemporaryFile('install-deps.bat');
+  ExtractTemporaryFile('requirements.txt');
+  ExtractTemporaryFile('season_tracker.py');
+
+  TmpBat    := ExpandConstant('{tmp}\install-deps.bat');
+  TmpScript := ExpandConstant('{tmp}\season_tracker.py');
+  LogPath   := ExpandConstant('{%USERPROFILE}\.season-sprint\install.log');
+  MonFile   := ExpandConstant('{tmp}\monitors.txt');
+  VenvPy    := ExpandConstant('{%USERPROFILE}\.season-sprint\venv\Scripts\python.exe');
+
+  Progress := CreateOutputProgressPage('Installing dependencies',
+    'Setting up Python and the Season Sprint tracker.');
+  Progress.Show;
+  try
+    Progress.SetText('Installing Python, PyTorch and EasyOCR...',
+      'This can take 1-2 minutes on the first install. Please wait.');
+    Progress.SetProgress(10, 100);
+    // cmd /C with a redirect; the doubled "" are literal quotes in the Pascal
+    // string. cmd strips the outer pair, leaving: "<bat>" > "<log>" 2>&1
+    Exec(ExpandConstant('{cmd}'),
+      '/C ""' + TmpBat + '" > "' + LogPath + '" 2>&1"',
+      ExpandConstant('{tmp}'), SW_HIDE, ewWaitUntilTerminated, rc);
+
+    DepsOK := VenvPythonExists;
+    if DepsOK then begin
+      Progress.SetText('Detecting monitors...', '');
+      Progress.SetProgress(90, 100);
+      Exec(ExpandConstant('{cmd}'),
+        '/C ""' + VenvPy + '" "' + TmpScript + '" --list-monitors > "' + MonFile + '" 2>&1"',
+        ExpandConstant('{tmp}'), SW_HIDE, ewWaitUntilTerminated, rc);
+
+      if LoadStringsFromFile(MonFile, Lines) then begin
+        for i := 0 to GetArrayLength(Lines) - 1 do begin
+          line := Trim(Lines[i]);
+          // Expect: MON|<idx>|<w>x<h>|<left>,<top>  (prefix filters noise)
+          if Copy(line, 1, 4) = 'MON|' then begin
+            rest := Copy(line, 5, Length(line));
+            p1 := Pos('|', rest);
+            if p1 > 0 then begin
+              idxStr := Copy(rest, 1, p1 - 1);
+              rest2  := Copy(rest, p1 + 1, Length(rest));
+              p2 := Pos('|', rest2);
+              if p2 > 0 then begin
+                resStr := Copy(rest2, 1, p2 - 1);
+                posStr := Copy(rest2, p2 + 1, Length(rest2));
+                idx := StrToIntDef(idxStr, 0);
+                if idx > 0 then begin
+                  SetArrayLength(MonitorIndices, GetArrayLength(MonitorIndices) + 1);
+                  MonitorIndices[GetArrayLength(MonitorIndices) - 1] := idx;
+                  MonitorPage.Add('Monitor ' + idxStr + '  -  ' + resStr + '  @ (' + posStr + ')');
+                end;
+              end;
+            end;
+          end;
+        end;
+      end;
+      if GetArrayLength(MonitorIndices) > 0 then
+        MonitorPage.SelectedValueIndex := 0;
+    end;
+  finally
+    Progress.Hide;
+  end;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if CurPageID = TokenPage.ID then begin
+    if not IsValidApiKey(Trim(TokenPage.Values[0])) then begin
+      MsgBox('That does not look like a valid API key.' + #13#10 + #13#10 +
+             'It should be 67 characters: "sk_" followed by 64 hex characters.' + #13#10 +
+             'Copy the full key from the web app''s "API Keys" banner (not the truncated prefix).',
+             mbError, MB_OK);
+      Result := False;
+      exit;
+    end;
+    if not DepsAttempted then begin
+      DepsAttempted := True;
+      RunDepsAndEnumerate;
+    end;
+  end;
+end;
+
+function ShouldSkipPage(PageID: Integer): Boolean;
+begin
+  Result := False;
+  // Skip the monitor page if deps failed (nothing to enumerate) or there is
+  // only one monitor (auto-selected).
+  if PageID = MonitorPage.ID then
+    Result := (not DepsOK) or (GetArrayLength(MonitorIndices) <= 1);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  EnvLines: TArrayOfString;
+  idx, sel: Integer;
+begin
+  // Write {app}\.env once the files are in place. Done in Inno (not by calling
+  // the script) so the token never lands on a command line.
+  if CurStep = ssPostInstall then begin
+    idx := 1;
+    if GetArrayLength(MonitorIndices) > 0 then begin
+      sel := MonitorPage.SelectedValueIndex;
+      if (sel < 0) or (sel >= GetArrayLength(MonitorIndices)) then sel := 0;
+      idx := MonitorIndices[sel];
+    end;
+    SetArrayLength(EnvLines, 2);
+    EnvLines[0] := 'AUTH_TOKEN=' + Trim(TokenPage.Values[0]);
+    EnvLines[1] := 'MONITOR_INDEX=' + IntToStr(idx);
+    SaveStringsToFile(ExpandConstant('{app}\.env'), EnvLines, False);
+  end;
 end;
 
 procedure CurPageChanged(CurPageID: Integer);
@@ -108,16 +268,15 @@ begin
     WizardForm.FinishedLabel.AutoSize := False;
     WizardForm.FinishedLabel.WordWrap := True;
     if not VenvPythonExists then begin
-      // Phase 1 failed — Python/venv/deps never got installed. Point the
-      // user at the log and the re-runnable Start Menu shortcut rather than
-      // leaving them with a "complete" message for a broken install.
+      // Deps install failed — point the user at the log and the re-runnable
+      // Start Menu shortcut rather than implying a working install.
       WizardForm.FinishedLabel.Caption :=
         'Setup could not finish installing the tracker''s dependencies.' + #13#10 + #13#10 +
         'A common cause is no internet connection, or "winget" being ' +
         'unavailable on older Windows 10 builds (install Python 3.11+ from ' +
         'python.org first, then re-run setup).' + #13#10 + #13#10 +
         'Details were written to:' + #13#10 +
-        ExpandConstant('{app}') + '\install.log' + #13#10 + #13#10 +
+        ExpandConstant('{%USERPROFILE}\.season-sprint\install.log') + #13#10 + #13#10 +
         'After fixing the cause, re-run via Start Menu > ' +
         '"Season Sprint Tracker" > "Reconfigure tracker".';
       exit;

--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -172,6 +172,28 @@ def _list_monitors() -> list[dict]:
         return list(sct.monitors)
 
 
+def _print_monitor_list() -> int:
+    """Print the physical monitors in a machine-parseable form for the Inno
+    Setup installer's monitor-picker page. One line per physical monitor:
+
+        MON|<idx>|<width>x<height>|<left>,<top>
+
+    <idx> is the mss index (1-based into sct.monitors, skipping the index-0
+    "all monitors" bounding box) — exactly the value written as MONITOR_INDEX
+    and consumed by _grab_points_region, so the installer's picker, the saved
+    config, and the running tracker all agree on what each number means.
+
+    The "MON|" prefix lets the installer ignore unrelated stdout noise — most
+    notably the "=== Tracker started ===" banner that the module-level _Tee
+    emits at import time into whatever stdout the installer redirects to a file.
+    """
+    monitors = _list_monitors()
+    physical = monitors[1:]  # skip the "all" bounding-box at index 0
+    for i, m in enumerate(physical, start=1):
+        print(f"MON|{i}|{m['width']}x{m['height']}|{m['left']},{m['top']}")
+    return 0
+
+
 def _prompt_config() -> Config:
     existing = _parse_env_file(ENV_FILE)
 
@@ -489,6 +511,12 @@ def _sleep_interruptible(total_secs: int) -> None:
 
 
 def main() -> int:
+    # Non-interactive query used by the installer's wizard to build its
+    # monitor-picker page. Handled before anything else (no signal handlers,
+    # no config load, no prompts) so it stays a fast, side-effect-free probe.
+    if "--list-monitors" in sys.argv[1:]:
+        return _print_monitor_list()
+
     signal.signal(signal.SIGINT, _handle_signal)
     if hasattr(signal, "SIGTERM"):
         signal.signal(signal.SIGTERM, _handle_signal)


### PR DESCRIPTION
## What

Moves the installer's first-run config **into the wizard window**. Previously the API key + monitor were entered in a separate cmd window (a `[Run]` phase running `season_tracker.py --setup-only`). Now they're native Inno wizard pages — no cmd popup.

## New wizard flow

```
Welcome
  -> Choose install location
  -> Enter API key            (native page, format-validated)
  -> Installing dependencies   (progress page, 1-2 min on cold install)
  -> Pick game monitor         (native page; auto-skipped if only 1 monitor)
  -> Install (copies files, writes .env)
  -> Finish (Steam launch line, or deps-failure message)
```

## Why deps install mid-wizard

The monitor picker must match exactly what the running tracker sees, and the tracker enumerates monitors via Python's `mss` — which only exists after the dependency install. Native wizard pages run *before* the install step, so dependencies are installed on the API-key page's **Next**, then the picker is populated by querying the real tracker. This keeps `mss` the single source of truth (correct ordering + DPI), with no fragile native re-implementation.

## Changes

**`season_tracker.py`** (small, additive)
- New non-interactive `--list-monitors` mode: prints `MON|<idx>|<w>x<h>|<left>,<top>` per physical monitor, where `<idx>` is the same mss index written as `MONITOR_INDEX`. The `MON|` prefix lets the installer ignore unrelated stdout (notably the import-time `_Tee` banner). Handled first in `main()`. The interactive `--setup-only` path is untouched.

**`installer.iss`** (main work)
- Native **API-key page** (masked input; validated against the `sk_` + 64-hex format, mirroring `_API_KEY_RE`).
- Native **monitor-picker page**, populated from `--list-monitors`; auto-skipped when there's a single monitor (writes `MONITOR_INDEX=1`).
- Deps install moved into `[Code]`: runs `install-deps.bat` from a `dontcopy` temp copy with a progress page, logged to `%USERPROFILE%\.season-sprint\install.log`.
- `.env` is written directly by Inno at `ssPostInstall` — the token never lands on a command line.
- Removed the two `[Run]` phases; finish page still branches success/failure on `VenvPythonExists`.
- `AppVersion` 0.1.5 → **0.1.6**.

**Unchanged:** `install-deps.bat`, `setup.bat`, `launch.bat`, the "Reconfigure tracker" shortcut, and the interactive `--setup-only` flow.

## Testing

- **Automated:** this PR triggers the **Build Windows installer** workflow; `ISCC.exe` compiling the `.iss` catches Pascal syntax/type errors (the main risk). `season_tracker.py` passes `py_compile`.
- **Manual (Windows VM):** verify the API-key page rejects a malformed key, the deps progress page shows, the monitor page lists displays (auto-skips on a single-monitor VM), `{app}\.env` has the right token + index, and the tracker runs. No cmd window should appear.

## Release

After merge, tag `v0.1.6` to publish the updated installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
