### PR TITLE
fix(web): anchor ranked graph at placement instead of climbing from 0

### DIFF
--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -241,6 +241,13 @@
             class="proj proj-average-pace"
           />
 
+          <!-- Ranked: flat baseline from season start to the placement point -->
+          <path
+            v-if="placementBaselinePath"
+            :d="placementBaselinePath"
+            class="placement-baseline"
+          />
+
           <!-- Path -->
           <path v-if="pathD" :d="pathD" class="line" />
 
@@ -518,12 +525,27 @@ const scaledPoints = computed(() =>
   sortedPointsInSeason.value.map((p) => ({ x: scaleX(p.date), y: scaleY(p.y) }))
 );
 
-// Build path points with a synthetic baseline at season start (y=0) when
-// the first in-season point occurs after the season start. This extends the
-// blue line visually back to day zero without adding a visible point.
+// Anchor that pace/projection math is measured from. World Tour starts every
+// season at 0, so the anchor is (seasonStart, 0). Ranked starts at a placement
+// rank, so the anchor is the first recorded point — pace, projections and
+// "points earned" then measure progress *since placement*, not from 0.
+const paceBaseline = computed(() => {
+  const sp = sortedPointsInSeason.value;
+  if (props.mode === "ranked" && sp.length) {
+    return { ms: dateToMs(sp[0].date), dateStr: sp[0].date, y: Number(sp[0].y) || 0 };
+  }
+  return { ms: xDomain.value[0], dateStr: seasonStart.value, y: 0 };
+});
+
+// Build path points with a synthetic baseline at season start (y=0) when the
+// first in-season point occurs after the season start. This extends the blue
+// line visually back to day zero without adding a visible point. Ranked is
+// exempt: its line starts at the placement point, with the pre-placement span
+// drawn as a separate flat baseline (see placementBaselinePath).
 const scaledPathPoints = computed(() => {
   const sp = scaledPoints.value;
   if (!sp.length) return sp;
+  if (props.mode === "ranked") return sp;
   const seasonStartMs = dateToMs(seasonStart.value);
   const firstMs = dateToMs(sortedPointsInSeason.value[0].date);
   if (isFinite(seasonStartMs) && isFinite(firstMs) && firstMs > seasonStartMs) {
@@ -534,6 +556,21 @@ const scaledPathPoints = computed(() => {
 });
 
 const pathD = computed(() => buildPathD(scaledPathPoints.value));
+
+// Ranked only: a flat line from season start across to the placement point at
+// the placement RS, making it clear the climb begins at placement (not 0).
+const placementBaselinePath = computed(() => {
+  if (props.mode !== "ranked") return "";
+  const sp = sortedPointsInSeason.value;
+  if (!sp.length) return "";
+  const seasonStartMs = dateToMs(seasonStart.value);
+  const firstMs = dateToMs(sp[0].date);
+  if (!(isFinite(seasonStartMs) && isFinite(firstMs) && firstMs > seasonStartMs)) return "";
+  const x1 = scaleX(seasonStart.value);
+  const x2 = scaleX(sp[0].date);
+  const y = scaleY(Number(sp[0].y) || 0);
+  return `M${x1},${y} L${x2},${y}`;
+});
 
 // Rank info based on goalOptions thresholds
 const goalOptionsRef = computed(() => props.goalOptions);
@@ -554,8 +591,8 @@ const {
 // Projection paths
 const pathGoalFromZero = computed(() => {
   if (!isSeasonValid.value) return "";
-  const x1 = scaleX(seasonStart.value);
-  const y1 = scaleY(0);
+  const x1 = scaleX(paceBaseline.value.dateStr);
+  const y1 = scaleY(paceBaseline.value.y);
   const x2 = scaleX(seasonEnd.value);
   const y2 = scaleY(goalWinPoints.value);
   return `M${x1},${y1} L${x2},${y2}`;
@@ -582,7 +619,8 @@ const pathAveragePace = computed(() => {
     xDomain.value[0],
     xDomain.value[1],
     scaleX,
-    scaleY
+    scaleY,
+    paceBaseline.value
   );
 });
 
@@ -593,7 +631,8 @@ const pathDeviationWedge = computed(() => {
     xDomain.value[0],
     xDomain.value[1],
     scaleX,
-    scaleY
+    scaleY,
+    paceBaseline.value
   );
 });
 
@@ -606,7 +645,7 @@ const paceRequiredData = computed(() => {
 });
 
 const paceEarnedData = computed(() =>
-  buildPointsEarnedData(sortedPointsInSeason.value)
+  buildPointsEarnedData(sortedPointsInSeason.value, paceBaseline.value.y)
 );
 
 const paceYDomain = computed(() => {
@@ -1140,6 +1179,14 @@ svg.nav-disabled {
   filter: drop-shadow(
     0 0 6px color-mix(in oklab, var(--accent) 60%, transparent)
   );
+}
+
+.placement-baseline {
+  fill: none;
+  stroke: color-mix(in oklab, var(--accent) 55%, #9ca3af);
+  stroke-width: 2;
+  stroke-dasharray: 4 5;
+  opacity: 0.55;
 }
 
 .proj {

--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -385,6 +385,7 @@ import {
   buildDeviationWedgePath,
   buildRequiredPaceData,
   buildPointsEarnedData,
+  requiredPerDayFromBaseline,
 } from "@/utils/chart";
 import { loadSeasonJson } from "@/utils/season";
 import { buildRankBands } from "@/utils/rankColors";
@@ -674,16 +675,12 @@ const paceRequiredPath = computed(() => buildPathD(scaledPaceRequired.value));
 const paceEarnedPath = computed(() => buildPathD(scaledPaceEarned.value));
 
 // Pace stats
-const daysInSeason = computed(() => {
-  if (!isSeasonValid.value) return 1;
-  const [min, max] = xDomain.value;
-  const days = (max - min) / MS_PER_DAY;
-  return Math.max(1, Math.round(days));
-});
-
 const requiredPerDayZero = computed(() => {
-  // slope of the zero→goal projection per day
-  return goalWinPoints.value / daysInSeason.value;
+  // Slope of the baseline→goal projection per day, matching pathGoalFromZero.
+  // World Tour anchors at (seasonStart, 0) → goal over the whole season. Ranked
+  // anchors at the placement point → (goal - placement) over days since placement.
+  const { ms, y } = paceBaseline.value;
+  return requiredPerDayFromBaseline(goalWinPoints.value, y, ms, xDomain.value[1]);
 });
 
 const isFromLastDefined = computed(

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -52,7 +52,10 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     const prev = [...sortedPoints.value]
       .filter((p) => p.date < todayStr)
       .pop()
-    const prevY = prev ? prev.y : 0
+    // In ranked the first point is the placement rank, not earned progress, so
+    // when there's no prior point treat the placement as the baseline (0 gain)
+    // rather than a jump from 0. World Tour genuinely starts at 0.
+    const prevY = prev ? prev.y : (mode === 'ranked' ? todayPoint.value.y : 0)
     return Math.round((todayPoint.value.y - prevY) * 100) / 100
   })
 

--- a/packages/web/src/utils/chart.js
+++ b/packages/web/src/utils/chart.js
@@ -51,19 +51,26 @@ export function buildPathD(pointsScaled) {
   return pointsScaled.reduce((d, p, i) => d + `${i === 0 ? 'M' : ' L'}${p.x},${p.y}`, '')
 }
 
-export function buildAveragePacePath(pointsInSeason, seasonStartMs, seasonEndMs, scaleX, scaleY) {
+// `baseline` is the anchor the pace line is drawn from: { ms, y }. For World
+// Tour it is season start at 0 points; for ranked it is the placement point
+// (first recorded point) so the line measures gains *since placement* rather
+// than from 0. Defaults preserve the original season-start/zero behavior.
+export function buildAveragePacePath(pointsInSeason, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline = { ms: seasonStartMs, y: 0 }) {
   if (!pointsInSeason.length) return ''
 
-  // Convert points to (dayOffset, y) pairs, including an implicit origin (0, 0)
+  const baseMs = baseline?.ms ?? seasonStartMs
+  const baseY = baseline?.y ?? 0
+
+  // Convert points to (dayOffset, yOffset) pairs relative to the baseline
+  // anchor, plus the anchor itself at the origin (0, 0).
   const pts = [{ x: 0, y: 0 }]
   for (const p of pointsInSeason) {
-    const day = (dateToMs(p.date) - seasonStartMs) / MS_PER_DAY
-    pts.push({ x: day, y: p.y })
+    const day = (dateToMs(p.date) - baseMs) / MS_PER_DAY
+    pts.push({ x: day, y: p.y - baseY })
   }
 
   // Through-origin least-squares regression: y = slope * x
-  // Anchors the line at (0, 0) = season start with 0 points.
-  // slope = Σ(x·y) / Σ(x²)
+  // Anchors the line at the baseline. slope = Σ(x·y) / Σ(x²)
   let sumXX = 0, sumXY = 0
   for (const p of pts) {
     sumXX += p.x * p.x
@@ -72,33 +79,31 @@ export function buildAveragePacePath(pointsInSeason, seasonStartMs, seasonEndMs,
   if (sumXX === 0) return ''
 
   const slope = sumXY / sumXX
-  const totalDays = (seasonEndMs - seasonStartMs) / MS_PER_DAY
-  const yAtEnd = slope * totalDays
+  const totalDays = (seasonEndMs - baseMs) / MS_PER_DAY
+  const yAtEnd = baseY + slope * totalDays
 
-  console.log('[avg-pace]', {
-    points: pts,
-    slope: slope.toFixed(2) + ' pts/day',
-    yAtEnd,
-    totalDays,
-  })
-
-  const startDateStr = msToDateInput(seasonStartMs)
+  const startDateStr = msToDateInput(baseMs)
   const endDateStr = msToDateInput(seasonEndMs)
   const x1 = scaleX(startDateStr)
-  const y1 = scaleY(0)
+  const y1 = scaleY(baseY)
   const x2 = scaleX(endDateStr)
   const y2 = scaleY(yAtEnd)
   return `M${x1},${y1} L${x2},${y2}`
 }
 
-export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEndMs, scaleX, scaleY) {
+// See buildAveragePacePath for `baseline`. The wedge is anchored at the same
+// point so its uncertainty band fans out from the baseline, not from 0.
+export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline = { ms: seasonStartMs, y: 0 }) {
   if (pointsInSeason.length < 2) return ''
 
-  // Convert to (dayOffset, y) with implicit origin
+  const baseMs = baseline?.ms ?? seasonStartMs
+  const baseY = baseline?.y ?? 0
+
+  // Convert to (dayOffset, yOffset) relative to the baseline, plus origin
   const pts = [{ x: 0, y: 0 }]
   for (const p of pointsInSeason) {
-    const day = (dateToMs(p.date) - seasonStartMs) / MS_PER_DAY
-    pts.push({ x: day, y: p.y })
+    const day = (dateToMs(p.date) - baseMs) / MS_PER_DAY
+    pts.push({ x: day, y: p.y - baseY })
   }
 
   // Through-origin regression: slope = Σ(x·y) / Σ(x²)
@@ -124,8 +129,8 @@ export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEnd
   // Approximates t-distribution critical value for small samples.
   const tFactor = n <= 2 ? 4.303 : n <= 3 ? 3.182 : n <= 5 ? 2.776 : n <= 10 ? 2.228 : 1.96
 
-  const totalDays = (seasonEndMs - seasonStartMs) / MS_PER_DAY
-  const startDateStr = msToDateInput(seasonStartMs)
+  const totalDays = (seasonEndMs - baseMs) / MS_PER_DAY
+  const startDateStr = msToDateInput(baseMs)
   const endDateStr = msToDateInput(seasonEndMs)
   const x1 = scaleX(startDateStr)
   const x2 = scaleX(endDateStr)
@@ -138,11 +143,11 @@ export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEnd
   const projectedMag = Math.abs(projected)
   const minDeviation = n <= 3 ? projectedMag * 0.3 : n <= 6 ? projectedMag * 0.15 : projectedMag * 0.05
   const deviation = Math.max(stdDev * tFactor, minDeviation)
-  const yUpperEnd = slope * totalDays + deviation
-  const yLowerEnd = Math.max(0, slope * totalDays - deviation)
+  const yUpperEnd = baseY + slope * totalDays + deviation
+  const yLowerEnd = Math.max(0, baseY + slope * totalDays - deviation)
 
-  // Polygon: origin → upper end → lower end → origin → close
-  const y0 = scaleY(0)
+  // Polygon: baseline anchor → upper end → lower end → anchor → close
+  const y0 = scaleY(baseY)
   const yU = scaleY(yUpperEnd)
   const yL = scaleY(yLowerEnd)
 
@@ -159,8 +164,11 @@ export function buildRequiredPaceData(sortedPoints, goalWinPoints, seasonEndMs) 
   return out
 }
 
-export function buildPointsEarnedData(sortedPoints) {
-  let prev = 0
+// `baselineY` is the value the first point is measured against. Defaults to 0
+// (World Tour starts at 0). In ranked, pass the placement value so the
+// placement day shows 0 earned rather than the full placement total.
+export function buildPointsEarnedData(sortedPoints, baselineY = 0) {
+  let prev = baselineY
   return sortedPoints.map(p => {
     const delta = p.y - prev
     prev = p.y

--- a/packages/web/src/utils/chart.js
+++ b/packages/web/src/utils/chart.js
@@ -154,6 +154,14 @@ export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEnd
   return `M${x1},${y0} L${x2},${yU} L${x2},${yL} L${x1},${y0} Z`
 }
 
+// Required points/day to reach the goal from a baseline anchor by season end,
+// i.e. the slope of the baseline→goal projection. World Tour anchors at
+// (seasonStart, 0); ranked anchors at the placement point.
+export function requiredPerDayFromBaseline(goalWinPoints, baselineY, baselineMs, seasonEndMs) {
+  const days = Math.max(1, Math.round((seasonEndMs - baselineMs) / MS_PER_DAY))
+  return (goalWinPoints - baselineY) / days
+}
+
 export function buildRequiredPaceData(sortedPoints, goalWinPoints, seasonEndMs) {
   const out = []
   for (const p of sortedPoints) {

--- a/packages/web/tests/chart.spec.js
+++ b/packages/web/tests/chart.spec.js
@@ -262,6 +262,73 @@ describe('buildPointsEarnedData', () => {
       { date: '2025-01-02', y: -10 },
     ])
   })
+
+  it('measures the first point against a non-zero baseline (ranked placement)', () => {
+    // Placement at 20000; the placement day earns nothing, gains accrue after.
+    const points = [
+      { date: '2025-01-01', y: 20000 }, // placement
+      { date: '2025-01-03', y: 20500 },
+      { date: '2025-01-05', y: 21200 },
+    ]
+    const result = buildPointsEarnedData(points, 20000)
+    expect(result).toEqual([
+      { date: '2025-01-01', y: 0 },
+      { date: '2025-01-03', y: 500 },
+      { date: '2025-01-05', y: 700 },
+    ])
+  })
+})
+
+describe('ranked placement baseline', () => {
+  const seasonStart = '2025-01-01'
+  const seasonEnd = '2025-01-11'
+  const seasonStartMs = dateToMs(seasonStart)
+  const seasonEndMs = dateToMs(seasonEnd)
+  const xDomain = calcXDomain(seasonStart, seasonEnd, new Date(2025, 0, 1))
+  const scaleX = scaleXFactory(xDomain, width, padding)
+  // Wide y-domain to cover ranked RS values
+  const scaleY = scaleYFactory([0, 30000], height, padding)
+
+  it('average pace line is anchored at the placement point, not (start, 0)', () => {
+    // Placement 20000 on day 2, then +500/day. Baseline = placement point.
+    const points = [
+      { date: '2025-01-03', y: 20000 }, // day 2 — placement
+      { date: '2025-01-05', y: 21000 }, // day 4
+      { date: '2025-01-07', y: 22000 }, // day 6
+    ]
+    const baseline = { ms: dateToMs('2025-01-03'), y: 20000 }
+    const result = buildAveragePacePath(points, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    // Line should START at the placement point (day 2, 20000), not (start, 0)
+    const x1 = scaleX('2025-01-03')
+    const y1 = scaleY(20000)
+    expect(result.startsWith(`M${x1},${y1}`)).toBe(true)
+    // ...and NOT at season start / zero
+    expect(result.startsWith(`M${scaleX(seasonStart)},${scaleY(0)}`)).toBe(false)
+  })
+
+  it('without a baseline it still anchors at (start, 0) — World Tour unchanged', () => {
+    const points = [
+      { date: '2025-01-03', y: 20000 },
+      { date: '2025-01-05', y: 21000 },
+    ]
+    const result = buildAveragePacePath(points, seasonStartMs, seasonEndMs, scaleX, scaleY)
+    expect(result.startsWith(`M${scaleX(seasonStart)},${scaleY(0)}`)).toBe(true)
+  })
+
+  it('deviation wedge fans out from the placement point', () => {
+    const points = [
+      { date: '2025-01-03', y: 20000 },
+      { date: '2025-01-05', y: 21000 },
+      { date: '2025-01-07', y: 22000 },
+    ]
+    const baseline = { ms: dateToMs('2025-01-03'), y: 20000 }
+    const result = buildDeviationWedgePath(points, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    // Both wedge edges meet at the placement point (day 2, 20000)
+    const x1 = scaleX('2025-01-03')
+    const y0 = scaleY(20000)
+    expect(result.startsWith(`M${x1},${y0}`)).toBe(true)
+    expect(result.trimEnd().endsWith(`L${x1},${y0} Z`)).toBe(true)
+  })
 })
 
 describe('buildRequiredPaceData', () => {

--- a/packages/web/tests/chart.spec.js
+++ b/packages/web/tests/chart.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calcXDomain, calcYDomain, scaleXFactory, scaleYFactory, buildPathD, buildXTicks, buildAveragePacePath, buildDeviationWedgePath, buildPointsEarnedData, buildRequiredPaceData } from '@/utils/chart'
+import { calcXDomain, calcYDomain, scaleXFactory, scaleYFactory, buildPathD, buildXTicks, buildAveragePacePath, buildDeviationWedgePath, buildPointsEarnedData, buildRequiredPaceData, requiredPerDayFromBaseline } from '@/utils/chart'
 import { dateToMs } from '@/utils/date'
 
 const width = 600
@@ -328,6 +328,25 @@ describe('ranked placement baseline', () => {
     const y0 = scaleY(20000)
     expect(result.startsWith(`M${x1},${y0}`)).toBe(true)
     expect(result.trimEnd().endsWith(`L${x1},${y0} Z`)).toBe(true)
+  })
+
+  it('required/day from baseline matches the placement→goal slope (and 0→goal for World Tour)', () => {
+    const goal = 30000
+    // World Tour: baseline (seasonStart, 0) over the 10-day season → goal / 10
+    const wt = requiredPerDayFromBaseline(goal, 0, seasonStartMs, seasonEndMs)
+    expect(wt).toBe(goal / 10)
+
+    // Ranked: placement 20000 on day 2 → (30000 - 20000) over the 8 days left
+    const placementMs = dateToMs('2025-01-03')
+    const ranked = requiredPerDayFromBaseline(goal, 20000, placementMs, seasonEndMs)
+    expect(ranked).toBe((30000 - 20000) / 8)
+  })
+
+  it('required/day clamps the day count to at least 1', () => {
+    // Baseline at season end → 0 days left, must not divide by zero
+    const result = requiredPerDayFromBaseline(30000, 20000, seasonEndMs, seasonEndMs)
+    expect(result).toBe(30000 - 20000)
+    expect(Number.isFinite(result)).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Problem
In **Ranked**, players don't start a season at 0 — placement rounds drop them somewhere up to Gold 4. The graph assumed a 0 start everywhere, so it:
- drew the blue line climbing from **0 → first point** (a fake jump), and
- counted the placement as a giant **day-1 gain** in pace/"points earned" and `todayGain`, and
- anchored the average-pace regression + deviation wedge at `(0,0)`, inflating projections.

## Fix
Ranked mode now treats the **first recorded point as the placement baseline** (auto — no new UI). World Tour genuinely starts at 0 and is **unchanged**.

- **Line starts at placement.** A flat dotted baseline is drawn from season start across to the placement point so it's visually clear the climb begins there, not at 0 (`placementBaselinePath`).
- **Pace math measures progress since placement.** `buildAveragePacePath`, `buildDeviationWedgePath`, and `buildPointsEarnedData` gained an optional `baseline` arg; the goal-from-zero projection and pace data pass the placement anchor in ranked. Defaults preserve the old `(season-start, 0)` behavior, so World Tour math is byte-for-byte identical.
- **`todayGain`** no longer reports the placement value as a same-day gain in ranked.
- Removed a stray `console.log('[avg-pace]', …)` debug line.

## How it's decided
- *Placement source:* first recorded ranked point (automatic).
- *Pre-placement:* flat dotted baseline from season start to the placement point.

## Verification
- `pnpm -F web test` → **67 passed** (added baseline coverage for pace line, deviation wedge, points-earned; existing tests unchanged).
- `pnpm -F web lint` → clean. `pnpm -F web build` → succeeds.

> Worth a quick visual check on the live Ranked view after deploy (it's behind the `ranked` feature flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)