### PR TITLE
chore(local): stop tracking tracker.log.ocr_err runtime log

### DIFF
--- a/packages/local/tracker.log.ocr_err
+++ b/packages/local/tracker.log.ocr_err
@@ -1,5 +1,0 @@
-ERROR: ld.so: object '$HOME/.steam/debian-installation/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.
-/home/linuxbrew/.linuxbrew/lib/python3.14/site-packages/torch/utils/data/dataloader.py:775: UserWarning: 'pin_memory' argument is set as true but no accelerator is found, then device pinned memory won't be used.
-  super().__init__(loader)
-/home/linuxbrew/.linuxbrew/lib/python3.14/site-packages/torch/utils/data/dataloader.py:775: UserWarning: 'pin_memory' argument is set as true but no accelerator is found, then device pinned memory won't be used.
-  super().__init__(loader)


### PR DESCRIPTION
`packages/local/tracker.log.ocr_err` is a runtime OCR error log. It's already
covered by `.gitignore` (line 32, alongside `tracker.log`), but it was
committed *before* that rule was added — and `.gitignore` doesn't untrack
already-tracked files, so git kept reporting it as modified on every checkout.

This `git rm --cached` untracks it (working copy is left in place), letting the
existing ignore rule finally take effect. It should never have been in the repo
and will never be "merged" as content — it's regenerated at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)