### PR TITLE
chore(local-linux): gitignore .last-rank tracker state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ pnpm-debug.log*
 
 # Local tracker state
 packages/local-linux/.last-wtp
+packages/local-linux/.last-rank
 packages/local-linux/.capture-tmp.png
 packages/local-linux/tracker.log
 packages/local-linux/tracker.log.ocr_err


### PR DESCRIPTION
`.last-rank` is runtime state written by `season-tracker.c` (see `season-tracker.c:166`) alongside `.last-wtp` — it's the Ranked-mode equivalent of the world-tour points state file. It was missed when Ranked mode was added, so it kept showing up as an untracked file.

This adds it to `.gitignore` right next to the already-ignored `.last-wtp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)