### PR TITLE
feat(web): mode switcher in title bar; Ranked "coming soon"

### DIFF
--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -17,7 +17,6 @@
     <ClerkLoaded>
       <SignedIn>
         <main class="container">
-          <ModeSwitcher v-if="$route.meta.modeSwitcher" />
           <router-view />
         </main>
       </SignedIn>
@@ -27,7 +26,6 @@
     </ClerkLoaded>
   </template>
   <main v-else class="container">
-    <ModeSwitcher v-if="$route.meta.modeSwitcher" />
     <router-view />
   </main>
   <footer class="site-footer" role="contentinfo">
@@ -40,7 +38,6 @@ import { watch } from "vue";
 import { useAuth } from "@clerk/vue";
 import HeaderBar from "./components/HeaderBar.vue";
 import SignInView from "./components/SignInView.vue";
-import ModeSwitcher from "./components/ModeSwitcher.vue";
 import {
   ClerkLoading,
   ClerkLoaded,
@@ -60,7 +57,6 @@ export default {
     ClerkLoaded,
     SignedIn,
     SignedOut,
-    ModeSwitcher,
   },
   setup() {
     const { loadFlags } = useFlags();

--- a/packages/web/src/components/HeaderBar.vue
+++ b/packages/web/src/components/HeaderBar.vue
@@ -1,10 +1,15 @@
 <script setup>
+import { useRoute } from "vue-router";
 import { SignedIn } from "@clerk/vue";
 import UserMenu from "@/components/UserMenu.vue";
+import ModeSwitcher from "@/components/ModeSwitcher.vue";
 import { isClerkEnabled } from "@/services/clerk";
 
 // The signed-out redirect is handled in App.vue alongside the content gate.
 const clerkEnabled = isClerkEnabled();
+// The mode switcher lives in the title bar, shown only on routes that opt in
+// via `meta.modeSwitcher` (World Tour / Ranked).
+const route = useRoute();
 </script>
 
 <template>
@@ -13,6 +18,7 @@ const clerkEnabled = isClerkEnabled();
       <img src="/logo-transparent.svg" alt="Season Sprint logo" class="brand-logo" />
       <span class="brand-text"><span class="brand-accent">THE</span>&nbsp;FINALS</span> <span class="brand-sep">|</span> <span class="brand-text">Season Sprint</span>
     </router-link>
+    <ModeSwitcher v-if="route.meta.modeSwitcher" class="header-mode" />
     <div class="user-actions">
       <template v-if="clerkEnabled">
         <SignedIn>
@@ -42,6 +48,7 @@ const clerkEnabled = isClerkEnabled();
 
 .brand {
   display: flex;
+  flex: 1 1 0;
   align-items: center;
   gap: 10px;
   font-weight: 800;
@@ -86,6 +93,32 @@ const clerkEnabled = isClerkEnabled();
 
 .brand-accent {
   color: var(--primary);
+}
+
+/* Mode switcher sits centered in the title bar; size it to its segments
+   rather than the full-width pill it uses when standalone. */
+.header-mode {
+  flex: 0 0 auto;
+}
+.header-mode :deep(.mode-switch) {
+  width: auto;
+  margin: 0;
+}
+
+.user-actions {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+@media (max-width: 640px) {
+  .header-mode :deep(.mode-seg) {
+    min-height: 32px;
+    padding: 0 10px;
+    font-size: 12px;
+  }
 }
 
 .actions {

--- a/packages/web/src/components/ModeSwitcher.vue
+++ b/packages/web/src/components/ModeSwitcher.vue
@@ -4,6 +4,17 @@
     <router-link v-if="flags.ranked" to="/ranked" class="mode-seg"
       >Ranked</router-link
     >
+    <!-- When the flag is off, Ranked is shown disabled rather than hidden, so
+         players can see it's on the way. -->
+    <span
+      v-else
+      class="mode-seg is-disabled"
+      aria-disabled="true"
+      title="Ranked is coming soon"
+    >
+      Ranked
+      <span class="mode-soon">Soon</span>
+    </span>
   </nav>
 </template>
 
@@ -58,6 +69,28 @@ const { flags } = useFlags();
   background: linear-gradient(180deg, #ffd400 0%, #ffea00 100%);
   border-color: var(--ring-strong);
   box-shadow: 0 8px 24px rgba(255, 212, 0, 0.28);
+}
+
+/* Disabled "coming soon" segment — visibly inert: muted, no pointer, and it
+   ignores the hover treatment above. */
+.mode-seg.is-disabled,
+.mode-seg.is-disabled:hover {
+  gap: 6px;
+  color: color-mix(in oklab, var(--muted) 70%, transparent);
+  background: transparent;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.mode-soon {
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+  background: color-mix(in oklab, var(--primary) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 30%, transparent);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/packages/web/tests/modeswitcher.spec.js
+++ b/packages/web/tests/modeswitcher.spec.js
@@ -43,10 +43,21 @@ describe('ModeSwitcher segments', () => {
     expect(html).not.toContain('Admin')
   })
 
-  it('hides the Ranked link until the ranked flag is on', async () => {
+  it('shows Ranked as a disabled "coming soon" segment until the flag is on', async () => {
+    // Flag off: Ranked is visible but inert — no link to /ranked, marked
+    // disabled with a "Soon" badge.
     flags.ranked = false
-    expect(await render()).not.toContain('/ranked')
+    const off = await render()
+    expect(off).not.toContain('href="/ranked"')
+    expect(off).toContain('Ranked')
+    expect(off).toContain('aria-disabled="true"')
+    expect(off).toContain('Soon')
+
+    // Flag on: Ranked becomes a real link with no disabled markers.
     flags.ranked = true
-    expect(await render()).toContain('/ranked')
+    const on = await render()
+    expect(on).toContain('href="/ranked"')
+    expect(on).not.toContain('aria-disabled="true"')
+    expect(on).not.toContain('Soon')
   })
 })


### PR DESCRIPTION
## Summary
- Move the **World Tour / Ranked** mode switcher from the page body into the **title bar** (HeaderBar), centered between the brand and the user menu. Same `route.meta.modeSwitcher` gating as before, so it only appears on World Tour / Ranked routes.
- When the `ranked` feature flag is **off**, Ranked is now shown as a **disabled "coming soon"** segment (muted, `not-allowed` cursor, `aria-disabled`, "Soon" badge) instead of being hidden — so players can see it's on the way. The router guard still redirects `/ranked` while the flag is off, so this is purely a UI affordance.

## Changes
- `HeaderBar.vue` — render `<ModeSwitcher>` in the bar; flex layout centers it; `:deep` overrides size it to its segments; small-screen tweak shrinks segments under 640px.
- `App.vue` — remove the in-body `<ModeSwitcher>` (and its import/registration).
- `ModeSwitcher.vue` — disabled `<span>` "coming soon" branch + styles when the flag is off.
- `modeswitcher.spec.js` — assert both flag states (disabled markers off, real link on).

## Testing
- `vitest run tests/modeswitcher.spec.js` — 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
