### PR TITLE
fix(web): stop signed-out app content flash before sign-in redirect

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -1,8 +1,33 @@
 <template>
   <HeaderBar />
-  <main class="container">
-    <!-- Mode toggle hidden for now — Ranked is disabled. -->
-    <!-- <ModeSwitcher /> -->
+  <!--
+    Gate the app body behind Clerk's auth state so signed-out visitors never
+    see app content flash before the sign-in redirect. While Clerk loads we
+    show a placeholder; once loaded we render content only when SignedIn, and
+    the SignedOut branch redirects to sign-in. In dev-auth mode (no Clerk
+    plugin) the gate is bypassed.
+  -->
+  <template v-if="clerkEnabled">
+    <ClerkLoading>
+      <div class="auth-loading" role="status" aria-live="polite">
+        <span class="auth-spinner" aria-hidden="true"></span>
+        <span class="auth-loading-sr">Loading…</span>
+      </div>
+    </ClerkLoading>
+    <ClerkLoaded>
+      <SignedIn>
+        <main class="container">
+          <!-- Mode toggle hidden for now — Ranked is disabled. -->
+          <!-- <ModeSwitcher /> -->
+          <router-view />
+        </main>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </ClerkLoaded>
+  </template>
+  <main v-else class="container">
     <router-view />
   </main>
   <footer class="site-footer" role="contentinfo">
@@ -14,16 +39,29 @@
 import HeaderBar from "./components/HeaderBar.vue";
 // ModeSwitcher hidden for now — Ranked is disabled.
 // import ModeSwitcher from "./components/ModeSwitcher.vue";
+import {
+  ClerkLoading,
+  ClerkLoaded,
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+} from "@clerk/vue";
 import { loadSeasonJson } from "@/utils/season";
+import { isClerkEnabled } from "@/services/clerk";
 
 export default {
   name: "App",
   components: {
     HeaderBar,
+    ClerkLoading,
+    ClerkLoaded,
+    SignedIn,
+    SignedOut,
+    RedirectToSignIn,
     // ModeSwitcher,
   },
   data() {
-    return { seasonInfo: null };
+    return { seasonInfo: null, clerkEnabled: isClerkEnabled() };
   },
   computed: {
     seasonName() {
@@ -160,6 +198,44 @@ button:disabled,
   padding: 24px 16px 48px;
   max-width: 1000px;
   margin: 0 auto;
+}
+
+/* Shown while Clerk resolves auth state, in place of the app body, so
+   signed-out visitors never see app content before the sign-in redirect. */
+.auth-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+}
+.auth-spinner {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid color-mix(in oklab, var(--primary) 25%, transparent);
+  border-top-color: var(--primary);
+  animation: auth-spin 0.8s linear infinite;
+}
+.auth-loading-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@keyframes auth-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .auth-spinner {
+    animation-duration: 2s;
+  }
 }
 
 .site-footer {

--- a/packages/web/src/components/HeaderBar.vue
+++ b/packages/web/src/components/HeaderBar.vue
@@ -1,15 +1,11 @@
 <script setup>
 import { ref } from "vue";
-import { RedirectToSignIn, SignedIn, SignedOut, UserButton } from "@clerk/vue";
+import { SignedIn, UserButton } from "@clerk/vue";
 import ApiKeyModal from "@/components/modals/ApiKeyModal.vue";
+import { isClerkEnabled } from "@/services/clerk";
 
-const publishableKey = process.env.VUE_APP_CLERK_PUBLISHABLE_KEY;
-const isLocalDevHost =
-  window.location.hostname === "localhost" ||
-  window.location.hostname === "127.0.0.1";
-const isLiveClerkKey =
-  typeof publishableKey === "string" && publishableKey.startsWith("pk_live_");
-const clerkEnabled = Boolean(publishableKey) && !(isLocalDevHost && isLiveClerkKey);
+// The signed-out redirect is handled in App.vue alongside the content gate.
+const clerkEnabled = isClerkEnabled();
 
 const showApiKeyModal = ref(false);
 </script>
@@ -26,9 +22,6 @@ const showApiKeyModal = ref(false);
         <SignedIn>
           <UserButton />
         </SignedIn>
-        <SignedOut>
-          <RedirectToSignIn />
-        </SignedOut>
       </template>
       <span v-else class="dev-auth-pill">Dev auth mode</span>
     </div>

--- a/packages/web/src/services/clerk.js
+++ b/packages/web/src/services/clerk.js
@@ -3,6 +3,20 @@ import { useUser, useAuth } from "@clerk/vue";
 const w = typeof window !== "undefined" ? window : undefined;
 
 /**
+ * Whether the Clerk auth plugin is active in this environment. Mirrors the
+ * mounting condition in main.js: Clerk is skipped when there's no publishable
+ * key, or on localhost with a live key (a test key should be used locally).
+ * When disabled the app runs in dev-auth mode and isn't gated behind sign-in.
+ */
+export function isClerkEnabled() {
+  const key = process.env.VUE_APP_CLERK_PUBLISHABLE_KEY;
+  const host = w?.location?.hostname;
+  const isLocalDevHost = host === "localhost" || host === "127.0.0.1";
+  const isLiveClerkKey = typeof key === "string" && key.startsWith("pk_live_");
+  return Boolean(key) && !(isLocalDevHost && isLiveClerkKey);
+}
+
+/**
  * Normalizes a Clerk user into a lightweight POJO for app-wide use.
  */
 function normalizeUser(u) {


### PR DESCRIPTION
## Problem
Visiting `app.seasonsprint.com` while signed out briefly showed the full app UI before the Clerk sign-in redirect took over.

## Cause
In `App.vue`, `<router-view>` rendered unconditionally. The only auth enforcement was `<SignedOut><RedirectToSignIn/></SignedOut>` in `HeaderBar`, and that redirect only fires *after* Clerk finishes loading — so there's a window where app content is visible.

## Fix
Gate the app body behind Clerk's resolved auth state in `App.vue`:
- `<ClerkLoading>` → a loading placeholder (no app content) while Clerk initializes.
- `<ClerkLoaded>` → render `<main>`/`<router-view>` only inside `<SignedIn>`; `<SignedOut>` redirects to sign-in.
- Dev-auth mode (no Clerk plugin) bypasses the gate and renders directly.

Content now renders only once auth is known, eliminating the flash.

Also added an `isClerkEnabled()` helper in `services/clerk.js` (mirrors the mounting condition in `main.js`), used in both `App.vue` and `HeaderBar`, and centralized the signed-out redirect in `App.vue` (removed the duplicate from `HeaderBar`).

## Test plan
- CI build/lint/test.
- Signed out: only the loading spinner shows, then redirect to Clerk sign-in — no app content flash.
- Signed in: app renders normally with the `UserButton` in the header.
- Dev-auth mode (local, no Clerk): app renders directly, "Dev auth mode" pill shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)