### PR TITLE
feat(web): branded in-app sign-in page

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -23,7 +23,7 @@
         </main>
       </SignedIn>
       <SignedOut>
-        <RedirectToSignIn />
+        <SignInView />
       </SignedOut>
     </ClerkLoaded>
   </template>
@@ -37,6 +37,7 @@
 
 <script>
 import HeaderBar from "./components/HeaderBar.vue";
+import SignInView from "./components/SignInView.vue";
 // ModeSwitcher hidden for now — Ranked is disabled.
 // import ModeSwitcher from "./components/ModeSwitcher.vue";
 import {
@@ -44,7 +45,6 @@ import {
   ClerkLoaded,
   SignedIn,
   SignedOut,
-  RedirectToSignIn,
 } from "@clerk/vue";
 import { loadSeasonJson } from "@/utils/season";
 import { isClerkEnabled } from "@/services/clerk";
@@ -53,11 +53,11 @@ export default {
   name: "App",
   components: {
     HeaderBar,
+    SignInView,
     ClerkLoading,
     ClerkLoaded,
     SignedIn,
     SignedOut,
-    RedirectToSignIn,
     // ModeSwitcher,
   },
   data() {

--- a/packages/web/src/components/SignInView.vue
+++ b/packages/web/src/components/SignInView.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { SignIn } from "@clerk/vue";
+
+// Brand-matched theming layered on the global dark Clerk theme (set in main.js).
+// Kept light-touch so Clerk's component stays intact — we just align the accent
+// and font, and hide Clerk's own header since our branding above is the title.
+const appearance = {
+  variables: {
+    colorPrimary: "#ffd400", // --primary (THE FINALS gold)
+    fontFamily: "var(--font-sans)",
+    borderRadius: "10px",
+  },
+  elements: {
+    header: { display: "none" },
+  },
+};
+</script>
+
+<template>
+  <main class="signin-view">
+    <div class="signin-brand">
+      <img src="/logo-transparent.svg" alt="" class="signin-logo" />
+      <h1 class="signin-title">Sign in to Season Sprint</h1>
+      <p class="signin-tagline">
+        Track your World Tour points and sync across all your devices.
+      </p>
+    </div>
+    <div class="signin-widget">
+      <!-- routing="hash" keeps the whole flow on app.seasonsprint.com without a
+           dedicated route, so the user never leaves the site to sign in. -->
+      <SignIn routing="hash" :appearance="appearance" />
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.signin-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 48px 16px 64px;
+  max-width: 480px;
+  margin: 0 auto;
+}
+.signin-brand {
+  text-align: center;
+}
+.signin-logo {
+  height: 64px;
+  width: auto;
+  background: #ce2c30;
+  border-radius: 10px;
+  padding: 6px;
+}
+.signin-title {
+  margin: 16px 0 6px;
+  font-size: clamp(22px, 5vw, 28px);
+  color: var(--text-strong);
+  letter-spacing: 0.02em;
+}
+.signin-tagline {
+  margin: 0 auto;
+  color: var(--muted);
+  font-size: 14px;
+  max-width: 36ch;
+}
+.signin-widget {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+</style>


### PR DESCRIPTION
## Why
Signed-out visitors were sent to Clerk's **hosted** sign-in page on a separate `accounts.*`/Clerk domain, so it wasn't obviously the same Season Sprint site they'd just been on.

## What
- New `SignInView.vue`: mounts Clerk's `<SignIn>` **inline** on `app.seasonsprint.com`, wrapped in Season Sprint branding — logo, "Sign in to Season Sprint" heading, and a tagline — themed to the dark UI with the brand gold accent (`#ffd400`). `routing="hash"` keeps the entire flow on-site with no dedicated route.
- `App.vue`: the `SignedOut` branch now renders `<SignInView />` instead of `<RedirectToSignIn />`. (Loading gate + `SignedIn` content from #100 are unchanged.)
- Dev-auth mode (no Clerk plugin) is unaffected.

The user now stays on the site and sees clear Season Sprint branding around the sign-in form.

## Test plan
- CI build/lint/test.
- Signed out → spinner, then the branded in-app sign-in (logo + heading + tagline + Clerk form), all on `app.seasonsprint.com` — no redirect off-site.
- Complete sign-in (email + Google OAuth) → returns to the app signed in. *(OAuth round-trips to the provider and back to the app origin; verify the configured Clerk allowed origins cover `app.seasonsprint.com`.)*
- Signed in → app renders normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)