### PR TITLE
feat(ranked): add Ranked mode behind a feature-flag system

### DIFF
--- a/packages/server/migrations/0005_add_record_mode.sql
+++ b/packages/server/migrations/0005_add_record_mode.sql
@@ -1,0 +1,8 @@
+-- AddColumn
+-- Discriminates which game mode a record belongs to ("world-tour" | "ranked").
+-- Existing rows backfill to "world-tour" via the default, preserving current data.
+ALTER TABLE "Record" ADD COLUMN "mode" TEXT NOT NULL DEFAULT 'world-tour';
+
+-- CreateIndex
+-- Supports the (userId, mode, date) lookup used by upsert/query/delete-all.
+CREATE INDEX "Record_userId_mode_date_idx" ON "Record"("userId", "mode", "date");

--- a/packages/server/migrations/0006_create_feature_flags.sql
+++ b/packages/server/migrations/0006_create_feature_flags.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "FeatureFlag" (
+    "key" TEXT NOT NULL PRIMARY KEY,
+    "description" TEXT NOT NULL DEFAULT '',
+    "enabledGlobally" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "UserFlagOverride" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "flagKey" TEXT NOT NULL,
+    "enabled" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "UserFlagOverride_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "UserFlagOverride_flagKey_fkey" FOREIGN KEY ("flagKey") REFERENCES "FeatureFlag" ("key") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserFlagOverride_userId_flagKey_key" ON "UserFlagOverride"("userId", "flagKey");
+
+-- Seed the ranked flag (off globally; admins enable it globally or per-user).
+INSERT INTO "FeatureFlag" ("key", "description", "enabledGlobally")
+VALUES ('ranked', 'Ranked game mode', 0);

--- a/packages/server/migrations/0007_add_user_is_admin.sql
+++ b/packages/server/migrations/0007_add_user_is_admin.sql
@@ -1,0 +1,3 @@
+-- AddColumn
+-- Marks a user as an admin (can manage feature flags via the admin panel).
+ALTER TABLE "User" ADD COLUMN "isAdmin" INTEGER NOT NULL DEFAULT 0;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -15,14 +15,16 @@ datasource db {
 }
 
 model User {
-  id          String   @id @default(uuid())
-  email       String   @unique
-  name        String?
-  clerkUserId String   @unique
-  records     Record[]
-  apiKeys     ApiKey[]
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id            String             @id @default(uuid())
+  email         String             @unique
+  name          String?
+  clerkUserId   String             @unique
+  isAdmin       Boolean            @default(false)
+  records       Record[]
+  apiKeys       ApiKey[]
+  flagOverrides UserFlagOverride[]
+  createdAt     DateTime           @default(now())
+  updatedAt     DateTime           @updatedAt
 }
 
 model ApiKey {
@@ -41,8 +43,33 @@ model Record {
   id        String   @id @default(uuid())
   date      DateTime
   winPoints Int
+  mode      String   @default("world-tour")
   User      User     @relation(fields: [userId], references: [id])
   userId    String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId, mode, date])
+}
+
+model FeatureFlag {
+  key             String             @id
+  description     String             @default("")
+  enabledGlobally Boolean            @default(false)
+  overrides       UserFlagOverride[]
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+}
+
+model UserFlagOverride {
+  id        String      @id @default(uuid())
+  User      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  Flag      FeatureFlag @relation(fields: [flagKey], references: [key], onDelete: Cascade)
+  flagKey   String
+  enabled   Boolean
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  @@unique([userId, flagKey])
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,8 @@ import { clerkOrDevToken, resolveAuth } from "./middleware/auth";
 import records from "./routes/records";
 import apiKeys from "./routes/apiKeys";
 import stream from "./routes/stream";
+import flags from "./routes/flags";
+import admin from "./routes/admin";
 
 interface Bindings {
   D1: D1Database;
@@ -20,6 +22,9 @@ interface Bindings {
   DEV_USER_ID?: string;
   CLERK_PUBLISHABLE_KEY: string;
   CLERK_SECRET_KEY: string;
+  // Comma-separated Clerk user IDs that are always admins. Bootstraps the admin
+  // panel so the owner is never locked out regardless of the DB isAdmin flag.
+  ADMIN_CLERK_USER_IDS?: string;
 }
 
 export interface Variables {
@@ -85,6 +90,8 @@ app.use("*", resolveAuth);
 // Authenticated routes
 app.route("/me/records", records);
 app.route("/me/api-keys", apiKeys);
+app.route("/me/flags", flags);
+app.route("/admin", admin);
 
 // Stream token exchange — uses normal Clerk auth to issue a stream token
 app.post("/me/stream/token", async (c) => {

--- a/packages/server/src/middleware/admin.ts
+++ b/packages/server/src/middleware/admin.ts
@@ -1,0 +1,33 @@
+import type { Env } from "../index";
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * Parse the comma-separated ADMIN_CLERK_USER_IDS allowlist into a set.
+ * The allowlist guarantees the owner is always an admin regardless of DB
+ * state, which prevents a bootstrap lockout for the admin panel.
+ */
+function allowlist(env: Env["Bindings"]): Set<string> {
+  return new Set(
+    (env.ADMIN_CLERK_USER_IDS ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+}
+
+/** Returns true if the user is an admin via the env allowlist or the DB flag. */
+export async function isAdmin(
+  c: Parameters<MiddlewareHandler<Env>>[0]
+): Promise<boolean> {
+  const { userId } = c.get("auth");
+  if (allowlist(c.env).has(userId)) return true;
+  return c.get("db").isUserAdmin(userId);
+}
+
+/** Guards admin-only routes. Must run after resolveAuth. */
+export const requireAdmin: MiddlewareHandler<Env> = async (c, next) => {
+  if (!(await isAdmin(c))) {
+    return c.text("Forbidden", 403);
+  }
+  return next();
+};

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,0 +1,73 @@
+import { Hono } from "hono";
+import type { Env } from "../index";
+import { requireAdmin } from "../middleware/admin";
+
+const admin = new Hono<Env>();
+
+// Every route here is admin-only.
+admin.use("*", requireAdmin);
+
+// ── Flags ─────────────────────────────────────────────────────────────────
+
+admin.get("/flags", async (c) => {
+  return c.json(await c.get("db").listFlags());
+});
+
+admin.post("/flags", async (c) => {
+  const { key, description } = await c.req.json<{
+    key: string;
+    description?: string;
+  }>();
+  if (!key || typeof key !== "string") {
+    return c.text("Missing flag key", 400);
+  }
+  const flag = await c.get("db").createFlag(key, description ?? "");
+  return c.json(flag);
+});
+
+admin.patch("/flags/:key", async (c) => {
+  const key = c.req.param("key");
+  const { enabledGlobally } = await c.req.json<{ enabledGlobally: boolean }>();
+  if (typeof enabledGlobally !== "boolean") {
+    return c.text("enabledGlobally must be a boolean", 400);
+  }
+  const flag = await c.get("db").setFlagGlobal(key, enabledGlobally);
+  return c.json(flag);
+});
+
+// ── Users & per-user overrides ──────────────────────────────────────────────
+
+admin.get("/users", async (c) => {
+  const email = c.req.query("email") ?? "";
+  return c.json(await c.get("db").searchUsersByEmail(email));
+});
+
+admin.put("/users/:userId/flags/:flagKey", async (c) => {
+  const userId = c.req.param("userId");
+  const flagKey = c.req.param("flagKey");
+  const { enabled } = await c.req.json<{ enabled: boolean }>();
+  if (typeof enabled !== "boolean") {
+    return c.text("enabled must be a boolean", 400);
+  }
+  const override = await c.get("db").setUserOverride(userId, flagKey, enabled);
+  return c.json(override);
+});
+
+admin.delete("/users/:userId/flags/:flagKey", async (c) => {
+  const userId = c.req.param("userId");
+  const flagKey = c.req.param("flagKey");
+  const cleared = await c.get("db").clearUserOverride(userId, flagKey);
+  return c.json({ cleared });
+});
+
+admin.patch("/users/:userId", async (c) => {
+  const userId = c.req.param("userId");
+  const { isAdmin } = await c.req.json<{ isAdmin: boolean }>();
+  if (typeof isAdmin !== "boolean") {
+    return c.text("isAdmin must be a boolean", 400);
+  }
+  const user = await c.get("db").setUserAdmin(userId, isAdmin);
+  return c.json(user);
+});
+
+export default admin;

--- a/packages/server/src/routes/flags.ts
+++ b/packages/server/src/routes/flags.ts
@@ -1,0 +1,20 @@
+import { Hono } from "hono";
+import type { Env } from "../index";
+import { isAdmin } from "../middleware/admin";
+
+const flags = new Hono<Env>();
+
+// Resolved flags + admin status for the current user, fetched on app boot.
+flags.get("/", async (c) => {
+  const { userId } = c.get("auth");
+  const db = c.get("db");
+
+  const [resolved, admin] = await Promise.all([
+    db.getResolvedFlags(userId),
+    isAdmin(c),
+  ]);
+
+  return c.json({ flags: resolved, isAdmin: admin });
+});
+
+export default flags;

--- a/packages/server/src/routes/records.ts
+++ b/packages/server/src/routes/records.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "../index";
-import type { Record } from "../types";
+import type { GameMode, Record } from "../types";
 import getEmail from "../getEmail";
 import { parseDate } from "../utils/parseDate";
 import { broadcast } from "../utils/broadcast";
@@ -21,7 +21,10 @@ records.post("/", async (c) => {
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  const { date, winPoints, mode } = await c.req.json<Record>();
+  // `mode` is optional on the wire (older clients omit it) — default it.
+  const { date, winPoints, mode } = await c.req.json<
+    Omit<Record, "id" | "userId" | "mode"> & { mode?: GameMode }
+  >();
   const resolvedMode = mode ?? "world-tour";
 
   const record = await db.upsertRecord(

--- a/packages/server/src/routes/records.ts
+++ b/packages/server/src/routes/records.ts
@@ -11,7 +11,8 @@ records.get("/", async (c) => {
   const { userId } = c.get("auth");
   const db = c.get("db");
 
-  const result = await db.getUserRecords(userId);
+  const mode = c.req.query("mode") ?? "world-tour";
+  const result = await db.getUserRecords(userId, mode);
   return c.json(result);
 });
 
@@ -20,9 +21,16 @@ records.post("/", async (c) => {
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  const { date, winPoints } = await c.req.json<Record>();
+  const { date, winPoints, mode } = await c.req.json<Record>();
+  const resolvedMode = mode ?? "world-tour";
 
-  const record = await db.upsertRecord(userId, email, date, winPoints);
+  const record = await db.upsertRecord(
+    userId,
+    email,
+    date,
+    winPoints,
+    resolvedMode
+  );
 
   broadcast(c, userId, "record:upsert", record);
 
@@ -79,7 +87,7 @@ records.delete("/:id", async (c) => {
     return c.text("Not found", 404);
   }
 
-  broadcast(c, userId, "record:delete", { id });
+  broadcast(c, userId, "record:delete", { id, mode: deleted.mode });
 
   return c.json({ deleted: true });
 });
@@ -88,9 +96,10 @@ records.delete("/", async (c) => {
   const { userId } = c.get("auth");
   const db = c.get("db");
 
-  const count = await db.deleteAllUserRecords(userId);
+  const mode = c.req.query("mode") ?? "world-tour";
+  const count = await db.deleteAllUserRecords(userId, mode);
 
-  broadcast(c, userId, "record:delete-all", {});
+  broadcast(c, userId, "record:delete-all", { mode });
 
   return c.json({ deleted: count });
 });
@@ -100,17 +109,23 @@ records.post("/bulk", async (c) => {
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  const { records: input } = await c.req.json<{
+  const { records: input, mode } = await c.req.json<{
     records: { date: string; winPoints: number }[];
+    mode?: string;
   }>();
+  const resolvedMode = mode ?? "world-tour";
 
   const result = await db.bulkUpsertRecords(
     userId,
     email,
-    input.map((r) => ({ date: new Date(r.date), winPoints: r.winPoints }))
+    input.map((r) => ({ date: new Date(r.date), winPoints: r.winPoints })),
+    resolvedMode
   );
 
-  broadcast(c, userId, "record:bulk-upsert", { records: result });
+  broadcast(c, userId, "record:bulk-upsert", {
+    records: result,
+    mode: resolvedMode,
+  });
 
   return c.json({ records: result });
 });

--- a/packages/server/src/services/db.ts
+++ b/packages/server/src/services/db.ts
@@ -21,11 +21,12 @@ export class DbService {
     });
   }
 
-  async getUserRecords(clerkUserId: string) {
+  async getUserRecords(clerkUserId: string, mode = "world-tour") {
     console.warn("Getting user records for clerk user", clerkUserId);
 
     return await this.prisma.record.findMany({
       where: {
+        mode,
         User: {
           clerkUserId,
         },
@@ -34,6 +35,7 @@ export class DbService {
         id: true,
         date: true,
         winPoints: true,
+        mode: true,
       },
       orderBy: {
         date: "desc",
@@ -45,7 +47,8 @@ export class DbService {
     clerkUserId: string,
     userEmail: string,
     date: Date,
-    winPoints: number
+    winPoints: number,
+    mode = "world-tour"
   ) {
     const user = await this.getOrCreateUserByClerkId(clerkUserId, userEmail);
 
@@ -54,6 +57,7 @@ export class DbService {
         userId: user.id,
         date: new Date(date),
         winPoints,
+        mode,
       },
     });
   }
@@ -62,7 +66,8 @@ export class DbService {
     clerkUserId: string,
     userEmail: string,
     date: Date,
-    winPoints: number
+    winPoints: number,
+    mode = "world-tour"
   ) {
     const user = await this.getOrCreateUserByClerkId(clerkUserId, userEmail);
 
@@ -70,10 +75,11 @@ export class DbService {
     const normalizedDate = new Date(date);
     normalizedDate.setUTCHours(0, 0, 0, 0);
 
-    // Find existing record for this user and date
+    // Find existing record for this user, mode, and date
     const existing = await this.prisma.record.findFirst({
       where: {
         userId: user.id,
+        mode,
         date: normalizedDate,
       },
     });
@@ -83,7 +89,7 @@ export class DbService {
       return await this.prisma.record.update({
         where: { id: existing.id },
         data: { winPoints },
-        select: { id: true, date: true, winPoints: true },
+        select: { id: true, date: true, winPoints: true, mode: true },
       });
     } else {
       // Create new record
@@ -92,33 +98,38 @@ export class DbService {
           userId: user.id,
           date: normalizedDate,
           winPoints,
+          mode,
         },
-        select: { id: true, date: true, winPoints: true },
+        select: { id: true, date: true, winPoints: true, mode: true },
       });
     }
   }
 
+  // Returns the deleted record's mode so callers can scope the live broadcast.
   async deleteRecordIfOwner(
     clerkUserId: string,
     recordId: string
-  ): Promise<boolean> {
+  ): Promise<{ mode: string } | null> {
     const existing = await this.prisma.record.findFirst({
       where: {
         id: recordId,
         User: { clerkUserId },
       },
-      select: { id: true },
+      select: { id: true, mode: true },
     });
 
     if (!existing) {
-      return false;
+      return null;
     }
 
     await this.prisma.record.delete({ where: { id: recordId } });
-    return true;
+    return { mode: existing.mode };
   }
 
-  async deleteAllUserRecords(clerkUserId: string): Promise<number> {
+  async deleteAllUserRecords(
+    clerkUserId: string,
+    mode = "world-tour"
+  ): Promise<number> {
     const user = await this.prisma.user.findUnique({
       where: { clerkUserId },
       select: { id: true },
@@ -129,7 +140,7 @@ export class DbService {
     }
 
     const result = await this.prisma.record.deleteMany({
-      where: { userId: user.id },
+      where: { userId: user.id, mode },
     });
 
     return result.count;
@@ -138,7 +149,8 @@ export class DbService {
   async bulkUpsertRecords(
     clerkUserId: string,
     userEmail: string,
-    records: { date: Date; winPoints: number }[]
+    records: { date: Date; winPoints: number }[],
+    mode = "world-tour"
   ) {
     if (records.length === 0) return [];
 
@@ -150,20 +162,20 @@ export class DbService {
       normalizedDate.setUTCHours(0, 0, 0, 0);
 
       const existing = await this.prisma.record.findFirst({
-        where: { userId: user.id, date: normalizedDate },
+        where: { userId: user.id, mode, date: normalizedDate },
       });
 
       if (existing) {
         const updated = await this.prisma.record.update({
           where: { id: existing.id },
           data: { winPoints },
-          select: { id: true, date: true, winPoints: true },
+          select: { id: true, date: true, winPoints: true, mode: true },
         });
         results.push(updated);
       } else {
         const created = await this.prisma.record.create({
-          data: { userId: user.id, date: normalizedDate, winPoints },
-          select: { id: true, date: true, winPoints: true },
+          data: { userId: user.id, date: normalizedDate, winPoints, mode },
+          select: { id: true, date: true, winPoints: true, mode: true },
         });
         results.push(created);
       }
@@ -263,7 +275,108 @@ export class DbService {
     return await this.prisma.record.update({
       where: { id: recordId },
       data,
-      select: { id: true, date: true, winPoints: true },
+      select: { id: true, date: true, winPoints: true, mode: true },
+    });
+  }
+
+  // ── Feature flags ─────────────────────────────────────────────────────────
+
+  /** Resolve every flag for a user: per-user override wins over the global default. */
+  async getResolvedFlags(clerkUserId: string): Promise<Record<string, boolean>> {
+    const flags = await this.prisma.featureFlag.findMany({
+      select: { key: true, enabledGlobally: true },
+    });
+
+    const user = await this.prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { id: true },
+    });
+
+    const overrides = user
+      ? await this.prisma.userFlagOverride.findMany({
+          where: { userId: user.id },
+          select: { flagKey: true, enabled: true },
+        })
+      : [];
+    const overrideMap = new Map(overrides.map((o) => [o.flagKey, o.enabled]));
+
+    const resolved: Record<string, boolean> = {};
+    for (const flag of flags) {
+      resolved[flag.key] = overrideMap.has(flag.key)
+        ? Boolean(overrideMap.get(flag.key))
+        : flag.enabledGlobally;
+    }
+    return resolved;
+  }
+
+  async isUserAdmin(clerkUserId: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { isAdmin: true },
+    });
+    return Boolean(user?.isAdmin);
+  }
+
+  async listFlags() {
+    return await this.prisma.featureFlag.findMany({
+      select: { key: true, description: true, enabledGlobally: true },
+      orderBy: { key: "asc" },
+    });
+  }
+
+  async createFlag(key: string, description: string) {
+    return await this.prisma.featureFlag.upsert({
+      where: { key },
+      update: { description },
+      create: { key, description },
+      select: { key: true, description: true, enabledGlobally: true },
+    });
+  }
+
+  async setFlagGlobal(key: string, enabledGlobally: boolean) {
+    return await this.prisma.featureFlag.update({
+      where: { key },
+      data: { enabledGlobally },
+      select: { key: true, description: true, enabledGlobally: true },
+    });
+  }
+
+  /** Look up users by an email substring, including their per-flag overrides. */
+  async searchUsersByEmail(query: string) {
+    return await this.prisma.user.findMany({
+      where: { email: { contains: query } },
+      select: {
+        id: true,
+        email: true,
+        isAdmin: true,
+        flagOverrides: { select: { flagKey: true, enabled: true } },
+      },
+      orderBy: { email: "asc" },
+      take: 25,
+    });
+  }
+
+  async setUserOverride(userId: string, flagKey: string, enabled: boolean) {
+    return await this.prisma.userFlagOverride.upsert({
+      where: { userId_flagKey: { userId, flagKey } },
+      update: { enabled },
+      create: { userId, flagKey, enabled },
+      select: { userId: true, flagKey: true, enabled: true },
+    });
+  }
+
+  async clearUserOverride(userId: string, flagKey: string): Promise<boolean> {
+    const result = await this.prisma.userFlagOverride.deleteMany({
+      where: { userId, flagKey },
+    });
+    return result.count > 0;
+  }
+
+  async setUserAdmin(userId: string, isAdmin: boolean) {
+    return await this.prisma.user.update({
+      where: { id: userId },
+      data: { isAdmin },
+      select: { id: true, email: true, isAdmin: true },
     });
   }
 }

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,6 +1,9 @@
+export type GameMode = "world-tour" | "ranked";
+
 export type Record = {
   id: string;
   userId: string;
   date: Date;
   winPoints: number;
+  mode: GameMode;
 };

--- a/packages/server/tests/db.test.ts
+++ b/packages/server/tests/db.test.ts
@@ -66,7 +66,7 @@ describe("DbService", () => {
   });
 
   describe("deleteRecordIfOwner", () => {
-    it("deletes an owned record and returns true", async () => {
+    it("deletes an owned record and returns its mode", async () => {
       const record = await db.upsertRecord(
         "clerk-1",
         "test@example.com",
@@ -75,13 +75,13 @@ describe("DbService", () => {
       );
 
       const result = await db.deleteRecordIfOwner("clerk-1", record.id);
-      expect(result).toBe(true);
+      expect(result).toEqual({ mode: "world-tour" });
 
       const remaining = await db.getUserRecords("clerk-1");
       expect(remaining).toHaveLength(0);
     });
 
-    it("returns false for a record owned by another user", async () => {
+    it("returns null for a record owned by another user", async () => {
       const record = await db.upsertRecord(
         "clerk-1",
         "user1@example.com",
@@ -90,16 +90,16 @@ describe("DbService", () => {
       );
 
       const result = await db.deleteRecordIfOwner("clerk-2", record.id);
-      expect(result).toBe(false);
+      expect(result).toBeNull();
 
       // Record should still exist
       const remaining = await db.getUserRecords("clerk-1");
       expect(remaining).toHaveLength(1);
     });
 
-    it("returns false for a non-existent record", async () => {
+    it("returns null for a non-existent record", async () => {
       const result = await db.deleteRecordIfOwner("clerk-1", "non-existent-id");
-      expect(result).toBe(false);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/server/wrangler.jsonc
+++ b/packages/server/wrangler.jsonc
@@ -28,7 +28,10 @@
   "vars": {
     "DATABASE_URL": "file:./dev.db",
     "CLERK_PUBLISHABLE_KEY": "pk_live_Y2xlcmsuc2Vhc29uc3ByaW50LmNvbSQ",
-    "ENVIRONMENT": "production"
+    "ENVIRONMENT": "production",
+    // Comma-separated Clerk user IDs that are always admins (bootstraps the
+    // admin panel). Set this to the owner's Clerk user id before deploying.
+    "ADMIN_CLERK_USER_IDS": ""
     // DEV_AUTH_TOKEN / DEV_USER_ID are intentionally NOT set here. The Clerk
     // bypass they enable must never exist in production. They live in the
     // gitignored .dev.vars (loaded only by `wrangler dev`), and the auth

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,10 +21,11 @@
     "vue-router": "4"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.12.16",
+    "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/preset-typescript": "^7.27.1",
+    "@vitejs/plugin-vue": "^5.2.4",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-service": "~5.0.0",

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -17,8 +17,7 @@
     <ClerkLoaded>
       <SignedIn>
         <main class="container">
-          <!-- Mode toggle hidden for now — Ranked is disabled. -->
-          <!-- <ModeSwitcher /> -->
+          <ModeSwitcher />
           <router-view />
         </main>
       </SignedIn>
@@ -28,6 +27,7 @@
     </ClerkLoaded>
   </template>
   <main v-else class="container">
+    <ModeSwitcher />
     <router-view />
   </main>
   <footer class="site-footer" role="contentinfo">
@@ -36,10 +36,11 @@
 </template>
 
 <script>
+import { watch } from "vue";
+import { useAuth } from "@clerk/vue";
 import HeaderBar from "./components/HeaderBar.vue";
 import SignInView from "./components/SignInView.vue";
-// ModeSwitcher hidden for now — Ranked is disabled.
-// import ModeSwitcher from "./components/ModeSwitcher.vue";
+import ModeSwitcher from "./components/ModeSwitcher.vue";
 import {
   ClerkLoading,
   ClerkLoaded,
@@ -48,6 +49,7 @@ import {
 } from "@clerk/vue";
 import { loadSeasonJson } from "@/utils/season";
 import { isClerkEnabled } from "@/services/clerk";
+import { useFlags } from "@/composables/useFlags";
 
 export default {
   name: "App",
@@ -58,7 +60,18 @@ export default {
     ClerkLoaded,
     SignedIn,
     SignedOut,
-    // ModeSwitcher,
+    ModeSwitcher,
+  },
+  setup() {
+    const { loadFlags } = useFlags();
+    // Flags depend on auth — load now, and reload when Clerk sign-in changes.
+    loadFlags();
+    try {
+      const { isSignedIn } = useAuth();
+      watch(isSignedIn, () => loadFlags());
+    } catch (e) {
+      // Clerk not available (e.g. dev mode) — initial load above is enough.
+    }
   },
   data() {
     return { seasonInfo: null, clerkEnabled: isClerkEnabled() };

--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -25,7 +25,7 @@
           :current-win-points="currentWinPoints"
           :to-next="toNext"
           :progress-pct="progressPct"
-          unit="WP"
+          :unit="unit"
           @select-goal="onSelectGoal"
           @set-goal-win-points="setGoalWinPoints"
         />
@@ -35,7 +35,9 @@
         <div class="today-progress">
           <template v-if="todayPoint">
             <span class="today-label">Today</span>
-            <span class="today-value">+{{ todayGain }} pts</span>
+            <span class="today-value" :class="{ 'today-loss': todayGain < 0 }"
+              >{{ todayGain >= 0 ? "+" : "" }}{{ todayGain }} pts</span
+            >
           </template>
           <template v-else>
             <span class="today-label">No points logged today</span>
@@ -327,7 +329,7 @@
           :y="height / 2"
           text-anchor="middle"
           :transform="`rotate(-90 22 ${height / 2})`"
-        >Total Win Points</text>
+        >{{ yAxisLabel }}</text>
         <text
           class="axis-label"
           :x="width / 2"
@@ -423,6 +425,12 @@ const props = defineProps({
   goalOptions: { type: Array, default: () => [] },
   headerDisclaimer: { type: String, default: "" },
   headerTitle: { type: String, default: "" },
+  // Which game mode's data this graph reads/writes. Keeps World Tour and
+  // Ranked records in separate buckets on the server.
+  mode: { type: String, default: "world-tour" },
+  // Y-axis label and progress unit (e.g. "Rank Score" / "RS" for Ranked).
+  yAxisLabel: { type: String, default: "Total Win Points" },
+  unit: { type: String, default: "WP" },
 });
 
 // Config
@@ -489,7 +497,7 @@ const {
   onImportedRows,
   addWinPoints,
   incrementWinPoints,
-} = usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport });
+} = usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode: props.mode });
 
 // Modal state
 const showImportModal = ref(false);
@@ -1052,6 +1060,9 @@ try {
 .today-value {
   color: var(--success);
   font-weight: 800;
+}
+.today-value.today-loss {
+  color: var(--danger);
 }
 
 .status-banner {

--- a/packages/web/src/components/ModeSwitcher.vue
+++ b/packages/web/src/components/ModeSwitcher.vue
@@ -1,14 +1,23 @@
 <template>
   <nav class="mode-switch" aria-label="Game mode">
     <router-link to="/world-tour" class="mode-seg">World Tour</router-link>
-    <router-link to="/ranked" class="mode-seg">Ranked</router-link>
+    <router-link v-if="flags.ranked" to="/ranked" class="mode-seg"
+      >Ranked</router-link
+    >
+    <router-link v-if="isAdmin" to="/admin" class="mode-seg mode-seg-admin"
+      >Admin</router-link
+    >
   </nav>
 </template>
 
 <script setup>
-// Segmented control between the two game modes. Pure navigation — vue-router
+// Segmented control between the game modes. Pure navigation — vue-router
 // applies `router-link-active` to the matching segment, which we style as the
-// selected pill.
+// selected pill. The Ranked segment appears only when the `ranked` flag is on;
+// the Admin segment only for admins.
+import { useFlags } from "@/composables/useFlags";
+
+const { flags, isAdmin } = useFlags();
 </script>
 
 <style scoped>

--- a/packages/web/src/composables/useFlags.js
+++ b/packages/web/src/composables/useFlags.js
@@ -1,0 +1,45 @@
+import { reactive, ref } from 'vue'
+import { getFlags, getAuthorizationHeader } from '@/services/api'
+
+// Module-level singleton so every component shares one resolved flag set.
+const flags = reactive({})
+const isAdmin = ref(false)
+const loaded = ref(false)
+let inflight = null
+
+/**
+ * Fetch the current user's resolved flags + admin status from the server.
+ * No-ops (all flags false) when unauthenticated. Safe to call repeatedly;
+ * concurrent calls share a single in-flight request.
+ */
+async function loadFlags() {
+  if (inflight) return inflight
+  inflight = (async () => {
+    try {
+      const authHeader = await getAuthorizationHeader()
+      if (!authHeader) {
+        // Signed out — clear any previously loaded state.
+        for (const k of Object.keys(flags)) delete flags[k]
+        isAdmin.value = false
+        return
+      }
+      const data = await getFlags(authHeader)
+      const next = data?.flags || {}
+      for (const k of Object.keys(flags)) {
+        if (!(k in next)) delete flags[k]
+      }
+      Object.assign(flags, next)
+      isAdmin.value = Boolean(data?.isAdmin)
+    } catch (e) {
+      console.warn('Failed to load feature flags', e)
+    } finally {
+      loaded.value = true
+      inflight = null
+    }
+  })()
+  return inflight
+}
+
+export function useFlags() {
+  return { flags, isAdmin, loaded, loadFlags }
+}

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -19,7 +19,10 @@ import { connectLiveUpdates } from '@/services/liveUpdates'
  * @param {import('vue').Ref<string>} opts.seasonEnd
  * @param {import('vue').Ref<boolean>} opts.autoSetSeasonFromImport
  */
-export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport }) {
+export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode = 'world-tour' }) {
+  // Live events carry a `mode`; ignore any that belong to a different graph.
+  // Treat a missing mode as 'world-tour' for backward-compat with old payloads.
+  const matchesMode = (payload) => (payload?.mode ?? 'world-tour') === mode
   const points = reactive([])
   const isLoading = ref(false)
   const loadError = ref('')
@@ -73,15 +76,21 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
         onStatus(s) {
           liveStatus.value = s
         },
-        onUpsert: upsertPoint,
-        onDelete({ id }) {
+        onUpsert(record) {
+          if (!matchesMode(record)) return
+          upsertPoint(record)
+        },
+        onDelete({ id, mode: m }) {
+          if (!matchesMode({ mode: m })) return
           const idx = points.findIndex((p) => p.remoteId === id)
           if (idx !== -1) points.splice(idx, 1)
         },
-        onDeleteAll() {
+        onDeleteAll(payload) {
+          if (!matchesMode(payload)) return
           points.splice(0, points.length)
         },
-        onBulkUpsert({ records }) {
+        onBulkUpsert({ records, mode: m }) {
+          if (!matchesMode({ mode: m })) return
           if (Array.isArray(records)) records.forEach(upsertPoint)
         },
       })
@@ -106,7 +115,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
         return
       }
       isAuthenticated.value = true
-      const records = await getRecords(authHeader)
+      const records = await getRecords(authHeader, mode)
       const mapped = records.map((r) => ({
         remoteId: r.id,
         date: typeof r.date === 'string' ? r.date.slice(0, 10) : '',
@@ -131,7 +140,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     try {
       const authHeader = await getAuthorizationHeader()
       if (!authHeader) return null
-      const result = await upsertRecord(dateStr, Number(yVal), authHeader)
+      const result = await upsertRecord(dateStr, Number(yVal), authHeader, mode)
       return result.record
     } catch (error) {
       console.warn('Failed to persist point to server', error)
@@ -189,7 +198,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     points.splice(0, points.length)
     try {
       const authHeader = await getAuthorizationHeader()
-      if (authHeader) await deleteAllRecords(authHeader)
+      if (authHeader) await deleteAllRecords(authHeader, mode)
     } catch (e) {
       console.warn('Failed to clear points on server', e)
     }
@@ -209,7 +218,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
       const authHeader = await getAuthorizationHeader()
       if (authHeader) {
         const input = rows.map((r) => ({ date: r.date, winPoints: r.y }))
-        const result = await bulkUpsertRecords(input, authHeader)
+        const result = await bulkUpsertRecords(input, authHeader, mode)
         if (result.records) {
           for (const rec of result.records) {
             const dateStr = typeof rec.date === 'string' ? rec.date.slice(0, 10) : ''

--- a/packages/web/src/router/index.js
+++ b/packages/web/src/router/index.js
@@ -1,16 +1,25 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import WorldTour from '@/views/WorldTour.vue'
-// Ranked mode is disabled for now. Keep the import/route commented so it can be
-// restored quickly later.
-// import Ranked from '@/views/Ranked.vue'
+import { useFlags } from '@/composables/useFlags'
 
 const routes = [
   { path: '/', redirect: '/world-tour' },
   { path: '/world-tour', name: 'WorldTour', component: WorldTour },
-  // Ranked is disabled for now — redirect any /ranked links back to World Tour.
-  // { path: '/ranked', name: 'Ranked', component: Ranked },
-  { path: '/ranked', redirect: '/world-tour' },
+  // Ranked is gated by the `ranked` feature flag (see the guard below).
+  {
+    path: '/ranked',
+    name: 'Ranked',
+    component: () => import('@/views/Ranked.vue'),
+    meta: { flag: 'ranked' },
+  },
+  // Admin panel — only for admins.
+  {
+    path: '/admin',
+    name: 'Admin',
+    component: () => import('@/views/Admin.vue'),
+    meta: { admin: true },
+  },
 ]
 
 const router = createRouter({
@@ -21,5 +30,16 @@ const router = createRouter({
   },
 })
 
-export default router
+// Gate flag-protected and admin-only routes. Flags depend on auth, so ensure
+// they are loaded before deciding (idempotent — shares one in-flight request).
+router.beforeEach(async (to) => {
+  const { flags, isAdmin, loaded, loadFlags } = useFlags()
+  if (to.meta?.flag || to.meta?.admin) {
+    if (!loaded.value) await loadFlags()
+    if (to.meta.admin && !isAdmin.value) return '/world-tour'
+    if (to.meta.flag && !flags[to.meta.flag]) return '/world-tour'
+  }
+  return true
+})
 
+export default router

--- a/packages/web/src/services/api.js
+++ b/packages/web/src/services/api.js
@@ -14,14 +14,17 @@ function requireApiBaseUrl() {
   return BASE;
 }
 
-export async function getRecords(authorizationHeader) {
+export async function getRecords(authorizationHeader, mode = "world-tour") {
   if (!authorizationHeader) {
     throw new Error("Missing authorization header");
   }
   const apiBase = requireApiBaseUrl();
-  const response = await fetch(`${apiBase}/me/records`, {
-    headers: { Authorization: authorizationHeader },
-  });
+  const response = await fetch(
+    `${apiBase}/me/records?mode=${encodeURIComponent(mode)}`,
+    {
+      headers: { Authorization: authorizationHeader },
+    }
+  );
 
   if (!response.ok) {
     throw new Error(`Failed to fetch records: ${response.status}`);
@@ -30,7 +33,12 @@ export async function getRecords(authorizationHeader) {
   return response.json();
 }
 
-export async function upsertRecord(date, winPoints, authorizationHeader) {
+export async function upsertRecord(
+  date,
+  winPoints,
+  authorizationHeader,
+  mode = "world-tour"
+) {
   if (!authorizationHeader) {
     throw new Error("Missing authorization header");
   }
@@ -41,7 +49,7 @@ export async function upsertRecord(date, winPoints, authorizationHeader) {
       "Content-Type": "application/json",
       Authorization: authorizationHeader,
     },
-    body: JSON.stringify({ date, winPoints }),
+    body: JSON.stringify({ date, winPoints, mode }),
   });
 
   if (!response.ok) {
@@ -68,15 +76,21 @@ export async function deleteRecord(id, authorizationHeader) {
   return response.json();
 }
 
-export async function deleteAllRecords(authorizationHeader) {
+export async function deleteAllRecords(
+  authorizationHeader,
+  mode = "world-tour"
+) {
   if (!authorizationHeader) {
     throw new Error("Missing authorization header");
   }
   const apiBase = requireApiBaseUrl();
-  const response = await fetch(`${apiBase}/me/records`, {
-    method: "DELETE",
-    headers: { Authorization: authorizationHeader },
-  });
+  const response = await fetch(
+    `${apiBase}/me/records?mode=${encodeURIComponent(mode)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: authorizationHeader },
+    }
+  );
 
   if (!response.ok) {
     throw new Error(`Failed to delete records: ${response.status}`);
@@ -85,7 +99,11 @@ export async function deleteAllRecords(authorizationHeader) {
   return response.json();
 }
 
-export async function bulkUpsertRecords(records, authorizationHeader) {
+export async function bulkUpsertRecords(
+  records,
+  authorizationHeader,
+  mode = "world-tour"
+) {
   if (!authorizationHeader) {
     throw new Error("Missing authorization header");
   }
@@ -96,7 +114,7 @@ export async function bulkUpsertRecords(records, authorizationHeader) {
       "Content-Type": "application/json",
       Authorization: authorizationHeader,
     },
-    body: JSON.stringify({ records }),
+    body: JSON.stringify({ records, mode }),
   });
 
   if (!response.ok) {
@@ -158,6 +176,93 @@ export async function revokeApiKey(keyId, authorizationHeader) {
   }
 
   return response.json();
+}
+
+// ── Feature flags ───────────────────────────────────────────────────────────
+
+export async function getFlags(authorizationHeader) {
+  if (!authorizationHeader) {
+    throw new Error("Missing authorization header");
+  }
+  const apiBase = requireApiBaseUrl();
+  const response = await fetch(`${apiBase}/me/flags`, {
+    headers: { Authorization: authorizationHeader },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch flags: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function adminFetch(path, authorizationHeader, options = {}) {
+  if (!authorizationHeader) {
+    throw new Error("Missing authorization header");
+  }
+  const apiBase = requireApiBaseUrl();
+  const response = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers: {
+      Authorization: authorizationHeader,
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Admin request failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function adminListFlags(authorizationHeader) {
+  return adminFetch("/admin/flags", authorizationHeader);
+}
+
+export function adminCreateFlag(key, description, authorizationHeader) {
+  return adminFetch("/admin/flags", authorizationHeader, {
+    method: "POST",
+    body: JSON.stringify({ key, description }),
+  });
+}
+
+export function adminToggleFlag(key, enabledGlobally, authorizationHeader) {
+  return adminFetch(`/admin/flags/${encodeURIComponent(key)}`, authorizationHeader, {
+    method: "PATCH",
+    body: JSON.stringify({ enabledGlobally }),
+  });
+}
+
+export function adminSearchUsers(email, authorizationHeader) {
+  return adminFetch(
+    `/admin/users?email=${encodeURIComponent(email)}`,
+    authorizationHeader
+  );
+}
+
+export function adminSetUserOverride(userId, flagKey, enabled, authorizationHeader) {
+  return adminFetch(
+    `/admin/users/${encodeURIComponent(userId)}/flags/${encodeURIComponent(flagKey)}`,
+    authorizationHeader,
+    { method: "PUT", body: JSON.stringify({ enabled }) }
+  );
+}
+
+export function adminClearUserOverride(userId, flagKey, authorizationHeader) {
+  return adminFetch(
+    `/admin/users/${encodeURIComponent(userId)}/flags/${encodeURIComponent(flagKey)}`,
+    authorizationHeader,
+    { method: "DELETE" }
+  );
+}
+
+export function adminSetUserAdmin(userId, isAdmin, authorizationHeader) {
+  return adminFetch(`/admin/users/${encodeURIComponent(userId)}`, authorizationHeader, {
+    method: "PATCH",
+    body: JSON.stringify({ isAdmin }),
+  });
 }
 
 export async function getAuthorizationHeader() {

--- a/packages/web/src/services/liveUpdates.js
+++ b/packages/web/src/services/liveUpdates.js
@@ -64,7 +64,7 @@ export async function connectLiveUpdates(handlers) {
         handlers.onDelete?.(data);
         break;
       case "record:delete-all":
-        handlers.onDeleteAll?.();
+        handlers.onDeleteAll?.(data);
         break;
       case "record:bulk-upsert":
         handlers.onBulkUpsert?.(data);

--- a/packages/web/src/views/Admin.vue
+++ b/packages/web/src/views/Admin.vue
@@ -1,0 +1,302 @@
+<template>
+  <section v-if="isAdmin" class="admin">
+    <h1 class="admin-title">Admin · Feature Flags</h1>
+
+    <p v-if="error" class="admin-error">{{ error }}</p>
+
+    <!-- Global flags -->
+    <div class="card">
+      <h2 class="card-title">Flags</h2>
+      <table v-if="flags.length" class="flag-table">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Description</th>
+            <th>Global</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="f in flags" :key="f.key">
+            <td class="mono">{{ f.key }}</td>
+            <td>{{ f.description }}</td>
+            <td>
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  :checked="f.enabledGlobally"
+                  @change="toggleGlobal(f, $event.target.checked)"
+                />
+                <span>{{ f.enabledGlobally ? "On" : "Off" }}</span>
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p v-else class="muted">No flags yet.</p>
+
+      <form class="create-flag" @submit.prevent="createFlag">
+        <input v-model.trim="newKey" placeholder="flag key (e.g. ranked)" />
+        <input v-model.trim="newDescription" placeholder="description" />
+        <button class="btn-primary" type="submit" :disabled="!newKey">
+          Create / update
+        </button>
+      </form>
+    </div>
+
+    <!-- Per-user overrides -->
+    <div class="card">
+      <h2 class="card-title">Users</h2>
+      <form class="user-search" @submit.prevent="searchUsers">
+        <input v-model.trim="searchEmail" placeholder="search by email…" />
+        <button type="submit">Search</button>
+      </form>
+
+      <div v-for="u in users" :key="u.id" class="user-row">
+        <div class="user-head">
+          <span class="user-email">{{ u.email }}</span>
+          <label class="switch">
+            <input
+              type="checkbox"
+              :checked="u.isAdmin"
+              @change="setAdmin(u, $event.target.checked)"
+            />
+            <span>Admin</span>
+          </label>
+        </div>
+        <div class="user-flags">
+          <label v-for="f in flags" :key="f.key" class="user-flag">
+            <span class="mono">{{ f.key }}</span>
+            <select
+              :value="overrideState(u, f.key)"
+              @change="changeOverride(u, f.key, $event.target.value)"
+            >
+              <option value="inherit">Inherit ({{ f.enabledGlobally ? "on" : "off" }})</option>
+              <option value="on">Force on</option>
+              <option value="off">Force off</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <p v-if="searched && !users.length" class="muted">No users found.</p>
+    </div>
+  </section>
+</template>
+
+<script>
+export default { name: "AdminView" };
+</script>
+
+<script setup>
+import { ref, onMounted, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useFlags } from "@/composables/useFlags";
+import {
+  getAuthorizationHeader,
+  adminListFlags,
+  adminCreateFlag,
+  adminToggleFlag,
+  adminSearchUsers,
+  adminSetUserOverride,
+  adminClearUserOverride,
+  adminSetUserAdmin,
+} from "@/services/api";
+
+const flags = ref([]);
+const users = ref([]);
+const newKey = ref("");
+const newDescription = ref("");
+const searchEmail = ref("");
+const searched = ref(false);
+const error = ref("");
+
+// Defense-in-depth: the router guard already blocks non-admins, but if this
+// view is ever reached without admin rights, render nothing and bounce out.
+// (The server still enforces admin on every /admin endpoint regardless.)
+const router = useRouter();
+const { isAdmin, loaded } = useFlags();
+watch(
+  [isAdmin, loaded],
+  ([admin, isLoaded]) => {
+    if (isLoaded && !admin) router.replace("/world-tour");
+  },
+  { immediate: true }
+);
+
+async function auth() {
+  const header = await getAuthorizationHeader();
+  if (!header) throw new Error("Not authenticated");
+  return header;
+}
+
+async function run(fn) {
+  error.value = "";
+  try {
+    return await fn();
+  } catch (e) {
+    error.value = e?.message || "Request failed";
+    return null;
+  }
+}
+
+async function loadFlags() {
+  await run(async () => {
+    flags.value = await adminListFlags(await auth());
+  });
+}
+
+async function createFlag() {
+  if (!newKey.value) return;
+  await run(async () => {
+    await adminCreateFlag(newKey.value, newDescription.value, await auth());
+    newKey.value = "";
+    newDescription.value = "";
+    await loadFlags();
+  });
+}
+
+async function toggleGlobal(flag, enabled) {
+  await run(async () => {
+    const updated = await adminToggleFlag(flag.key, enabled, await auth());
+    flag.enabledGlobally = updated.enabledGlobally;
+  });
+}
+
+async function searchUsers() {
+  await run(async () => {
+    users.value = await adminSearchUsers(searchEmail.value, await auth());
+    searched.value = true;
+  });
+}
+
+function overrideState(user, flagKey) {
+  const o = (user.flagOverrides || []).find((x) => x.flagKey === flagKey);
+  if (!o) return "inherit";
+  return o.enabled ? "on" : "off";
+}
+
+async function changeOverride(user, flagKey, state) {
+  await run(async () => {
+    const header = await auth();
+    if (state === "inherit") {
+      await adminClearUserOverride(user.id, flagKey, header);
+      user.flagOverrides = (user.flagOverrides || []).filter(
+        (x) => x.flagKey !== flagKey
+      );
+    } else {
+      const enabled = state === "on";
+      await adminSetUserOverride(user.id, flagKey, enabled, header);
+      const existing = (user.flagOverrides || []).find(
+        (x) => x.flagKey === flagKey
+      );
+      if (existing) existing.enabled = enabled;
+      else (user.flagOverrides = user.flagOverrides || []).push({ flagKey, enabled });
+    }
+  });
+}
+
+async function setAdmin(user, isAdmin) {
+  await run(async () => {
+    const updated = await adminSetUserAdmin(user.id, isAdmin, await auth());
+    user.isAdmin = updated.isAdmin;
+  });
+}
+
+onMounted(() => {
+  if (isAdmin.value) loadFlags();
+});
+</script>
+
+<style scoped>
+.admin {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: left;
+  width: 100%;
+}
+.admin-title {
+  font-size: 22px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-strong);
+}
+.admin-error {
+  color: var(--danger);
+  font-weight: 700;
+}
+.card {
+  border: 1px solid color-mix(in oklab, var(--primary) 16%, var(--surface));
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 20px;
+  background: color-mix(in oklab, var(--surface) 90%, #000);
+}
+.card-title {
+  margin: 0 0 12px;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+.flag-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.flag-table th,
+.flag-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid color-mix(in oklab, var(--primary) 12%, var(--surface));
+}
+.mono {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-strong);
+}
+.muted {
+  color: var(--muted);
+}
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.create-flag,
+.user-search {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.create-flag input,
+.user-search input {
+  flex: 1 1 160px;
+  min-width: 0;
+}
+.user-row {
+  padding: 10px 0;
+  border-bottom: 1px solid color-mix(in oklab, var(--primary) 12%, var(--surface));
+}
+.user-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.user-email {
+  font-weight: 700;
+  color: var(--text-strong);
+}
+.user-flags {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.user-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+</style>

--- a/packages/web/src/views/Ranked.vue
+++ b/packages/web/src/views/Ranked.vue
@@ -6,6 +6,9 @@
           ref="graphRef"
           storageKey="ranked"
           gamemode="Ranked"
+          mode="ranked"
+          yAxisLabel="Rank Score"
+          unit="RS"
           :goalOptions="rankedThresholds"
           @win-points="onRankScore"
         />

--- a/packages/web/tests/api.spec.js
+++ b/packages/web/tests/api.spec.js
@@ -40,7 +40,7 @@ describe('api service', () => {
 
       const result = await getRecords('Bearer token123')
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8787/me/records',
+        'http://localhost:8787/me/records?mode=world-tour',
         expect.objectContaining({
           headers: expect.objectContaining({ Authorization: 'Bearer token123' }),
         })
@@ -65,7 +65,7 @@ describe('api service', () => {
         'http://localhost:8787/me/records',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ date: '2026-03-01', winPoints: 100 }),
+          body: JSON.stringify({ date: '2026-03-01', winPoints: 100, mode: 'world-tour' }),
         })
       )
     })
@@ -107,7 +107,7 @@ describe('api service', () => {
 
       const result = await deleteAllRecords('Bearer token123')
       expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8787/me/records',
+        'http://localhost:8787/me/records?mode=world-tour',
         expect.objectContaining({
           method: 'DELETE',
           headers: expect.objectContaining({ Authorization: 'Bearer token123' }),
@@ -137,7 +137,7 @@ describe('api service', () => {
         'http://localhost:8787/me/records/bulk',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ records: input }),
+          body: JSON.stringify({ records: input, mode: 'world-tour' }),
         })
       )
       expect(result).toEqual({ records: input })

--- a/packages/web/tests/modeswitcher.spec.js
+++ b/packages/web/tests/modeswitcher.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import ModeSwitcher from '@/components/ModeSwitcher.vue'
+import { useFlags } from '@/composables/useFlags'
+
+// router-link is registered globally by the router plugin, which isn't present
+// in tests. Stub it with a plain <a> that renders the segment label.
+const RouterLinkStub = {
+  name: 'RouterLink',
+  props: { to: { type: [String, Object], default: '' } },
+  setup(props, { slots }) {
+    return () => h('a', { href: String(props.to) }, slots.default?.())
+  },
+}
+
+async function render() {
+  const app = createSSRApp(ModeSwitcher)
+  app.component('RouterLink', RouterLinkStub)
+  return renderToString(app)
+}
+
+describe('ModeSwitcher admin link visibility', () => {
+  const { flags, isAdmin } = useFlags()
+
+  beforeEach(() => {
+    // Reset the shared singleton between cases.
+    for (const k of Object.keys(flags)) delete flags[k]
+    isAdmin.value = false
+  })
+
+  it('hides the Admin link when the user is not an admin', async () => {
+    isAdmin.value = false
+    const html = await render()
+    expect(html).not.toContain('/admin')
+    expect(html).not.toContain('Admin')
+    // World Tour is always present.
+    expect(html).toContain('/world-tour')
+  })
+
+  it('shows the Admin link when the user is an admin', async () => {
+    isAdmin.value = true
+    const html = await render()
+    expect(html).toContain('/admin')
+    expect(html).toContain('Admin')
+  })
+
+  it('hides the Ranked link until the ranked flag is on', async () => {
+    flags.ranked = false
+    expect(await render()).not.toContain('/ranked')
+    flags.ranked = true
+    expect(await render()).toContain('/ranked')
+  })
+})

--- a/packages/web/vitest.config.js
+++ b/packages/web/vitest.config.js
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: 'node',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ importers:
         specifier: ^7.20.7
         version: 7.20.7(@babel/core@7.28.0)
 
+  packages/landing: {}
+
   packages/server:
     dependencies:
       '@clerk/backend':
@@ -103,6 +105,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.28.0)
+      '@vitejs/plugin-vue':
+        specifier: ^5.2.4
+        version: 5.2.4(vite@5.4.19(@types/node@24.2.1)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))
       '@vue/cli-plugin-babel':
         specifier: ~5.0.0
         version: 5.0.8(@vue/cli-service@5.0.8(@vue/compiler-sfc@3.5.18)(lodash@4.17.21)(vue@3.5.18(typescript@5.9.3))(webpack-sources@3.3.3))(core-js@3.45.0)(vue@3.5.18(typescript@5.9.3))
@@ -1887,6 +1892,13 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -7337,6 +7349,11 @@ snapshots:
       eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@24.2.1)(terser@5.43.1))(vue@3.5.18(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.19(@types/node@24.2.1)(terser@5.43.1)
+      vue: 3.5.18(typescript@5.9.3)
 
   '@vitest/expect@1.6.1':
     dependencies:


### PR DESCRIPTION
## Summary
Brings **Ranked** mode online (web + server) and gates its rollout behind a new **server-driven feature-flag system with an in-app admin panel**.

Two problems were blocking Ranked:
1. **Data collision (fixed):** World Tour and Ranked both POST to `/me/records`, which upserts on `(userId, date)` only — so a Ranked entry would overwrite the World Tour entry on the same date. Records now carry a `mode` discriminator.
2. **No gating:** Ranked is now gated by a `ranked` flag that admins can toggle globally or per-user.

## Server
- `Record.mode` column (migration `0005`), keyed on `(userId, mode, date)`. Routes accept `mode` (query/body, default `world-tour`) and live broadcasts carry it. Backward-compatible: ios/android/local callers that send no `mode` keep hitting the World Tour bucket.
- `FeatureFlag` + `UserFlagOverride` tables and `User.isAdmin` (migrations `0006`/`0007`; `ranked` seeded off).
- `GET /me/flags` resolves flags per-user (**override beats global**) and returns `isAdmin`.
- Admin-only `/admin` CRUD (flags, users, per-user overrides) guarded by `requireAdmin`, with an `ADMIN_CLERK_USER_IDS` allowlist so the owner is never locked out.

## Web
- `usePointsData`/`api.js` thread `mode` through and **filter live events by mode**. `LineGraph` gains `mode`/`yAxisLabel`/`unit` props (Ranked shows "Rank Score"/"RS" and a signed "today" gain; Y stays zero-floored). Ranked view sets `mode="ranked"`.
- `useFlags` singleton (loaded on boot + on auth change). Router guards gate `/ranked` (flag) and `/admin` (admin); `ModeSwitcher` shows the Ranked/Admin links conditionally; new `Admin.vue` panel.

## Testing
- Server: 47 tests pass (incl. updated `deleteRecordIfOwner` contract).
- Web: 63 tests pass, incl. new `modeswitcher.spec.js` asserting the Admin link is hidden for non-admins and Ranked is hidden until the flag is on (adds `@vitejs/plugin-vue` for SFC tests).
- Live end-to-end verified against `wrangler dev`: migration backfill, global + per-user flag toggles, same-date collision isolation, and no-`mode` backward-compat.

## Before deploying
1. Apply migrations to remote D1: `wrangler d1 migrations apply season-sprint-dev --remote` **before** `wrangler deploy`.
2. Set `ADMIN_CLERK_USER_IDS` in `wrangler.jsonc` (currently `""`) to the owner's Clerk user id to bootstrap admin access in prod.

## Notes
- The `ranked` flag is a **visibility gate, not a write boundary** — Ranked records flow through the auth-gated `/me/records` endpoints regardless of the flag. Happy to add a server-side enforce-on-flag check if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Ranked game mode alongside World Tour with separate record tracking
  * Introduced feature flags system to enable/disable features globally and per-user
  * Added Admin panel for managing feature flags and user access controls
  * Implemented mode switcher for navigating between game modes

* **Tests**
  * Added component tests for mode switcher functionality
  * Updated API tests to verify mode-specific record operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->