### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.10"
+#define AppVersion    "0.1.11"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 


### PR DESCRIPTION
Version bump for the **v0.1.11** release — the first to ship the Linux desktop
tracker.

Tagging `v0.1.11` after this merges triggers `build-linux.yml`, which packages
`season-sprint-linux.tar.gz` and attaches it to the release (alongside the
Windows installer and Android APK). `refresh-landing.yml` then re-bakes the
downloads page so the Linux card goes from coming-soon to the live `install.sh`
one-liner + tarball download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)