### PR TITLE
build(win): rename Windows artifact to SeasonSprintTracker

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -2,7 +2,7 @@ name: Build Windows installer
 
 # Builds the Inno Setup .exe whenever files under packages/local-win/ change,
 # on manual dispatch, or on a v* tag push. Every run uploads
-# SeasonSprintSetup.exe as a workflow artifact; tag pushes additionally
+# SeasonSprintTracker.exe as a workflow artifact; tag pushes additionally
 # publish a GitHub Release with the installer attached.
 
 on:
@@ -45,15 +45,15 @@ jobs:
         shell: pwsh
         working-directory: packages/local-win/dist
         run: |
-          Compress-Archive -Path SeasonSprintSetup.exe -DestinationPath SeasonSprintSetup.zip -CompressionLevel Optimal -Force
+          Compress-Archive -Path SeasonSprintTracker.exe -DestinationPath SeasonSprintTracker.zip -CompressionLevel Optimal -Force
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: SeasonSprintSetup
+          name: SeasonSprintTracker
           path: |
-            packages/local-win/dist/SeasonSprintSetup.exe
-            packages/local-win/dist/SeasonSprintSetup.zip
+            packages/local-win/dist/SeasonSprintTracker.exe
+            packages/local-win/dist/SeasonSprintTracker.zip
           if-no-files-found: error
 
       - name: Publish GitHub Release (on v* tag only)
@@ -61,7 +61,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            packages/local-win/dist/SeasonSprintSetup.exe
-            packages/local-win/dist/SeasonSprintSetup.zip
+            packages/local-win/dist/SeasonSprintTracker.exe
+            packages/local-win/dist/SeasonSprintTracker.zip
           draft: false
           generate_release_notes: true

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -1,6 +1,6 @@
 ; Inno Setup script for Season Sprint Tracker (Windows).
 ;
-; Produces a single SeasonSprintSetup.exe that installs per-user (no UAC),
+; Produces a single SeasonSprintTracker.exe that installs per-user (no UAC),
 ; copies the Python sources + a Steam-launch wrapper into
 ; %LOCALAPPDATA%\Programs\SeasonSprint\, and collects all first-run config
 ; inside the wizard itself (no separate cmd window):
@@ -24,7 +24,7 @@
 ; Build (on Windows with Inno Setup 6 installed):
 ;   "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer.iss
 ;
-; Output: dist\SeasonSprintSetup.exe (relative to this file).
+; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
 #define AppVersion    "0.1.9"
@@ -50,7 +50,7 @@ DisableProgramGroupPage=yes
 DisableDirPage=yes
 
 OutputDir=..\dist
-OutputBaseFilename=SeasonSprintSetup
+OutputBaseFilename=SeasonSprintTracker
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern


### PR DESCRIPTION
## What

Renames the published Windows release artifacts:

- `SeasonSprintSetup.exe` → **`SeasonSprintTracker.exe`**
- `SeasonSprintSetup.zip` → **`SeasonSprintTracker.zip`**

## How

- `installer.iss`: `OutputBaseFilename` → `SeasonSprintTracker` (+ comment updates).
- `build-windows-installer.yml`: the zip step, upload-artifact name/paths, and release `files` all use the new name.

## Notes

- **Android** needs no change — the CI workflow already publishes the clean `season-sprint-android.apk`; the `-debug` name on v0.1.9 was from an older manual build that predates that workflow, so the next release is already clean.
- The downloads page classifies assets by extension (`.exe`/`.zip` → Windows), so it picks up the new filename automatically with no landing-page changes.
- `packages/landing/releases.json` still references the old names because it's the baked snapshot of the *existing* v0.1.9 assets; it refreshes on the next release + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
