### PR TITLE
ci: build Android APK in CI + attach to releases; drop source zip

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,64 @@
+name: Build Android APK
+
+# Builds the Android app whenever packages/android/ changes (on PRs and on a
+# v* tag push), or on manual dispatch. Every run uploads season-sprint-android.apk
+# as a workflow artifact; tag pushes additionally attach it to the GitHub Release
+# created for that tag.
+#
+# This is a debug-signed build (Android's universal debug key) published under a
+# clean name — installable via sideload, no release keystore required. If a real
+# signed release build is ever wanted, add a signingConfig + keystore secrets and
+# switch assembleDebug -> assembleRelease.
+
+on:
+  push:
+    paths:
+      - "packages/android/**"
+      - ".github/workflows/build-android.yml"
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "packages/android/**"
+      - ".github/workflows/build-android.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write  # attach the APK to the Release on a v* tag
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build debug APK
+        working-directory: packages/android
+        run: |
+          chmod +x ./gradlew
+          ./gradlew --no-daemon assembleDebug
+
+      - name: Stage APK under a clean name
+        run: cp packages/android/app/build/outputs/apk/debug/app-debug.apk season-sprint-android.apk
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: season-sprint-android
+          path: season-sprint-android.apk
+          if-no-files-found: error
+
+      - name: Attach APK to Release (on v* tag only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: season-sprint-android.apk

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,6 +9,9 @@ name: Build Android APK
 # clean name — installable via sideload, no release keystore required. If a real
 # signed release build is ever wanted, add a signingConfig + keystore secrets and
 # switch assembleDebug -> assembleRelease.
+#
+# Permissions follow least privilege: the build job is read-only (so PR runs hold
+# no write token), and only the tag-gated release job gets contents: write.
 
 on:
   push:
@@ -23,14 +26,18 @@ on:
       - ".github/workflows/build-android.yml"
   workflow_dispatch:
 
-permissions:
-  contents: write  # attach the APK to the Release on a v* tag
+# Default to no permissions; each job opts into the minimum it needs.
+permissions: {}
 
 jobs:
-  build-android:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -57,8 +64,21 @@ jobs:
           path: season-sprint-android.apk
           if-no-files-found: error
 
-      - name: Attach APK to Release (on v* tag only)
-        if: startsWith(github.ref, 'refs/tags/v')
+  # Attach the built APK to the GitHub Release. Separate job so contents: write
+  # is only ever granted on a v* tag, never on PR/branch build runs.
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: season-sprint-android
+
+      - name: Attach APK to Release
         uses: softprops/action-gh-release@v2
         with:
           files: season-sprint-android.apk

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -47,20 +47,6 @@ jobs:
         run: |
           Compress-Archive -Path SeasonSprintSetup.exe -DestinationPath SeasonSprintSetup.zip -CompressionLevel Optimal -Force
 
-      - name: Build focused tracker source zip
-        # GitHub's auto-generated source zip ships the whole monorepo (web,
-        # server, Linux tracker, ~5MB+). Testers only need ~25KB of files.
-        # Stage just the Windows tracker files flat at the zip root so the
-        # user double-clicks setup.bat with no folder navigation.
-        shell: pwsh
-        working-directory: packages/local-win
-        run: |
-          Compress-Archive `
-            -Path setup.bat, install-deps.bat, launch.bat, watch-tracker.bat, season_tracker.py, test_ocr.py, requirements.txt, .env.example `
-            -DestinationPath dist/SeasonSprintTracker-source.zip `
-            -CompressionLevel Optimal `
-            -Force
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -68,7 +54,6 @@ jobs:
           path: |
             packages/local-win/dist/SeasonSprintSetup.exe
             packages/local-win/dist/SeasonSprintSetup.zip
-            packages/local-win/dist/SeasonSprintTracker-source.zip
           if-no-files-found: error
 
       - name: Publish GitHub Release (on v* tag only)
@@ -78,6 +63,5 @@ jobs:
           files: |
             packages/local-win/dist/SeasonSprintSetup.exe
             packages/local-win/dist/SeasonSprintSetup.zip
-            packages/local-win/dist/SeasonSprintTracker-source.zip
           draft: false
           generate_release_notes: true


### PR DESCRIPTION
## What

Makes the Android APK a permanent, automated release artifact, and removes the unneeded tracker source zip from releases.

## Changes

**New `build-android.yml`**
- Builds `packages/android` with Gradle (`assembleDebug`) on Android changes, PRs, manual dispatch, and `v*` tags.
- Publishes the APK under a clean name — **`season-sprint-android.apk`** (no "debug" in the name).
- On a `v*` tag, attaches it to that tag's GitHub Release (alongside the Windows installer that the other workflow publishes).
- It's a **debug-signed** build (Android's universal debug key) — installs via sideload with no release keystore. (To switch to a real signed release build later: add a `signingConfig` + keystore secrets and swap `assembleDebug` → `assembleRelease`.)

**`build-windows-installer.yml`**
- Drops the `SeasonSprintTracker-source.zip` step and its release/artifact entries. Releases now ship just `SeasonSprintSetup.exe` + the `.zip` fallback.

## ⚠️ Heads-up: CI builds what's on `main`

`origin/main` currently has the **MVP** Android app. Your latest in-progress screens (`DetailsScreen`, `PaceChart`, `SettingsSheet`, `BrandedLoadingScreen`, `LiveIndicator` refactor, `SettingsViewModel`) are **uncommitted** working-tree files, so the CI-built APK will be the MVP until those land on `main`. `main` does compile standalone (verified — `LiveIndicator` is still defined inline in `DashboardScreen.kt`).

## Testing

- This PR's `pull_request` trigger runs the Android build as a check, validating the Gradle build works in CI (JDK 17 + Android SDK).
- On the next `v*` tag, the APK auto-attaches to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Android debug APK builds now trigger on Android code changes, version tag releases, and manual dispatch, with artifacts available for download
  * Streamlined Windows installer release packages to include only the executable and archive files, removing source code archive distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->