### PR TITLE
fix(web): don't double-count the ranked placement point in pace/wedge math

### DIFF
--- a/packages/web/src/utils/chart.js
+++ b/packages/web/src/utils/chart.js
@@ -62,11 +62,15 @@ export function buildAveragePacePath(pointsInSeason, seasonStartMs, seasonEndMs,
   const baseY = baseline?.y ?? 0
 
   // Convert points to (dayOffset, yOffset) pairs relative to the baseline
-  // anchor, plus the anchor itself at the origin (0, 0).
+  // anchor, plus the anchor itself at the origin (0, 0). A point that coincides
+  // with the anchor (e.g. the ranked placement point) is skipped — the synthetic
+  // origin already represents it, so it must not be counted twice.
   const pts = [{ x: 0, y: 0 }]
   for (const p of pointsInSeason) {
     const day = (dateToMs(p.date) - baseMs) / MS_PER_DAY
-    pts.push({ x: day, y: p.y - baseY })
+    const yOff = p.y - baseY
+    if (day === 0 && yOff === 0) continue
+    pts.push({ x: day, y: yOff })
   }
 
   // Through-origin least-squares regression: y = slope * x
@@ -99,11 +103,16 @@ export function buildDeviationWedgePath(pointsInSeason, seasonStartMs, seasonEnd
   const baseMs = baseline?.ms ?? seasonStartMs
   const baseY = baseline?.y ?? 0
 
-  // Convert to (dayOffset, yOffset) relative to the baseline, plus origin
+  // Convert to (dayOffset, yOffset) relative to the baseline, plus origin. The
+  // point coinciding with the anchor (e.g. the ranked placement point) is
+  // skipped: it is the regression anchor, not a variance-bearing sample, so
+  // counting it would inflate the sample size and shrink the wedge.
   const pts = [{ x: 0, y: 0 }]
   for (const p of pointsInSeason) {
     const day = (dateToMs(p.date) - baseMs) / MS_PER_DAY
-    pts.push({ x: day, y: p.y - baseY })
+    const yOff = p.y - baseY
+    if (day === 0 && yOff === 0) continue
+    pts.push({ x: day, y: yOff })
   }
 
   // Through-origin regression: slope = Σ(x·y) / Σ(x²)

--- a/packages/web/tests/chart.spec.js
+++ b/packages/web/tests/chart.spec.js
@@ -330,6 +330,30 @@ describe('ranked placement baseline', () => {
     expect(result.trimEnd().endsWith(`L${x1},${y0} Z`)).toBe(true)
   })
 
+  it('treats the placement point as the anchor only, not a counted sample', () => {
+    // The placement point coincides with the baseline. Whether or not it appears
+    // in the input, the wedge must be identical — it's the anchor, not a sample.
+    // (If it were double-counted, the extra zero-residual point would inflate n
+    // and shrink the band.)
+    const baseline = { ms: dateToMs('2025-01-03'), y: 20000 }
+    const withPlacement = [
+      { date: '2025-01-03', y: 20000 }, // placement == baseline
+      { date: '2025-01-05', y: 21000 },
+      { date: '2025-01-07', y: 22000 },
+    ]
+    const withoutPlacement = [
+      { date: '2025-01-05', y: 21000 },
+      { date: '2025-01-07', y: 22000 },
+    ]
+    const a = buildDeviationWedgePath(withPlacement, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    const b = buildDeviationWedgePath(withoutPlacement, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    expect(a).toBe(b)
+    // Same invariance holds for the average-pace line.
+    const pa = buildAveragePacePath(withPlacement, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    const pb = buildAveragePacePath(withoutPlacement, seasonStartMs, seasonEndMs, scaleX, scaleY, baseline)
+    expect(pa).toBe(pb)
+  })
+
   it('required/day from baseline matches the placement→goal slope (and 0→goal for World Tour)', () => {
     const goal = 30000
     // World Tour: baseline (seasonStart, 0) over the 10-day season → goal / 10


### PR DESCRIPTION
Follow-up to #119 (this commit was pushed just after #119 merged, so it didn't ride along).

## Problem
In ranked, the placement point is the regression **anchor**, but it was also being counted as a regular data point: the helpers prepend a synthetic origin `(0,0)`, then the placement (which shifts to exactly `(0,0)` relative to the baseline) was pushed in again.
- **Average pace line:** harmless duplicate `(0,0)` (adds 0 to the sums).
- **Deviation wedge:** the duplicate inflated the sample size `n`, which shrank the confidence band (smaller `tFactor` / `minDeviation` tier).

## Fix
Skip any point that coincides exactly with the baseline anchor (`day === 0 && yOff === 0`) — the synthetic origin already represents it. Applied to both helpers so they stay symmetric.

## Test
Asserts the wedge **and** pace output are identical whether or not the placement point is present in the input — the clean proof it's treated as anchor-only, not a counted sample.

Verified: `pnpm -F web test` → 70 passed, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)