### PR TITLE
feat(landing): marketing site, downloads page & one-line Linux install

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,44 @@
+name: Build Linux tarball
+
+# Packages the Linux desktop tracker (source + installer script) into
+# season-sprint-linux.tar.gz whenever files under packages/local/ change, on
+# manual dispatch, or on a v* tag push. Every run uploads the tarball as a
+# workflow artifact; tag pushes additionally publish a GitHub Release with the
+# tarball attached, which is what install.sh and the downloads page fetch.
+
+on:
+  push:
+    paths:
+      - "packages/local/**"
+      - ".github/workflows/build-linux.yml"
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write  # needed to create GitHub Releases on tag push
+
+jobs:
+  build-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build tarball
+        working-directory: packages/local
+        run: bash package-linux.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: season-sprint-linux
+          path: packages/local/dist/season-sprint-linux.tar.gz
+          if-no-files-found: error
+
+      - name: Publish GitHub Release (on v* tag only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: packages/local/dist/season-sprint-linux.tar.gz
+          draft: false
+          generate_release_notes: true

--- a/packages/landing/README.md
+++ b/packages/landing/README.md
@@ -14,13 +14,38 @@ pnpm -F landing dev      # serves this folder on http://localhost:3000
 
 ## Files
 
-- `index.html` — the page
+- `index.html` — the landing page
+- `downloads.html` + `downloads.js` — the downloads page (`/downloads`)
 - `styles.css` — THE FINALS-inspired theme (mirrors `packages/web`)
 - `assets/logo.svg` — brand logo (copied from `packages/web/public/logo.svg`)
 - `favicon.ico`
 
-All CTAs point at `https://app.seasonsprint.com`; download links point at the
-GitHub releases page.
+All app CTAs point at `https://app.seasonsprint.com`. The "Get the apps" CTA and
+the Android/Windows platform tiles point at `/downloads`.
+
+### Downloads page
+
+`/downloads` fetches the **latest** GitHub release at runtime from
+`https://api.github.com/repos/lcflight/season-sprint/releases/latest` (public,
+CORS-enabled, 60 req/hr per IP) and renders one download card per platform from
+whatever assets are attached. Assets are classified by extension/name, not
+hardcoded URLs — `.apk` → Android, `.exe`/`.msi`/`.zip` → Windows,
+`.tar.gz`/`.AppImage` → Linux — so the page keeps up with releases
+automatically even when asset filenames drift. The Linux card also shows a
+copyable `curl … | bash` one-liner that runs `install.sh`. iOS is shown as
+"coming soon", and any fetch failure falls back to a GitHub Releases link.
+
+> Clean URL note: links use `/downloads` (no `.html`). Render static sites and
+> the `serve` dev command both resolve this to `downloads.html` automatically.
+
+### Linux installer (`install.sh`)
+
+Served from this folder at `/install.sh`. The one-liner
+`curl -fsSL https://www.seasonsprint.com/install.sh | bash` downloads the latest
+`season-sprint-linux.tar.gz` release asset (built by `.github/workflows/build-linux.yml`
+from `packages/local/`), extracts it, and hands off to the bundled
+`season-tracker.sh`, which installs deps + EasyOCR, compiles the tracker, and
+configures the Steam launch option.
 
 ---
 

--- a/packages/landing/downloads.html
+++ b/packages/landing/downloads.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Download Season Sprint — desktop & mobile apps</title>
+    <meta
+      name="description"
+      content="Download the latest Season Sprint apps for Windows, Linux, and Android. Always up to date with the newest release."
+    />
+    <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+
+    <!-- Open Graph / social -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Download Season Sprint" />
+    <meta
+      property="og:description"
+      content="Grab the latest Windows, Linux, and Android builds of Season Sprint."
+    />
+    <meta property="og:url" content="https://www.seasonsprint.com/downloads" />
+    <meta property="og:image" content="/assets/logo.svg" />
+
+    <link rel="preconnect" href="https://api.github.com" />
+    <link rel="preconnect" href="https://github.com" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <a class="brand" href="/" aria-label="Season Sprint home">
+        <img class="brand-mark" src="/assets/logo.svg" alt="" width="40" height="40" />
+        <span class="brand-name">Season&nbsp;Sprint</span>
+      </a>
+      <nav class="nav" aria-label="Primary">
+        <a href="/#features">Features</a>
+        <a href="/#platforms">Platforms</a>
+        <a href="/downloads" aria-current="page">Downloads</a>
+        <a class="button button-primary" href="https://app.seasonsprint.com">Open the app</a>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="section downloads-head">
+        <p class="eyebrow">Downloads</p>
+        <h1>Get Season Sprint</h1>
+        <p class="lede downloads-lede">
+          Install the companion apps to track your World Tour climb on your own
+          devices. The web app needs no install — just
+          <a href="https://app.seasonsprint.com">open it</a>.
+        </p>
+        <p class="downloads-release" id="release-meta" aria-live="polite">
+          Loading the latest release…
+        </p>
+      </section>
+
+      <section class="section downloads-section">
+        <div class="downloads" id="downloads">
+          <!-- Cards injected by downloads.js; fallback below shows if JS/fetch fails -->
+          <noscript>
+            <div class="download-card">
+              <div class="dl-body">
+                <h2 class="dl-name">Downloads</h2>
+                <p class="dl-desc">
+                  Enable JavaScript, or grab the latest builds straight from
+                  GitHub.
+                </p>
+              </div>
+              <a
+                class="button button-primary"
+                href="https://github.com/lcflight/season-sprint/releases/latest"
+                >View releases on GitHub</a
+              >
+            </div>
+          </noscript>
+        </div>
+
+        <p class="downloads-foot">
+          All builds are published on
+          <a href="https://github.com/lcflight/season-sprint/releases"
+            >GitHub Releases</a
+          >. Windows installers are unsigned — Windows SmartScreen may warn on
+          first launch. Android requires allowing installs from your browser.
+        </p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="footer-inner">
+        <a class="brand brand-sm" href="/" aria-label="Season Sprint home">
+          <img src="/assets/logo.svg" alt="" width="28" height="28" />
+          <span>Season Sprint</span>
+        </a>
+        <nav class="footer-nav" aria-label="Footer">
+          <a href="https://app.seasonsprint.com">Open the app</a>
+          <a href="https://github.com/lcflight/season-sprint">GitHub</a>
+        </nav>
+      </div>
+      <p class="footer-note">Created by Luke Arthur (Aireal) · © 2025</p>
+      <p class="footer-disclaimer">
+        Season Sprint is an unofficial fan-made tool and is not affiliated with,
+        endorsed by, or sponsored by Embark Studios. THE FINALS is a trademark of
+        Embark Studios AB.
+      </p>
+    </footer>
+
+    <script src="/downloads.js" defer></script>
+  </body>
+</html>

--- a/packages/landing/downloads.js
+++ b/packages/landing/downloads.js
@@ -1,0 +1,269 @@
+/* Downloads page — pulls the latest GitHub release and renders a card per
+ * platform from whatever assets are attached. No build step, no API key:
+ * the GitHub REST API for the latest release is public and CORS-enabled
+ * (rate-limited to 60 req/hr per IP, which is plenty for a static page).
+ *
+ * Asset names drift between releases (e.g. season-sprint-android.apk vs
+ * season-sprint-android-debug.apk), so we classify by extension/name rather
+ * than hardcoding URLs. New asset types fall back to a generic "Other" card,
+ * so nothing a release publishes ever goes missing here.
+ */
+(function () {
+  "use strict";
+
+  var REPO = "lcflight/season-sprint";
+  var API = "https://api.github.com/repos/" + REPO + "/releases/latest";
+  var RELEASES_URL = "https://github.com/" + REPO + "/releases";
+
+  var elList = document.getElementById("downloads");
+  var elMeta = document.getElementById("release-meta");
+
+  // Platform definitions, in display order. `match` decides which assets land
+  // on this card; the first definition that matches wins.
+  var PLATFORMS = [
+    {
+      key: "windows",
+      name: "Windows",
+      desc: "Desktop tracker with auto-capture — reads your points off-screen while you play.",
+      match: function (n) {
+        return /\.exe$/i.test(n) || /\.msi$/i.test(n) || /\.zip$/i.test(n);
+      },
+      // Prefer the installer over the zip when both exist.
+      rank: function (n) {
+        return /\.exe$/i.test(n) ? 0 : /\.msi$/i.test(n) ? 1 : 2;
+      },
+    },
+    {
+      key: "linux",
+      name: "Linux",
+      desc: "Desktop tracker with auto-capture (X11). One command installs deps, builds it, and wires it into Steam.",
+      // The easy path is the hosted installer; the tarball is the manual fallback.
+      install: "curl -fsSL https://www.seasonsprint.com/install.sh | bash",
+      match: function (n) {
+        return /\.tar\.gz$/i.test(n) || /\.AppImage$/i.test(n);
+      },
+      // Prefer an AppImage (no build step) over the source tarball when both exist.
+      rank: function (n) {
+        return /\.AppImage$/i.test(n) ? 0 : 1;
+      },
+    },
+    {
+      key: "android",
+      name: "Android",
+      desc: "Install the APK to log and sync your runs from your phone.",
+      match: function (n) {
+        return /\.apk$/i.test(n);
+      },
+      rank: function () {
+        return 0;
+      },
+    },
+  ];
+
+  function classify(assetName) {
+    for (var i = 0; i < PLATFORMS.length; i++) {
+      if (PLATFORMS[i].match(assetName)) return PLATFORMS[i];
+    }
+    return null;
+  }
+
+  function fmtSize(bytes) {
+    if (!bytes && bytes !== 0) return "";
+    var mb = bytes / (1024 * 1024);
+    if (mb >= 1) return mb.toFixed(1) + " MB";
+    var kb = bytes / 1024;
+    return Math.max(1, Math.round(kb)) + " KB";
+  }
+
+  function fmtDate(iso) {
+    if (!iso) return "";
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function renderFallback(message) {
+    elList.innerHTML = "";
+    var card = el("div", "download-card");
+    var body = el("div", "dl-body");
+    body.appendChild(el("h2", "dl-name", "Get the latest build"));
+    body.appendChild(
+      el(
+        "p",
+        "dl-desc",
+        message ||
+          "We couldn't load releases right now. Grab the latest build straight from GitHub."
+      )
+    );
+    card.appendChild(body);
+    var link = el("a", "button button-primary", "View releases on GitHub");
+    link.href = RELEASES_URL + "/latest";
+    link.rel = "noopener";
+    card.appendChild(link);
+    elList.appendChild(card);
+  }
+
+  function renderCard(platform, asset, tag) {
+    var card = el("div", "download-card");
+
+    var body = el("div", "dl-body");
+    body.appendChild(el("h2", "dl-name", platform.name));
+    body.appendChild(el("p", "dl-desc", platform.desc));
+
+    var meta = el("p", "dl-meta");
+    var bits = [];
+    if (tag) bits.push(tag);
+    if (asset.size) bits.push(fmtSize(asset.size));
+    meta.textContent = bits.join(" · ");
+    if (bits.length) body.appendChild(meta);
+
+    // Some platforms (Linux) install via a one-liner; show it as a copyable
+    // command above the raw asset download.
+    if (platform.install) {
+      var install = el("div", "dl-install");
+      var code = el("code", "dl-install-cmd", platform.install);
+      install.appendChild(code);
+      var copy = el("button", "dl-copy", "Copy");
+      copy.type = "button";
+      copy.setAttribute("aria-label", "Copy install command");
+      copy.addEventListener("click", function () {
+        var done = function () {
+          copy.textContent = "Copied";
+          copy.classList.add("is-copied");
+          setTimeout(function () {
+            copy.textContent = "Copy";
+            copy.classList.remove("is-copied");
+          }, 1500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(platform.install).then(done, function () {});
+        } else {
+          var r = document.createRange();
+          r.selectNode(code);
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(r);
+          try {
+            document.execCommand("copy");
+            done();
+          } catch (e) {}
+          sel.removeAllRanges();
+        }
+      });
+      install.appendChild(copy);
+      body.appendChild(install);
+    }
+
+    card.appendChild(body);
+
+    var actions = el("div", "dl-actions");
+    var dl = el("a", "button button-primary", "Download");
+    dl.href = asset.browser_download_url;
+    dl.setAttribute("download", "");
+    dl.rel = "noopener";
+    dl.setAttribute(
+      "aria-label",
+      "Download " + platform.name + " — " + asset.name
+    );
+    actions.appendChild(dl);
+
+    var fileName = el("span", "dl-filename", asset.name);
+    actions.appendChild(fileName);
+
+    card.appendChild(actions);
+    return card;
+  }
+
+  function renderSoon() {
+    var card = el("div", "download-card download-card-soon");
+    var body = el("div", "dl-body");
+    body.appendChild(el("h2", "dl-name", "iOS"));
+    body.appendChild(
+      el(
+        "p",
+        "dl-desc",
+        "An iOS build is in the works. For now, use the web app on your iPhone."
+      )
+    );
+    card.appendChild(body);
+    var note = el("span", "dl-soon-note", "Coming soon");
+    card.appendChild(note);
+    return card;
+  }
+
+  function render(release) {
+    var assets = (release && release.assets) || [];
+    var tag = release && (release.tag_name || release.name);
+
+    // Bucket assets by platform, then pick the best-ranked asset per platform.
+    var buckets = {};
+    assets.forEach(function (a) {
+      var p = classify(a.name);
+      if (!p) return;
+      (buckets[p.key] = buckets[p.key] || []).push(a);
+    });
+
+    elList.innerHTML = "";
+    var rendered = 0;
+
+    PLATFORMS.forEach(function (p) {
+      var list = buckets[p.key];
+      if (!list || !list.length) return;
+      list.sort(function (a, b) {
+        return p.rank(a.name) - p.rank(b.name);
+      });
+      elList.appendChild(renderCard(p, list[0], tag));
+      rendered++;
+    });
+
+    // Always show iOS as coming-soon so the platform story stays consistent
+    // with the landing page.
+    elList.appendChild(renderSoon());
+
+    if (!rendered) {
+      // No recognised desktop/mobile assets in this release.
+      renderFallback(
+        "This release has no desktop or mobile installers yet. Check GitHub for all assets."
+      );
+    }
+
+    if (elMeta) {
+      var when = fmtDate(release && release.published_at);
+      var parts = [];
+      if (tag) parts.push("Latest release " + tag);
+      if (when) parts.push("published " + when);
+      elMeta.textContent = parts.length
+        ? parts.join(" · ")
+        : "Latest release";
+    }
+  }
+
+  function load() {
+    fetch(API, { headers: { Accept: "application/vnd.github+json" } })
+      .then(function (res) {
+        if (!res.ok) throw new Error("GitHub API " + res.status);
+        return res.json();
+      })
+      .then(render)
+      .catch(function () {
+        if (elMeta) {
+          elMeta.textContent =
+            "Couldn't reach GitHub — open the releases page directly.";
+        }
+        renderFallback();
+      });
+  }
+
+  load();
+})();

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -162,10 +162,10 @@
             <span class="platform-name">Web app</span>
             <span class="platform-note">app.seasonsprint.com</span>
           </a>
-          <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
+          <div class="platform platform-soon" aria-disabled="true">
             <span class="platform-name">iOS</span>
-            <span class="platform-note">Latest build</span>
-          </a>
+            <span class="platform-note">Coming soon</span>
+          </div>
           <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
             <span class="platform-name">Android</span>
             <span class="platform-note">APK download</span>

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -35,6 +35,7 @@
       <nav class="nav" aria-label="Primary">
         <a href="#features">Features</a>
         <a href="#platforms">Platforms</a>
+        <a href="/downloads">Downloads</a>
         <a class="button button-primary" href="https://app.seasonsprint.com">Open the app</a>
       </nav>
     </header>
@@ -53,10 +54,7 @@
             <a class="button button-primary button-lg" href="https://app.seasonsprint.com">
               Open the web app
             </a>
-            <a
-              class="button button-ghost button-lg"
-              href="https://github.com/lcflight/season-sprint/releases"
-            >
+            <a class="button button-ghost button-lg" href="/downloads">
               Get the desktop &amp; mobile apps
             </a>
           </div>
@@ -166,13 +164,17 @@
             <span class="platform-name">iOS</span>
             <span class="platform-note">Coming soon</span>
           </div>
-          <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
+          <a class="platform" href="/downloads">
             <span class="platform-name">Android</span>
             <span class="platform-note">APK download</span>
           </a>
-          <a class="platform" href="https://github.com/lcflight/season-sprint/releases">
+          <a class="platform" href="/downloads">
             <span class="platform-name">Windows</span>
             <span class="platform-note">Auto-capture tracker</span>
+          </a>
+          <a class="platform" href="/downloads">
+            <span class="platform-name">Linux</span>
+            <span class="platform-note">One-line install</span>
           </a>
         </div>
       </section>

--- a/packages/landing/install.sh
+++ b/packages/landing/install.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Season Sprint — Linux installer bootstrap.
+#
+#   curl -fsSL https://www.seasonsprint.com/install.sh | bash
+#
+# Downloads the latest release tarball, extracts it to a stable location, and
+# hands off to season-tracker.sh, which installs system deps + EasyOCR, builds
+# the tracker, and walks you through configuration.
+#
+# Env overrides:
+#   SEASON_SPRINT_DIR     install location (default: ~/.local/share/season-sprint)
+#   SEASON_SPRINT_VERSION release tag to fetch (default: latest)
+
+set -euo pipefail
+
+REPO="lcflight/season-sprint"
+ASSET="season-sprint-linux.tar.gz"
+INSTALL_DIR="${SEASON_SPRINT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/season-sprint}"
+VERSION="${SEASON_SPRINT_VERSION:-latest}"
+
+if [[ "$VERSION" == "latest" ]]; then
+  URL="https://github.com/$REPO/releases/latest/download/$ASSET"
+else
+  URL="https://github.com/$REPO/releases/download/$VERSION/$ASSET"
+fi
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# X11 SHM screen capture — there is no native Wayland/macOS/Windows build here.
+[[ "$(uname -s)" == "Linux" ]] || die "the desktop tracker is Linux-only (uname=$(uname -s))."
+
+command -v curl >/dev/null 2>&1 || die "curl is required but not found."
+command -v tar  >/dev/null 2>&1 || die "tar is required but not found."
+
+echo "Season Sprint — Linux installer"
+echo "  source : $URL"
+echo "  install: $INSTALL_DIR"
+echo
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Downloading $ASSET ..."
+curl -fSL --proto '=https' --tlsv1.2 -o "$tmp/$ASSET" "$URL" \
+  || die "download failed. Check your connection or grab the tarball from https://github.com/$REPO/releases"
+
+echo "Extracting to $INSTALL_DIR ..."
+mkdir -p "$INSTALL_DIR"
+# Tarball has a top-level season-sprint/ dir; strip it so files land directly.
+tar -xzf "$tmp/$ASSET" -C "$INSTALL_DIR" --strip-components=1
+
+LAUNCHER="$INSTALL_DIR/season-tracker.sh"
+[[ -f "$LAUNCHER" ]] || die "season-tracker.sh missing from the release tarball."
+chmod +x "$LAUNCHER"
+
+echo
+echo "Starting setup ..."
+echo
+
+# Hand off to the interactive installer. It needs a real TTY for its prompts,
+# which the `curl | bash` pipe doesn't provide — reconnect stdin to the
+# terminal when one is available.
+if [[ -t 1 && -r /dev/tty ]]; then
+  exec "$LAUNCHER" < /dev/tty
+else
+  exec "$LAUNCHER"
+fi

--- a/packages/landing/styles.css
+++ b/packages/landing/styles.css
@@ -370,6 +370,147 @@ h3 {
   color: var(--muted);
 }
 
+/* ── Downloads page ── */
+.downloads-head {
+  text-align: center;
+  padding-bottom: 8px;
+}
+.downloads-head h1 {
+  font-size: clamp(34px, 5vw, 56px);
+  margin-bottom: 16px;
+}
+.downloads-lede {
+  margin-left: auto;
+  margin-right: auto;
+}
+.downloads-lede a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.downloads-release {
+  color: var(--muted);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 4px 0 0;
+}
+.downloads-section {
+  padding-top: 24px;
+}
+.downloads {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.download-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: linear-gradient(180deg, var(--surface-2) 0%, var(--surface) 100%);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 26px 24px;
+}
+.dl-body {
+  flex: 1;
+}
+.dl-name {
+  font-size: 20px;
+  color: var(--primary);
+  margin-bottom: 10px;
+}
+.dl-desc {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+}
+.dl-meta {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.dl-install {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+.dl-install-cmd {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  color: var(--accent);
+}
+.dl-copy {
+  flex: none;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0 12px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.dl-copy:hover {
+  border-color: var(--ring);
+  color: var(--text-strong);
+}
+.dl-copy.is-copied {
+  color: var(--success);
+  border-color: var(--success);
+}
+.dl-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+.dl-actions .button {
+  align-self: stretch;
+}
+.dl-filename {
+  color: var(--muted);
+  font-size: 11px;
+  word-break: break-all;
+}
+.download-card-soon {
+  opacity: 0.6;
+  border-style: dashed;
+}
+.dl-soon-note {
+  align-self: flex-start;
+  color: var(--accent);
+  font-weight: 900;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.downloads-foot {
+  max-width: 70ch;
+  margin: 32px auto 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+.downloads-foot a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 /* ── Final CTA ── */
 .cta-band {
   text-align: center;
@@ -441,6 +582,9 @@ h3 {
   .platforms {
     grid-template-columns: repeat(2, 1fr);
   }
+  .downloads {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 560px) {
@@ -452,6 +596,9 @@ h3 {
   }
   .platforms {
     grid-template-columns: 1fr 1fr;
+  }
+  .downloads {
+    grid-template-columns: 1fr;
   }
   .section {
     padding: 48px 20px;

--- a/packages/landing/styles.css
+++ b/packages/landing/styles.css
@@ -346,6 +346,19 @@ h3 {
   box-shadow: 0 0 0 1px rgba(255, 212, 0, 0.1),
     0 12px 30px rgba(255, 212, 0, 0.15);
 }
+.platform-soon {
+  cursor: default;
+  opacity: 0.6;
+  border-style: dashed;
+}
+.platform-soon:hover {
+  transform: none;
+  border-color: var(--border);
+  box-shadow: none;
+}
+.platform-soon .platform-note {
+  color: var(--accent);
+}
 .platform-name {
   font-weight: 900;
   text-transform: uppercase;

--- a/packages/local/.env.example
+++ b/packages/local/.env.example
@@ -1,0 +1,12 @@
+# Season Sprint tracker config. Copy to .env, or just run ./season-tracker.sh
+# and it will prompt for these and write the file for you (chmod 600).
+
+# Your Season Sprint API URL (no trailing slash), e.g. https://your-worker.workers.dev
+SERVER_URL=
+
+# Your personal API key — generate one in the web app via "API Keys" in the header.
+AUTH_TOKEN=sk_replace_me
+
+# Monitor geometry the game runs on, as WxH+X+Y (e.g. 2560x1440+0+0).
+# ./season-tracker.sh auto-detects this from xrandr during setup.
+SHOT_GEOMETRY=

--- a/packages/local/package-linux.sh
+++ b/packages/local/package-linux.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# package-linux.sh — Build the Linux release tarball (season-sprint-linux.tar.gz).
+#
+# Ships SOURCE, not a precompiled binary: the tracker links native libs
+# (tesseract, leptonica, libcurl, X11) whose ABIs skew across distros/glibc,
+# so building on the user's machine via season-tracker.sh is more portable than
+# shipping one binary. season-tracker.sh installs the toolchain + deps for them.
+#
+# Usage:
+#   ./package-linux.sh            # -> dist/season-sprint-linux.tar.gz
+#   ./package-linux.sh OUTDIR     # write the tarball into OUTDIR instead
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${1:-$SCRIPT_DIR/dist}"
+STAGE_PARENT="$(mktemp -d)"
+STAGE="$STAGE_PARENT/season-sprint"
+TARBALL="$OUT_DIR/season-sprint-linux.tar.gz"
+
+# Files the tracker needs at runtime / build time on the user's machine.
+FILES=(
+  season-tracker.c
+  Makefile
+  ocr_preprocess.py
+  season-tracker.sh
+  .env.example
+)
+
+cleanup() { rm -rf "$STAGE_PARENT"; }
+trap cleanup EXIT
+
+mkdir -p "$STAGE" "$OUT_DIR"
+
+for f in "${FILES[@]}"; do
+  if [[ ! -e "$SCRIPT_DIR/$f" ]]; then
+    echo "ERROR: missing required file: $f" >&2
+    exit 1
+  fi
+  cp "$SCRIPT_DIR/$f" "$STAGE/$f"
+done
+
+chmod +x "$STAGE/season-tracker.sh"
+
+# Tar with a stable top-level dir so install.sh can --strip-components=1.
+tar -czf "$TARBALL" -C "$STAGE_PARENT" season-sprint
+
+echo "Built $TARBALL"
+ls -lh "$TARBALL" | awk '{print "  size: " $5}'


### PR DESCRIPTION
## Summary

Brings up the marketing landing page and downloads experience, and makes the **Linux** desktop tracker an easy download/install.

### Landing site & downloads (earlier commits on this branch)
- Marketing landing page for `www.seasonsprint.com`.
- Downloads page that pulls the latest GitHub release at runtime and renders a card per platform by classifying assets by extension.
- iOS shown as "coming soon" rather than a download link.

### One-line Linux install (this work)
- `packages/landing/install.sh` — `curl -fsSL https://www.seasonsprint.com/install.sh | bash` bootstrap that fetches the latest `season-sprint-linux.tar.gz`, extracts it to `~/.local/share/season-sprint`, and hands off to `season-tracker.sh` (reconnects `/dev/tty` so the interactive prompts work through the pipe).
- `packages/local/package-linux.sh` builds the source tarball; `.github/workflows/build-linux.yml` uploads it as an artifact and attaches it to `v*` releases.
- Downloads page gains a **Linux** card (matches `.tar.gz`/`.AppImage`) with a copyable curl one-liner, plus a Linux tile on the landing page.
- Added `packages/local/.env.example`; refreshed downloads/README copy.

Ships **source** (built on the user's machine via `season-tracker.sh`) rather than a prebuilt binary to avoid glibc/native-lib ABI skew across distros. The `.AppImage` matcher is already wired in, so a prebuilt binary can be added later with zero page changes.

## Test plan
- `package-linux.sh` builds a tarball with the correct top-level `season-sprint/` layout and runtime files. ✅
- `install.sh` and `package-linux.sh` pass `bash -n`; `downloads.js` passes `node -c`. ✅
- `packages/local/dist/` is gitignored. ✅
- After merge + a `v*` tag: confirm the release asset attaches and the downloads page renders the Linux card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)