### PR TITLE
chore(server): add owner to ADMIN_CLERK_USER_IDS allowlist

### DIFF
--- a/packages/server/wrangler.jsonc
+++ b/packages/server/wrangler.jsonc
@@ -31,7 +31,7 @@
     "ENVIRONMENT": "production",
     // Comma-separated Clerk user IDs that are always admins (bootstraps the
     // admin panel). Set this to the owner's Clerk user id before deploying.
-    "ADMIN_CLERK_USER_IDS": ""
+    "ADMIN_CLERK_USER_IDS": "user_32Yjrat3MFU86GHwPE2x1SwDDH5"
     // DEV_AUTH_TOKEN / DEV_USER_ID are intentionally NOT set here. The Clerk
     // bypass they enable must never exist in production. They live in the
     // gitignored .dev.vars (loaded only by `wrangler dev`), and the auth


### PR DESCRIPTION
## What
Sets `ADMIN_CLERK_USER_IDS` in `packages/server/wrangler.jsonc` to the owner's Clerk user id (previously `""`).

## Why
`isAdmin()` checks the env allowlist **before** the DB `isUserAdmin` flag (`middleware/admin.ts:23`), so an allowlisted id can never be stripped of admin via `PATCH /admin/users/:userId`. This anchors admin access in config and prevents an admin-panel lockout if the DB flag is toggled off.

## Note on secrecy
A Clerk user id (`user_...`) is an opaque identifier, not a credential — the allowlist only grants admin to a request already authenticated as that user (valid Clerk session/JWT or API key). Committing it is safe.

## Deploy
Takes effect on the live worker only after `wrangler deploy` — there is no CI auto-deploy for the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)