### PR TITLE
feat(web): move "Today" gain back inside the graph area

### DIFF
--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -14,7 +14,8 @@
       Sign in to save and sync your data.
     </div>
 
-    <!-- Unified status: goal/progress, today's gain + live state, required pace -->
+    <!-- Unified status: goal/progress and required pace. Today's gain + live
+         state live inside the graph area (see chart-wrapper below). -->
     <section class="lg-status">
       <div class="controls" v-if="showGoalControl">
         <GoalControls
@@ -31,7 +32,44 @@
         />
       </div>
 
-      <div class="status-row" v-if="isSeasonValid">
+      <StatsPanel
+        v-if="isSeasonValid"
+        :required-per-day-zero="requiredPerDayZero"
+        :required-per-day-from-last="requiredPerDayFromLast"
+        :is-from-last-defined="isFromLastDefined"
+      />
+    </section>
+
+    <!-- Custom content below stats -->
+    <slot name="below-stats"></slot>
+
+    <!-- Import Modal -->
+    <ImportModal
+      v-if="showImportModal"
+      :auto-set-season-from-import="autoSetSeasonFromImport"
+      :simplify-import="simplifyImport"
+      @update:autoSetSeasonFromImport="(v) => (autoSetSeasonFromImport = v)"
+      @update:simplifyImport="(v) => (simplifyImport = v)"
+      @import-data="onImportedRows"
+      @close="closeImportModal"
+    />
+
+
+    <!-- Points Modal -->
+    <PointsModal
+      v-if="showPointsModal"
+      :points="points"
+      :sorted-points-reverse="sortedPointsReverse"
+      @save-edit="onSaveEdit"
+      @remove-point="removePoint"
+      @close="closePointsModal"
+    />
+
+    <p v-if="!isSeasonValid" class="error">Season start must be before end.</p>
+
+    <div class="chart-wrapper" v-if="isSeasonValid">
+      <!-- Today's gain + live state, at the top of the graph area. -->
+      <div class="status-row">
         <div class="today-progress">
           <template v-if="todayPoint">
             <span class="today-label">Today</span>
@@ -71,43 +109,6 @@
           </svg>
         </div>
       </div>
-
-      <StatsPanel
-        v-if="isSeasonValid"
-        :required-per-day-zero="requiredPerDayZero"
-        :required-per-day-from-last="requiredPerDayFromLast"
-        :is-from-last-defined="isFromLastDefined"
-      />
-    </section>
-
-    <!-- Custom content below stats -->
-    <slot name="below-stats"></slot>
-
-    <!-- Import Modal -->
-    <ImportModal
-      v-if="showImportModal"
-      :auto-set-season-from-import="autoSetSeasonFromImport"
-      :simplify-import="simplifyImport"
-      @update:autoSetSeasonFromImport="(v) => (autoSetSeasonFromImport = v)"
-      @update:simplifyImport="(v) => (simplifyImport = v)"
-      @import-data="onImportedRows"
-      @close="closeImportModal"
-    />
-
-
-    <!-- Points Modal -->
-    <PointsModal
-      v-if="showPointsModal"
-      :points="points"
-      :sorted-points-reverse="sortedPointsReverse"
-      @save-edit="onSaveEdit"
-      @remove-point="removePoint"
-      @close="closePointsModal"
-    />
-
-    <p v-if="!isSeasonValid" class="error">Season start must be before end.</p>
-
-    <div class="chart-wrapper" v-if="isSeasonValid">
       <button
         v-if="isOutOfDefault"
         class="recenter-btn"


### PR DESCRIPTION
## Summary
Move the **"Today +X pts"** line back **inside the graph area**, where it used to live.

Previously it sat in a status row above the required/day `StatsPanel`. This relocates the row (the today gain plus the live-status indicator it shares with) to the top of `.chart-wrapper`, so it reads as an in-graph header — today's gain top-left, live indicator top-right.

## Changes
- `LineGraph.vue` — move the `.status-row` from the `.lg-status` section into `.chart-wrapper` as its first child (above the SVG). Reuses existing `.status-row` styling; no style changes needed. Updated the section comment to match.

## Testing
- `vue-cli-service lint` — clean.
- Full vitest suite — 63/63 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the layout of chart display elements to improve information hierarchy. The status information and chart wrapper are now better structured for clearer visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->