### PR TITLE
perf(landing): bake releases.json at deploy time for instant downloads

### DIFF
--- a/.github/workflows/refresh-landing.yml
+++ b/.github/workflows/refresh-landing.yml
@@ -1,0 +1,33 @@
+name: Refresh landing downloads
+
+# When a release is published/updated, ping Render's deploy hook so the landing
+# static site rebuilds and re-bakes packages/landing/releases.json (via
+# `pnpm -F landing build` → generate-releases.mjs) with the new assets.
+#
+# Setup: in the Render dashboard for the landing static site, create a Deploy
+# Hook (Settings → Deploy Hook), then add its URL as the repo secret
+# RENDER_LANDING_DEPLOY_HOOK. Without the secret this job is a no-op, so the
+# downloads page still refreshes on the next normal deploy (and falls back to
+# the live GitHub API at runtime in the meantime).
+
+on:
+  release:
+    types: [published, edited, released, deleted, unpublished]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-render:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Render deploy
+        env:
+          HOOK: ${{ secrets.RENDER_LANDING_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "RENDER_LANDING_DEPLOY_HOOK not set — skipping (no-op)."
+            exit 0
+          fi
+          curl -fsSL -X POST "$HOOK" >/dev/null && echo "Render deploy triggered."

--- a/packages/landing/README.md
+++ b/packages/landing/README.md
@@ -4,18 +4,22 @@ Static marketing site served at **https://www.seasonsprint.com** (apex
 `seasonsprint.com` redirects here). The app lives separately at
 **https://app.seasonsprint.com**.
 
-No build step — plain HTML/CSS in this folder.
+Plain HTML/CSS/JS. The only build step bakes `releases.json` for the downloads
+page (see below); everything else is static.
 
 ## Local preview
 
 ```bash
 pnpm -F landing dev      # serves this folder on http://localhost:3000
+pnpm -F landing build    # regenerate releases.json from the latest GitHub release
 ```
 
 ## Files
 
 - `index.html` — the landing page
 - `downloads.html` + `downloads.js` — the downloads page (`/downloads`)
+- `generate-releases.mjs` — build-time script that bakes `releases.json`
+- `releases.json` — snapshot of the latest release (regenerated on every deploy)
 - `styles.css` — THE FINALS-inspired theme (mirrors `packages/web`)
 - `assets/logo.svg` — brand logo (copied from `packages/web/public/logo.svg`)
 - `favicon.ico`
@@ -25,14 +29,27 @@ the Android/Windows platform tiles point at `/downloads`.
 
 ### Downloads page
 
-`/downloads` fetches the **latest** GitHub release at runtime from
-`https://api.github.com/repos/lcflight/season-sprint/releases/latest` (public,
-CORS-enabled, 60 req/hr per IP) and renders one download card per platform from
-whatever assets are attached. Assets are classified by extension/name, not
-hardcoded URLs — `.apk` → Android, `.exe`/`.msi`/`.zip` → Windows — so the page
-keeps up with releases automatically even when asset filenames drift. iOS is
-shown as "coming soon", and any fetch failure falls back to a GitHub Releases
-link.
+`/downloads` renders one download card per platform. Assets are classified by
+extension/name, not hardcoded URLs — `.apk` → Android, `.exe`/`.msi`/`.zip` →
+Windows — so the page keeps up with releases even when asset filenames drift.
+iOS is shown as "coming soon".
+
+**Data source (fast path):** at deploy time `generate-releases.mjs` fetches the
+latest release **once** and bakes a trimmed `releases.json` into this folder.
+The page reads it **same-origin**, so cards render instantly with no
+per-visitor GitHub API call and no rate limit.
+
+**Fallbacks:** if `releases.json` is missing, `downloads.js` falls back to the
+live GitHub API (`.../releases/latest`); if that also fails it shows a GitHub
+Releases link (and there is a `<noscript>` link too). So the page works whether
+or not the build step ran.
+
+**Staying current:** a new release fires
+`.github/workflows/refresh-landing.yml`, which POSTs Render's deploy hook to
+rebuild the static site and re-bake `releases.json`. Set this up by creating a
+Deploy Hook on the landing static site (Render → Settings → Deploy Hook) and
+adding its URL as the repo secret `RENDER_LANDING_DEPLOY_HOOK`. Without the
+secret the workflow is a no-op and the page still refreshes on the next deploy.
 
 > Clean URL note: links use `/downloads` (no `.html`). Render static sites and
 > the `serve` dev command both resolve this to `downloads.html` automatically.
@@ -69,7 +86,8 @@ from the `app.` subdomain does not break API calls.
 New **Static Site** in Render, pointed at this repo:
 
 - **Root Directory:** `packages/landing`
-- **Build Command:** *(leave blank)* — or `pnpm -F landing build` (no-op)
+- **Build Command:** `pnpm -F landing build` — bakes `releases.json` from the
+  latest GitHub release so the downloads page loads instantly.
 - **Publish Directory:** `.`
 - **Custom Domains:** add `seasonsprint.com` **and** `www.seasonsprint.com`.
 

--- a/packages/landing/downloads.js
+++ b/packages/landing/downloads.js
@@ -1,17 +1,23 @@
-/* Downloads page — pulls the latest GitHub release and renders a card per
- * platform from whatever assets are attached. No build step, no API key:
- * the GitHub REST API for the latest release is public and CORS-enabled
- * (rate-limited to 60 req/hr per IP, which is plenty for a static page).
+/* Downloads page.
+ *
+ * Primary source is /releases.json — a trimmed snapshot of the latest GitHub
+ * release baked at deploy time (see generate-releases.mjs). Reading it
+ * same-origin means the cards render instantly, with no per-visitor GitHub API
+ * call and no rate limit.
+ *
+ * If the snapshot is missing (e.g. the build step didn't run, or local preview
+ * without a build), we fall back to the live GitHub API so the page still works
+ * everywhere.
  *
  * Asset names drift between releases (e.g. season-sprint-android.apk vs
- * season-sprint-android-debug.apk), so we classify by extension/name rather
- * than hardcoding URLs. New asset types fall back to a generic "Other" card,
- * so nothing a release publishes ever goes missing here.
+ * season-sprint-android-debug.apk), so assets are classified by extension/name
+ * rather than hardcoded URLs.
  */
 (function () {
   "use strict";
 
   var REPO = "lcflight/season-sprint";
+  var SNAPSHOT = "/releases.json";
   var API = "https://api.github.com/repos/" + REPO + "/releases/latest";
   var RELEASES_URL = "https://github.com/" + REPO + "/releases";
 
@@ -45,6 +51,23 @@
       },
     },
   ];
