### PR TITLE
feat(admin): lock allowlist admins in UI + audit admin mutations

### DIFF
--- a/packages/server/src/middleware/admin.ts
+++ b/packages/server/src/middleware/admin.ts
@@ -6,7 +6,7 @@ import type { MiddlewareHandler } from "hono";
  * The allowlist guarantees the owner is always an admin regardless of DB
  * state, which prevents a bootstrap lockout for the admin panel.
  */
-function allowlist(env: Env["Bindings"]): Set<string> {
+export function allowlist(env: Env["Bindings"]): Set<string> {
   return new Set(
     (env.ADMIN_CLERK_USER_IDS ?? "")
       .split(",")

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { requireAdmin } from "../middleware/admin";
+import { requireAdmin, allowlist } from "../middleware/admin";
+import { audit } from "../utils/audit";
 
 const admin = new Hono<Env>();
 
@@ -22,6 +23,7 @@ admin.post("/flags", async (c) => {
     return c.text("Missing flag key", 400);
   }
   const flag = await c.get("db").createFlag(key, description ?? "");
+  audit(c, "flag.create", { key });
   return c.json(flag);
 });
 
@@ -32,6 +34,7 @@ admin.patch("/flags/:key", async (c) => {
     return c.text("enabledGlobally must be a boolean", 400);
   }
   const flag = await c.get("db").setFlagGlobal(key, enabledGlobally);
+  audit(c, "flag.setGlobal", { key, enabledGlobally });
   return c.json(flag);
 });
 
@@ -39,7 +42,17 @@ admin.patch("/flags/:key", async (c) => {
 
 admin.get("/users", async (c) => {
   const email = c.req.query("email") ?? "";
-  return c.json(await c.get("db").searchUsersByEmail(email));
+  const allow = allowlist(c.env);
+  const users = await c.get("db").searchUsersByEmail(email);
+  // `allowlisted` users are admins via the env allowlist regardless of the DB
+  // isAdmin flag (see isAdmin()), so the UI greys out their admin toggle.
+  // clerkUserId is only needed for that match — drop it from the response.
+  return c.json(
+    users.map(({ clerkUserId, ...u }) => ({
+      ...u,
+      allowlisted: allow.has(clerkUserId),
+    }))
+  );
 });
 
 admin.put("/users/:userId/flags/:flagKey", async (c) => {
@@ -50,6 +63,7 @@ admin.put("/users/:userId/flags/:flagKey", async (c) => {
     return c.text("enabled must be a boolean", 400);
   }
   const override = await c.get("db").setUserOverride(userId, flagKey, enabled);
+  audit(c, "user.flag.override.set", { userId, flagKey, enabled });
   return c.json(override);
 });
 
@@ -57,6 +71,7 @@ admin.delete("/users/:userId/flags/:flagKey", async (c) => {
   const userId = c.req.param("userId");
   const flagKey = c.req.param("flagKey");
   const cleared = await c.get("db").clearUserOverride(userId, flagKey);
+  audit(c, "user.flag.override.clear", { userId, flagKey, cleared });
   return c.json({ cleared });
 });
 
@@ -67,6 +82,7 @@ admin.patch("/users/:userId", async (c) => {
     return c.text("isAdmin must be a boolean", 400);
   }
   const user = await c.get("db").setUserAdmin(userId, isAdmin);
+  audit(c, "user.setAdmin", { userId, isAdmin });
   return c.json(user);
 });
 

--- a/packages/server/src/services/db.ts
+++ b/packages/server/src/services/db.ts
@@ -22,8 +22,6 @@ export class DbService {
   }
 
   async getUserRecords(clerkUserId: string, mode = "world-tour") {
-    console.warn("Getting user records for clerk user", clerkUserId);
-
     return await this.prisma.record.findMany({
       where: {
         mode,
@@ -347,6 +345,7 @@ export class DbService {
       where: { email: { contains: query } },
       select: {
         id: true,
+        clerkUserId: true,
         email: true,
         isAdmin: true,
         flagOverrides: { select: { flagKey: true, enabled: true } },

--- a/packages/server/src/utils/audit.ts
+++ b/packages/server/src/utils/audit.ts
@@ -1,0 +1,29 @@
+import type { Context } from "hono";
+import type { Env } from "../index";
+
+/**
+ * Emit a structured audit line for a privileged admin mutation.
+ *
+ * These lines are captured durably by the worker's observability logs
+ * (persist + full sampling in wrangler.jsonc) and can be filtered in the
+ * Cloudflare dashboard with `audit:true`. They record who did what to whom so
+ * privilege changes — especially admin grants/revokes — are always traceable,
+ * without needing a dedicated DB table/migration.
+ */
+export function audit(
+  c: Context<Env>,
+  action: string,
+  details: Record<string, unknown> = {}
+): void {
+  // `auth` is always set here: resolveAuth runs before any admin route.
+  const actor = c.get("auth").userId;
+  console.log(
+    JSON.stringify({
+      audit: true,
+      action,
+      actor,
+      at: new Date().toISOString(),
+      ...details,
+    })
+  );
+}

--- a/packages/web/src/views/Admin.vue
+++ b/packages/web/src/views/Admin.vue
@@ -54,13 +54,18 @@
       <div v-for="u in users" :key="u.id" class="user-row">
         <div class="user-head">
           <span class="user-email">{{ u.email }}</span>
-          <label class="switch">
+          <label
+            class="switch"
+            :class="{ 'switch-locked': u.allowlisted }"
+            :title="u.allowlisted ? 'Admin via ADMIN_CLERK_USER_IDS allowlist — set in worker config, not editable here' : ''"
+          >
             <input
               type="checkbox"
-              :checked="u.isAdmin"
+              :checked="u.isAdmin || u.allowlisted"
+              :disabled="u.allowlisted"
               @change="setAdmin(u, $event.target.checked)"
             />
-            <span>Admin</span>
+            <span>Admin{{ u.allowlisted ? " (allowlist)" : "" }}</span>
           </label>
         </div>
         <div class="user-flags">
@@ -195,6 +200,9 @@ async function changeOverride(user, flagKey, state) {
 }
 
 async function setAdmin(user, isAdmin) {
+  // Allowlisted admins are fixed in worker config; the toggle is disabled in
+  // the UI, but guard here too so it can never clear their admin status.
+  if (user.allowlisted) return;
   await run(async () => {
     const updated = await adminSetUserAdmin(user.id, isAdmin, await auth());
     user.isAdmin = updated.isAdmin;
@@ -260,6 +268,13 @@ onMounted(() => {
   align-items: center;
   gap: 6px;
   cursor: pointer;
+}
+.switch-locked {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+.switch-locked input {
+  cursor: not-allowed;
 }
 .create-flag,
 .user-search {


### PR DESCRIPTION
## What
1. **Allowlist visibility** — `GET /admin/users` now returns an `allowlisted` flag (Clerk id ∈ `ADMIN_CLERK_USER_IDS`), computed server-side. The admin checkbox for an allowlisted user is **forced-checked, disabled, dimmed**, with a tooltip; `setAdmin` is also guarded client-side. Makes the de-admin protection visible — allowlisted admins keep access regardless of the DB `isAdmin` flag (`isAdmin()` checks the allowlist first).
2. **Audit logging** — new `audit()` helper emits structured `audit:true` JSON lines (actor, target, value), captured by the worker's persisted observability logs. Instruments all mutating admin endpoints: flag create / setGlobal, per-user override set / clear, and `user.setAdmin`.

## Why no audit table
The trail rides on existing observability (`persist: true`, full sampling in `wrangler.jsonc`) — queryable by `audit:true` in the CF dashboard, with no schema migration on remote D1.

## Notes
- `clerkUserId` is selected only to compute `allowlisted` and is stripped from the response.
- No DB shape change; all 47 server tests pass, both packages lint clean.

## Deploy
Server change needs `wrangler deploy`; web change ships via the SPA deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit logging to track admin actions including flag creation, flag changes, and admin role modifications

* **Changes**
  * Allowlisted admin users are now displayed as locked/non-editable in the admin interface
  * Admin users endpoint now includes allowlist status for each user

<!-- end of auto-generated comment: release notes by coderabbit.ai -->