### PR TITLE
feat(local-linux): add season-launch.sh wrapper to run the watcher per session

### DIFF
--- a/packages/local-linux/season-launch.sh
+++ b/packages/local-linux/season-launch.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# season-launch.sh — Thin Steam launcher that runs season-watcher alongside
+# season-tracker. Sister to season-tracker.sh / season-watcher.c.
+#
+# season-tracker.sh deliberately does NOT start the watcher (the watcher isn't
+# part of the shipped Linux release). This wrapper adds it for local use: it
+# backgrounds the watcher, then hands off to season-tracker.sh unchanged.
+#
+# Use it in place of season-tracker.sh in your Steam launch options:
+#   /full/path/to/season-launch.sh %command%
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACKER="$SCRIPT_DIR/season-tracker.sh"
+WATCHER="$SCRIPT_DIR/season-watcher"
+WATCHER_SRC="$SCRIPT_DIR/season-watcher.c"
+
+# Mirror season-tracker.sh's prep_launcher_env so the watcher — which we fork
+# here, before the tracker runs its own prep — loads system libs cleanly under
+# Steam (which injects LD_PRELOAD / LD_LIBRARY_PATH overrides and a minimal
+# PATH). Harmless when launched outside Steam; the tracker repeats it anyway.
+prep_env() {
+  local filtered="" entry
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    [[ "$entry" != *gameoverlay* ]] && continue
+    [[ "$entry" == *ubuntu12_32* ]] && continue
+    [[ -f "$entry" ]] || continue
+    filtered+="${filtered:+:}$entry"
+  done < <(tr ':' '\n' <<< "${LD_PRELOAD:-}")
+  export LD_PRELOAD="$filtered"
+  unset LD_LIBRARY_PATH STEAM_RUNTIME_LIBRARY_PATH 2>/dev/null || true
+
+  local p
+  for p in /home/linuxbrew/.linuxbrew/bin /usr/local/bin; do
+    [[ -d "$p" ]] && [[ ":$PATH:" != *":$p:"* ]] && export PATH="$p:$PATH"
+  done
+}
+
+# Only on an actual game launch (args passed), not interactive setup.
+if [[ $# -gt 0 ]]; then
+  prep_env
+
+  # Best-effort: build the watcher once if it's missing or out of date. A
+  # failure here (e.g. no toolchain) just means no season-date alerts; never
+  # block the game.
+  if [[ -f "$WATCHER_SRC" ]] \
+     && { [[ ! -x "$WATCHER" ]] || [[ "$WATCHER_SRC" -nt "$WATCHER" ]]; }; then
+    make -C "$SCRIPT_DIR" season-watcher >/dev/null 2>&1 || true
+  fi
+
+  [[ -x "$WATCHER" ]] && "$WATCHER" >/dev/null 2>&1 &
+fi
+
+exec "$TRACKER" "$@"


### PR DESCRIPTION
## What

Adds `season-launch.sh`, a thin Steam launcher that runs `season-watcher` alongside `season-tracker` — sister to `season-tracker.sh` and `season-watcher.c`.

`season-tracker.sh` deliberately doesn't start the watcher (it's not part of the shipped release), and Steam only allows a single launch command. This wrapper bridges that: it backgrounds the watcher, then `exec`s `season-tracker.sh` unchanged.

## Usage

Point the Steam launch option at the wrapper instead of `season-tracker.sh`:

```
/full/path/to/season-launch.sh %command%
```

## Notes

- **Per-session alerts:** the watcher keeps no cross-run state, so it re-checks and re-notifies on every game session where the dates mismatch — which is the intended behavior.
- **Self-building:** best-effort `make season-watcher` if the binary is missing/stale; a build failure just means no alerts that session and never blocks the game.
- **Env prep:** mirrors `season-tracker.sh`'s `prep_launcher_env` so the watcher (forked before the tracker runs its own prep) loads system libs cleanly under Steam.
- **Lifetime:** backgrounded from the same process that becomes the tracker, so the watcher's `getppid()` guard still exits it when the session ends.
- **Setup-safe:** only launches the watcher when game args are present, so an interactive `season-tracker.sh` setup run isn't affected.
- **Not in release:** committed for local use only; `package-linux.sh` does not ship it (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)