### PR TITLE
feat(landing): SEO — sitemap, robots, canonical, social previews, JSON-LD

### DIFF
--- a/packages/landing/README.md
+++ b/packages/landing/README.md
@@ -24,6 +24,10 @@ pnpm -F landing build    # regenerate releases.json from the latest GitHub relea
 - `styles.css` — THE FINALS-inspired theme (mirrors `packages/web`)
 - `assets/logo.svg` — brand logo (copied from `packages/web/public/logo.svg`)
 - `favicon.ico`
+- `robots.txt` — allows all crawlers, points to the sitemap
+- `sitemap.xml` — lists `/` and `/downloads` for search engines
+- `google*.html` — Google Search Console site-verification file (keep
+  permanently; deleting it un-verifies the property)
 
 All app CTAs point at `https://app.seasonsprint.com`. The "Get the apps" CTA and
 the Linux/Android/Windows platform tiles point at `/downloads`.

--- a/packages/landing/downloads.html
+++ b/packages/landing/downloads.html
@@ -10,16 +10,31 @@
     />
     <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="canonical" href="https://www.seasonsprint.com/downloads" />
 
     <!-- Open Graph / social -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Download Season Sprint" />
+    <meta property="og:site_name" content="Season Sprint" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content="Download Season Sprint — desktop &amp; mobile apps" />
     <meta
       property="og:description"
       content="Grab the latest Windows, Linux, and Android builds of Season Sprint."
     />
     <meta property="og:url" content="https://www.seasonsprint.com/downloads" />
-    <meta property="og:image" content="/assets/logo.svg" />
+    <meta property="og:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
+    <meta property="og:image:width" content="1400" />
+    <meta property="og:image:height" content="758" />
+    <meta property="og:image:alt" content="Season Sprint app" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Download Season Sprint — desktop &amp; mobile apps" />
+    <meta
+      name="twitter:description"
+      content="Grab the latest Windows, Linux, and Android builds of Season Sprint."
+    />
+    <meta name="twitter:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
 
     <link rel="preconnect" href="https://api.github.com" />
     <link rel="preconnect" href="https://github.com" />

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -10,16 +10,59 @@
     />
     <link rel="icon" type="image/svg+xml" href="/assets/logo.svg" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="canonical" href="https://www.seasonsprint.com/" />
 
     <!-- Open Graph / social -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Season Sprint" />
+    <meta property="og:site_name" content="Season Sprint" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content="Season Sprint — Track your THE FINALS World Tour climb" />
     <meta
       property="og:description"
       content="Track your THE FINALS World Tour climb — log win points, watch your rank, sync everywhere."
     />
-    <meta property="og:url" content="https://www.seasonsprint.com" />
-    <meta property="og:image" content="/assets/logo.svg" />
+    <meta property="og:url" content="https://www.seasonsprint.com/" />
+    <meta property="og:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
+    <meta property="og:image:width" content="1400" />
+    <meta property="og:image:height" content="758" />
+    <meta property="og:image:alt" content="Season Sprint web app showing a THE FINALS World Tour rank chart" />
+
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Season Sprint — Track your THE FINALS World Tour climb" />
+    <meta
+      name="twitter:description"
+      content="Track your THE FINALS World Tour climb — log win points, watch your rank, sync everywhere."
+    />
+    <meta name="twitter:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Season Sprint",
+        "url": "https://www.seasonsprint.com/",
+        "description": "Season Sprint logs your THE FINALS win points, charts your run toward the next rank, and syncs it live across web, desktop, and mobile."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "Season Sprint",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Web, Windows, Linux, Android",
+        "url": "https://www.seasonsprint.com/",
+        "downloadUrl": "https://www.seasonsprint.com/downloads",
+        "description": "Track your THE FINALS World Tour climb — log win points, watch your rank, and sync it live across web, desktop, and mobile.",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        }
+      }
+    </script>
 
     <link rel="preconnect" href="https://app.seasonsprint.com" />
     <link rel="stylesheet" href="/styles.css" />

--- a/packages/landing/robots.txt
+++ b/packages/landing/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.seasonsprint.com/sitemap.xml

--- a/packages/landing/sitemap.xml
+++ b/packages/landing/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.seasonsprint.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.seasonsprint.com/downloads</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Second SEO PR (follows #116, the Search Console verification file).

## What this adds
- **`robots.txt`** — allows all crawlers, points to the sitemap.
- **`sitemap.xml`** — lists `/` and `/downloads`. Submit this in Search Console (Sitemaps → enter `sitemap.xml`) to trigger crawling/indexing.
- **Fixed `og:image`** on both pages — was `/assets/logo.svg`; SVGs don't render in Google / Twitter / Discord / Slack previews. Now an absolute URL to `shot-web.png` (1400×758) with width/height/alt.
- **`rel=canonical`** on both pages (apex vs www dedup).
- **Twitter `summary_large_image`** card tags on both pages.
- **JSON-LD** (`WebSite` + `SoftwareApplication`) on the landing page for rich-result eligibility.

## Follow-up (not in this PR)
The og:image reuses the existing `shot-web.png` screenshot — good enough to render. For a polished share card, drop a dedicated **1200×630** image at `assets/og.png` and point the `og:image`/`twitter:image` tags at it.

## Verify after deploy
- `https://www.seasonsprint.com/robots.txt`
- `https://www.seasonsprint.com/sitemap.xml`
- Paste the homepage into the [Rich Results Test](https://search.google.com/test/rich-results) and a social card validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)