### PR TITLE
feat(landing): mark iOS as "coming soon"

### DIFF
--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -162,10 +162,10 @@
             <span class="platform-name">Web app</span>
             <span class="platform-note">app.seasonsprint.com</span>
           </a>
-          <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
+          <div class="platform platform-soon" aria-disabled="true">
             <span class="platform-name">iOS</span>
-            <span class="platform-note">Latest build</span>
-          </a>
+            <span class="platform-note">Coming soon</span>
+          </div>
           <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
             <span class="platform-name">Android</span>
             <span class="platform-note">APK download</span>

--- a/packages/landing/styles.css
+++ b/packages/landing/styles.css
@@ -346,6 +346,19 @@ h3 {
   box-shadow: 0 0 0 1px rgba(255, 212, 0, 0.1),
     0 12px 30px rgba(255, 212, 0, 0.15);
 }
+.platform-soon {
+  cursor: default;
+  opacity: 0.6;
+  border-style: dashed;
+}
+.platform-soon:hover {
+  transform: none;
+  border-color: var(--border);
+  box-shadow: none;
+}
+.platform-soon .platform-note {
+  color: var(--accent);
+}
 .platform-name {
   font-weight: 900;
   text-transform: uppercase;


### PR DESCRIPTION
## What

Follow-up to #89. The iOS app technically exists but isn't on the App Store and sideloading is impractical, so this changes the iOS entry in the landing page's platforms list from a download link to a dimmed, non-clickable **"Coming soon"** tile.

- `index.html`: iOS becomes a non-link tile with a "Coming soon" note (Web / Android / Windows unchanged)
- `styles.css`: adds a `.platform-soon` modifier (dashed border, dimmed, no hover, cyan note)

This commit was authored on the landing branch after #89 had already merged, so it's shipped here as a small standalone PR based on the current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