+
+  // Normalise both the baked snapshot shape (tag/download_url) and the live
+  // GitHub API shape (tag_name/browser_download_url) into one structure.
+  function normalize(raw) {
+    if (!raw) return null;
+    return {
+      tag: raw.tag || raw.tag_name || raw.name || "",
+      published_at: raw.published_at || "",
+      assets: (raw.assets || []).map(function (a) {
+        return {
+          name: a.name,
+          size: a.size,
+          url: a.download_url || a.browser_download_url,
+        };
+      }),
+    };
+  }
 
   function classify(assetName) {
     for (var i = 0; i < PLATFORMS.length; i++) {
@@ -118,7 +141,7 @@
 
     var actions = el("div", "dl-actions");
     var dl = el("a", "button button-primary", "Download");
-    dl.href = asset.browser_download_url;
+    dl.href = asset.url;
     dl.setAttribute("download", "");
     dl.rel = "noopener";
     dl.setAttribute(
@@ -153,11 +176,12 @@
 
   function render(release) {
     var assets = (release && release.assets) || [];
-    var tag = release && (release.tag_name || release.name);
+    var tag = release && release.tag;
 
     // Bucket assets by platform, then pick the best-ranked asset per platform.
     var buckets = {};
     assets.forEach(function (a) {
+      if (!a.url) return;
       var p = classify(a.name);
       if (!p) return;
       (buckets[p.key] = buckets[p.key] || []).push(a);
@@ -181,7 +205,6 @@
     elList.appendChild(renderSoon());
 
     if (!rendered) {
-      // No recognised desktop/mobile assets in this release.
       renderFallback(
         "This release has no desktop or mobile installers yet. Check GitHub for all assets."
       );
@@ -192,19 +215,28 @@
       var parts = [];
       if (tag) parts.push("Latest release " + tag);
       if (when) parts.push("published " + when);
-      elMeta.textContent = parts.length
-        ? parts.join(" · ")
-        : "Latest release";
+      elMeta.textContent = parts.length ? parts.join(" · ") : "Latest release";
     }
   }
 
+  function fetchJson(url, opts) {
+    return fetch(url, opts).then(function (res) {
+      if (!res.ok) throw new Error(url + " -> " + res.status);
+      return res.json();
+    });
+  }
+
   function load() {
-    fetch(API, { headers: { Accept: "application/vnd.github+json" } })
-      .then(function (res) {
-        if (!res.ok) throw new Error("GitHub API " + res.status);
-        return res.json();
+    // Same-origin baked snapshot first (instant), then live API, then fallback.
+    fetchJson(SNAPSHOT, { cache: "no-cache" })
+      .catch(function () {
+        return fetchJson(API, {
+          headers: { Accept: "application/vnd.github+json" },
+        });
       })
-      .then(render)
+      .then(function (raw) {
+        render(normalize(raw));
+      })
       .catch(function () {
         if (elMeta) {
           elMeta.textContent =

--- a/packages/landing/generate-releases.mjs
+++ b/packages/landing/generate-releases.mjs
@@ -1,0 +1,58 @@
+/* Build-time generator for releases.json.
+ *
+ * Run during the Render static-site build (`pnpm -F landing build`). It fetches
+ * the latest GitHub release once, at deploy time, and bakes a trimmed snapshot
+ * into releases.json so the downloads page can read it same-origin — instant,
+ * no per-visitor GitHub API call, no rate limit.
+ *
+ * Freshness: a new release triggers a Render redeploy via a deploy hook (see
+ * .github/workflows/refresh-landing.yml), which re-runs this script.
+ *
+ * This never fails the build: if GitHub is unreachable it leaves any existing
+ * releases.json in place and exits 0. The page also falls back to the live
+ * GitHub API at runtime if releases.json is missing or stale.
+ */
+import { writeFile } from "node:fs/promises";
+
+const REPO = "lcflight/season-sprint";
+const API = `https://api.github.com/repos/${REPO}/releases/latest`;
+const OUT = new URL("./releases.json", import.meta.url);
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  "User-Agent": "season-sprint-landing-build",
+};
+// GitHub raises the rate limit a lot when a token is present (Render exposes
+// none by default, but honour one if provided).
+if (process.env.GITHUB_TOKEN) {
+  headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+}
+
+try {
+  const res = await fetch(API, { headers });
+  if (!res.ok) {
+    console.warn(`[releases] GitHub API ${res.status}; keeping existing releases.json`);
+    process.exit(0);
+  }
+  const r = await res.json();
+  const snapshot = {
+    tag: r.tag_name,
+    name: r.name,
+    published_at: r.published_at,
+    html_url: r.html_url,
+    assets: (r.assets || []).map((a) => ({
+      name: a.name,
+      size: a.size,
+      download_url: a.browser_download_url,
+      content_type: a.content_type,
+    })),
+    generated_at: new Date().toISOString(),
+  };
+  await writeFile(OUT, JSON.stringify(snapshot, null, 2) + "\n");
+  console.log(
+    `[releases] wrote releases.json — ${snapshot.tag}, ${snapshot.assets.length} asset(s)`
+  );
+} catch (err) {
+  console.warn(`[releases] generation failed (${err.message}); keeping existing releases.json`);
+  process.exit(0);
+}

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Marketing landing page for Season Sprint (www.seasonsprint.com)",
   "scripts": {
-    "build": "echo \"static site — nothing to build\"",
+    "build": "node generate-releases.mjs",
     "dev": "npx -y serve ."
   }
 }

--- a/packages/landing/releases.json
+++ b/packages/landing/releases.json
@@ -1,0 +1,27 @@
+{
+  "tag": "v0.1.9",
+  "name": "v0.1.9",
+  "published_at": "2026-06-16T22:35:58Z",
+  "html_url": "https://github.com/lcflight/season-sprint/releases/tag/v0.1.9",
+  "assets": [
+    {
+      "name": "season-sprint-android-debug.apk",
+      "size": 22600357,
+      "download_url": "https://github.com/lcflight/season-sprint/releases/download/v0.1.9/season-sprint-android-debug.apk",
+      "content_type": "application/vnd.android.package-archive"
+    },
+    {
+      "name": "SeasonSprintSetup.exe",
+      "size": 2144167,
+      "download_url": "https://github.com/lcflight/season-sprint/releases/download/v0.1.9/SeasonSprintSetup.exe",
+      "content_type": "application/x-msdos-program"
+    },
+    {
+      "name": "SeasonSprintSetup.zip",
+      "size": 1581588,
+      "download_url": "https://github.com/lcflight/season-sprint/releases/download/v0.1.9/SeasonSprintSetup.zip",
+      "content_type": "application/zip"
+    }
+  ],
+  "generated_at": "2026-06-17T02:23:43.498Z"
+}


### PR DESCRIPTION
## What

Makes the downloads page load **instantly**. Previously `/downloads` waited on a live `api.github.com` request before it could draw anything — that's the lag. This bakes the release data at deploy time so the page reads it same-origin.

Follow-up to #91 (which shipped the runtime-API version).

## How

- **`generate-releases.mjs`** — fetches the latest release **once** at build time and writes a trimmed `releases.json` into the landing folder. Wired as the `build` script, so Render runs it via `pnpm -F landing build`. Never fails the build (keeps the existing snapshot if GitHub is unreachable).
- **`downloads.js`** — now reads `/releases.json` same-origin (instant, no rate limit), falling back to the live GitHub API, then to a GitHub link. Asset classification (`.apk`→Android, `.exe`/`.msi`/`.zip`→Windows) is unchanged, so it still tracks filename drift.
- **`refresh-landing.yml`** — on release events, POSTs Render's deploy hook to rebuild + re-bake `releases.json`. No-op until the `RENDER_LANDING_DEPLOY_HOOK` secret is set.
- Commits a **seed `releases.json`** (v0.1.9) so the page works before the first build.

## Setup needed (one time)

1. Set the landing static site's **Build Command** to `pnpm -F landing build`.
2. Create a **Deploy Hook** on that site (Render → Settings) and add its URL as the repo secret **`RENDER_LANDING_DEPLOY_HOOK`**.

Both are optional for correctness — without them the page still works (live-API fallback) and refreshes on the next deploy — but they're what make it instant *and* auto-fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
