### PR TITLE
fix(web): set browser tab title instead of defaulting to "web"

### DIFF
--- a/packages/web/vue.config.js
+++ b/packages/web/vue.config.js
@@ -8,6 +8,14 @@ dotenv.config({ path: path.resolve(__dirname, "../../.env") });
 
 module.exports = defineConfig({
   transpileDependencies: true,
+  // Browser tab title (and the <noscript> fallback message). Without this,
+  // html-webpack-plugin falls back to the package name ("web").
+  chainWebpack: (config) => {
+    config.plugin("html").tap((args) => {
+      args[0].title = "Season Sprint — THE FINALS World Tour tracker";
+      return args;
+    });
+  },
   configureWebpack: {
     plugins: [
       new webpack.DefinePlugin({


### PR DESCRIPTION
The Vue app's browser tab title was just **"web"** — `vue.config.js` set no title, so html-webpack-plugin fell back to the package name. That's what showed in the tab, in bookmarks, and in link shares.

Sets the title via `chainWebpack` to **"Season Sprint — THE FINALS World Tour tracker"**, which also fixes the `<noscript>` fallback message (it uses the same plugin title).

Verified with `pnpm -F web build`:
```
<title>Season Sprint — THE FINALS World Tour tracker</title>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the browser tab title to "Season Sprint — THE FINALS World Tour tracker"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->