### PR TITLE
feat(landing): move iOS coming-soon block to last in platforms

### DIFF
--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -163,10 +163,6 @@
             <span class="platform-name">Web app</span>
             <span class="platform-note">app.seasonsprint.com</span>
           </a>
-          <div class="platform platform-soon" aria-disabled="true">
-            <span class="platform-name">iOS</span>
-            <span class="platform-note">Coming soon</span>
-          </div>
           <a class="platform" href="/downloads">
             <span class="platform-name">Android</span>
             <span class="platform-note">APK download</span>
@@ -179,6 +175,10 @@
             <span class="platform-name">Linux</span>
             <span class="platform-note">One-line install</span>
           </a>
+          <div class="platform platform-soon" aria-disabled="true">
+            <span class="platform-name">iOS</span>
+            <span class="platform-note">Coming soon</span>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Moves the iOS "Coming soon" tile to the end of the **Play anywhere, track everywhere** section, so the available platforms (Web, Android, Windows, Linux) lead and the not-yet-available one sits last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)