### PR TITLE
release: bump installer AppVersion to 0.1.10

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.9"
+#define AppVersion    "0.1.10"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 


### PR DESCRIPTION
Bumps the Inno Setup AppVersion to 0.1.10 ahead of cutting the v0.1.10 tag.

This is the first release with:
- Windows artifact renamed to **SeasonSprintTracker.{exe,zip}** (#93)
- clean Android APK name **season-sprint-android.apk** (already in CI)

After merge, pushing the `v0.1.10` tag triggers the build workflows to create the release with the new-named artifacts, which fires the Render deploy hook to refresh the downloads page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)