### PR TITLE
docs: add root README and READMEs for ios, local-linux, local-win

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# Season Sprint
+
+Track your season progress in **THE FINALS**. Season Sprint records your World
+Tour points (and Ranked score) over the course of a season and shows how you're
+pacing toward a goal — rank-threshold overlays, projection lines, and a
+required-vs-earned pace graph — with your data synced live across web, iOS, and
+Android. Optional desktop trackers (Linux/Windows) read your score straight off
+the in-game screen via OCR and push it automatically while you play.
+
+Live at **https://app.seasonsprint.com** (marketing site:
+**https://www.seasonsprint.com**).
+
+## Monorepo layout
+
+pnpm workspace; every package lives under `packages/*` and is developed and
+deployed independently.
+
+| Package | What it is | Stack |
+|---------|-----------|-------|
+| [`web`](packages/web) | The main app (the SPA at `app.seasonsprint.com`) | Vue 3 (Vue CLI), Vitest |
+| [`server`](packages/server) | The backend API + realtime + persistence | Cloudflare Worker, Hono, D1 (SQLite), Clerk, Durable Objects |
+| [`ios`](packages/ios) | Native iOS client | SwiftUI, SwiftPM, built with xtool |
+| [`android`](packages/android) | Native Android client | Kotlin + Jetpack Compose |
+| [`landing`](packages/landing) | Marketing + downloads site (`www`/apex) | Static HTML/CSS/JS |
+| [`local-linux`](packages/local-linux) | Local desktop tracker that OCRs the in-game score | C + Python (EasyOCR), X11 |
+| [`local-win`](packages/local-win) | Windows desktop tracker (counterpart to `local-linux`) | Python (EasyOCR), Inno Setup installer |
+
+## Architecture
+
+All clients talk to the same backend — there is no build-time coupling between
+them:
+
+```
+ web  ┐
+ ios  ┤                         ┌── D1 (SQLite)        records
+android┤── HTTPS REST ─────────►│── Clerk              auth (session JWT / API keys)
+local-linux ┤   + live WebSocket │── Durable Object     per-user live updates
+local-win  ┘                     └  (Hibernation API)
+                Cloudflare Worker (packages/server, Hono)
+```
+
+- **Auth** is Clerk. Web/iOS/Android sign in with Clerk and send a session JWT;
+  the desktop trackers authenticate with a personal API key (`sk_…`) minted in
+  the web app.
+- **Records** are cumulative win-points per day, stored in D1, keyed per user
+  and game mode (`world-tour` / `ranked`).
+- **Live updates** are pushed over a per-user WebSocket backed by a Durable
+  Object (Hibernation API), so an edit on one device shows up on the others
+  immediately.
+- **Domain logic** (rank thresholds + pace/projection math) is implemented once
+  per client and kept in sync — see `useChartGeometry.js`/`useRankInfo.js` (web),
+  `Domain/Rank.swift`+`Domain/Pace.swift` (iOS), and the ported Kotlin `Rank`/
+  `Pace` (Android), all sharing the `worldTourRanks.json` thresholds.
+
+## Getting started
+
+Requires [pnpm](https://pnpm.io) (see `packageManager` in `package.json` for the
+pinned version) and Node (see `.nvmrc`).
+
+```bash
+pnpm install                 # install all workspace deps
+
+pnpm -F web run serve        # web app dev server (hot reload)
+pnpm -F server run dev       # backend on http://localhost:8787
+pnpm -F landing dev          # landing site on http://localhost:3000
+```
+
+Run any package script from the repo root with `pnpm -F <package> run <script>`
+(alias `-F` = `--filter`). `pnpm dev` runs every package's `dev` script in
+parallel.
+
+The native and desktop-tracker packages have their own toolchains — see each
+package README:
+
+- iOS — [`packages/ios/README.md`](packages/ios/README.md)
+- Android — [`packages/android/README.md`](packages/android/README.md)
+- Linux tracker — [`packages/local-linux/README.md`](packages/local-linux/README.md)
+- Windows tracker — [`packages/local-win/README.md`](packages/local-win/README.md)
+
+## Deploy & release
+
+- **Web** and **landing** deploy on Render; **server** deploys to Cloudflare
+  Workers (`pnpm -F server run deploy`). The www/app domain split is documented
+  in [`packages/landing/README.md`](packages/landing/README.md).
+- **Desktop trackers** ship via GitHub Releases. `.github/workflows/build-linux.yml`
+  builds the Linux tarball from `packages/local-linux` and
+  `.github/workflows/build-windows-installer.yml` builds the Windows installer
+  from `packages/local-win/installer`. The downloads page picks assets up
+  automatically by extension.
+
+See [`WARP.md`](WARP.md) for additional command reference.

--- a/packages/ios/README.md
+++ b/packages/ios/README.md
@@ -1,0 +1,56 @@
+# Season Sprint — iOS
+
+Native iOS client for Season Sprint, mirroring the Android app
+(`packages/android`) against the same Cloudflare Worker backend
+(`packages/server`). No server changes are required.
+
+## Stack
+- **SwiftUI** + Apple's **Charts** framework (single source of truth via
+  `@Observable` stores), iOS 17+, Swift tools 6.0
+- **Clerk iOS SDK** (`clerk-ios`, `ClerkKit` product) — email-code (OTP) auth,
+  session JWTs
+- **URLSession** REST client + a live **WebSocket** stream
+- Domain logic (`Rank`/`Pace`) ported from the web app and shared with Android,
+  driven by the same `worldTourRanks.json` thresholds
+- Built with **[xtool](https://github.com/xtool-org/xtool)** (SwiftPM-based, no
+  `.xcodeproj`) — so the app can be built from Linux as well as macOS
+
+## App layout (`Sources/SeasonSprint/`)
+- **`Views/`** — all SwiftUI screens. `ContentView` is the auth gate;
+  `MainTabView` hosts the Graph / Log / Details tabs + `SettingsSheet`.
+  `PointsChartView` is the hero chart (rank overlay, goal + pace projections,
+  deviation wedge); `PaceChartView` is the required/earned pace sub-graph.
+- **`State/`** — `DashboardStore` (loads records, merges live events, derives
+  rank/pace/goal, handles writes) and `AppSettings` (UserDefaults-backed toggles).
+- **`Networking/`** — `APIClient` (REST: records, seasons, stream token),
+  `SSEClient` (WebSocket with auto-reconnect + heartbeat; name is legacy),
+  `Models` (Codable DTOs).
+- **`Domain/`** — `Rank.swift` (threshold table + rank computation) and
+  `Pace.swift` (required pace, average-pace projection, deviation wedge).
+- **Root** — `SeasonSprintApp` (`@main`, Clerk init), `Config.swift` (server URL
+  + Clerk publishable key), `Diagnostics`.
+
+## Prerequisites
+- **xtool** installed and on `PATH` (see the
+  [xtool docs](https://github.com/xtool-org/xtool) for setup, including device
+  pairing / signing).
+- A real **Clerk** account to sign in — the verification code arrives by email.
+
+## Build & run
+This is an xtool project (`xtool.yml` + `Package.swift`), not an Xcode project.
+The typical loop:
+
+```bash
+cd packages/ios
+xtool dev        # build and run on the paired device / simulator
+xtool build      # produce an installable build
+```
+
+> The app links **`ClerkKit` only**, not `ClerkKitUI` — `ClerkKitUI`'s
+> `#Preview` macros can't cross-compile under xtool, so the sign-in UI
+> (`SignInView`) is built by hand against the email-code flow.
+
+## Configuration
+`Config.swift` holds the server URL (the deployed Cloudflare Worker) and the
+live Clerk publishable key — the same values used by `packages/web` and
+`packages/android`. Changing them requires a recompile.

--- a/packages/local-linux/README.md
+++ b/packages/local-linux/README.md
@@ -1,0 +1,104 @@
+# Season Sprint — Linux tracker
+
+A local desktop tracker for Linux. It watches THE FINALS' end-of-match score
+screen, OCRs your **World Tour points** / **Ranked score** straight off the
+display, and pushes changes to your Season Sprint account automatically while
+you play — no manual entry. This is the package the published
+`season-sprint-linux.tar.gz` release is built from.
+
+## How it works
+A small C program drives the hot path; a Python sidecar does the heavy OCR:
+
+1. **Capture** — `season-tracker.c` grabs the screen via X11 shared memory
+   (`XShmGetImage`, sub-millisecond).
+2. **Gate** — it runs the Tesseract C API on a small corner region to cheaply
+   detect when the score screen is actually up, so the expensive OCR only runs
+   when there's something to read.
+3. **Read** — on a hit it writes the score region to a BMP and hands the path to
+   `ocr_preprocess.py`, a long-lived **EasyOCR** daemon that finds the
+   "WORLD TOUR POINTS" / "RANK SCORE" header and returns the number below it.
+4. **Sync** — when the parsed value changes versus local state
+   (`.last-wtp` / `.last-rank`), it `POST`s `{ date, winPoints, mode }` to
+   `SERVER_URL/me/records` with your API key (libcurl), then backs off.
+
+When launched as a Steam launch option it also `fork`/`exec`s the game, and
+exits when the game does.
+
+## Files
+- `season-tracker.c` — the tracker (capture → gate → OCR handoff → POST). Built
+  by the `Makefile`.
+- `ocr_preprocess.py` — the EasyOCR daemon `season-tracker` talks to over a FIFO.
+- `season-tracker.sh` — one-shot installer **and** Steam launcher: installs
+  system deps, creates the Python venv + EasyOCR, compiles the tracker, prompts
+  for config, then execs the binary with the game command.
+- `Makefile` — `make season-tracker` (default) and `make season-watcher`.
+- `.env.example` — config template (`SERVER_URL`, `AUTH_TOKEN`, `SHOT_GEOMETRY`).
+- `package-linux.sh` — builds the release tarball (see [Release](#release)).
+- `season-watcher.c` / `season-launch.sh` — a separate local-only helper, **not
+  shipped** in the release (see [Season watcher](#season-watcher-local-only)).
+
+## Prerequisites
+The installer pulls these via your distro's package manager (apt / dnf / pacman
+/ zypper), so you normally don't install them by hand:
+
+- **Build:** `gcc`, `make`, `pkg-config`
+- **Native libs:** Tesseract + dev headers, Leptonica, libcurl, X11 (`libx11`,
+  `libxext`)
+- **Python:** `python3` + `venv` + `pip`, into which EasyOCR is installed
+  (this pulls PyTorch — a large, multi-minute first-time download)
+- An **X11** session (screen capture uses XShm; Wayland needs Xorg/XWayland)
+
+## Install & run
+The normal path is the published release: download
+`season-sprint-linux.tar.gz`, extract, and run `./season-tracker.sh` — or use
+the one-liner on the [downloads page](https://www.seasonsprint.com/downloads).
+From this repo directly:
+
+```bash
+cd packages/local-linux
+./season-tracker.sh        # installs deps, builds, and walks you through config
+```
+
+The script installs system packages, builds the venv + EasyOCR, compiles the
+tracker, and interactively writes `.env` (chmod 600) — it auto-detects your
+monitor geometry via `xrandr` and verifies the server connection. You'll need a
+personal **API key** (`sk_…`) from the web app's API Keys panel.
+
+To track automatically while playing, set the tracker as your **Steam launch
+option** for THE FINALS:
+
+```
+/full/path/to/season-tracker.sh %command%
+```
+
+It re-runs setup if anything's missing, strips Steam's library overrides so
+system libs load cleanly, then launches the game. Build it by hand with
+`make season-tracker` if you'd rather not use the installer.
+
+## Configuration (`.env`)
+| Var | Meaning |
+|-----|---------|
+| `SERVER_URL` | API base URL (no trailing slash) |
+| `AUTH_TOKEN` | Personal API key (`sk_…`) from the web app |
+| `SHOT_GEOMETRY` | Monitor geometry `WxH+X+Y` (auto-detected by the installer) |
+
+Runtime files (all gitignored): `.last-wtp` / `.last-rank` (last synced values),
+`tracker.log` (+ `tracker.log.ocr_err`), and `/tmp/st-*` capture/FIFO temporaries.
+
+## Season watcher (local-only)
+`season-watcher.c` is a separate notify tool that is **not part of the release**.
+It OCRs the lobby's "SEASON N ENDS IN D DAYS" banner and fires a desktop
+notification (`notify-send`) if the in-game countdown drifts from the season
+dates the backend serves at `/seasons` — a canary for a mis-scraped season
+window. Build it explicitly with `make season-watcher` (needs `-lm`).
+`season-launch.sh` is a thin wrapper that backgrounds the watcher and then hands
+off to `season-tracker.sh`; use it as the Steam launch option instead if you
+want watcher alerts while you play.
+
+## Release
+`package-linux.sh` builds `dist/season-sprint-linux.tar.gz`. It ships **source,
+not a binary** — the tracker links native libs (Tesseract, Leptonica, libcurl,
+X11) whose ABIs skew across distros, so building on the user's machine via
+`season-tracker.sh` is more portable. The tarball contains exactly:
+`season-tracker.c`, `Makefile`, `ocr_preprocess.py`, `season-tracker.sh`, and
+`.env.example`. In CI this is driven by `.github/workflows/build-linux.yml`.

--- a/packages/local-win/README.md
+++ b/packages/local-win/README.md
@@ -1,0 +1,89 @@
+# Season Sprint — Windows tracker
+
+The Windows counterpart to [`packages/local-linux`](../local-linux). It watches
+THE FINALS' end-of-match score screen, OCRs your **World Tour points** straight
+off the display, and pushes changes to your Season Sprint account automatically
+while you play. Distributed as a one-click installer (`SeasonSprintTracker.exe`).
+
+## How it works
+A single Python program (`season_tracker.py`):
+
+1. **Capture** — grabs the bottom-centre of your chosen monitor with **mss**
+   (no PIL/OpenCV needed for capture).
+2. **Read** — runs **EasyOCR** (CPU-only PyTorch) over the region, looks for the
+   "WORLD TOUR POINTS" header, and parses the number beneath it. It requires two
+   identical consecutive reads before trusting a value.
+3. **Sync** — when the value changes versus local state (`.last-wtp`), it `POST`s
+   `{ date, winPoints }` to the server with your API key, then cools down ~5 min.
+
+The token is validated (`sk_` + 64 hex) before sending and masked in logs, and
+SSL is pinned to certifi's CA bundle so model downloads work on fresh Windows
+installs.
+
+## Files
+- `season_tracker.py` — the tracker (capture → OCR → POST), config, state, and
+  logging. Supports `--setup-only`, `--list-monitors`.
+- `tray.py` — system-tray launcher for **non-Steam** players (Epic/Xbox/direct);
+  runs headless via `pythonw.exe`, single-instance, with a tray menu.
+- `launch.bat` — **Steam** wrapper (`launch.bat %command%`): starts the tracker
+  headless, runs the game, kills the tracker on exit. Run with no args to test
+  in a console.
+- `setup.bat` / `install-deps.bat` — interactive setup and (idempotent)
+  dependency bootstrap: find/install Python, MSVC redist, create the venv,
+  pip-install requirements with **CPU-only torch**.
+- `watch-tracker.bat` — live-tails `tracker.log`. `test_ocr.py` — runs the OCR
+  pipeline against a saved image to debug parsing.
+- `requirements.txt` — `easyocr`, `mss`, `requests`, `numpy`, `Pillow`,
+  `pystray`.
+- `installer/installer.iss` — Inno Setup 6 script that builds the installer.
+- `.env.example` — config template (`AUTH_TOKEN`, `MONITOR_INDEX`).
+
+## Prerequisites
+- **Windows x64**. Python **3.9+** (the installer/`install-deps.bat` will install
+  Python 3.12 via `winget` if it's missing), plus the MSVC C++ redistributable
+  (needed by PyTorch).
+- The dependency bootstrap creates a venv at `%USERPROFILE%\.season-sprint\venv`
+  — outside the repo, stable across drives/updates — and installs **CPU-only**
+  torch from the PyTorch CPU wheel index (avoids the ~2 GB CUDA wheels).
+- A personal **API key** (`sk_…`) from the web app's API Keys panel.
+
+## Install & run
+**End users:** download and run `SeasonSprintTracker.exe` from the
+[downloads page](https://www.seasonsprint.com/downloads). The wizard takes your
+API key, installs dependencies, lets you pick a monitor, and prints the Steam
+launch line + a Start-menu entry for the tray launcher.
+
+**From source** (this repo): double-click the repo-root
+`INSTALL-TRACKER-WINDOWS.bat`, which `cd`s here and runs `setup.bat`.
+
+Once installed:
+
+- **Steam:** paste into the game's *Properties → Launch Options*:
+  ```
+  "<install-dir>\launch.bat" %command%
+  ```
+- **Non-Steam:** launch **"Season Sprint Tracker"** from the Start menu (tray
+  launcher). Right-click the tray icon → Quit to stop.
+
+## Configuration (`.env`)
+| Var | Meaning |
+|-----|---------|
+| `AUTH_TOKEN` | Personal API key (`sk_…`) from the web app |
+| `MONITOR_INDEX` | Which monitor to read (`mss` convention: `1` = primary, `2+` = secondary) |
+
+The server URL is **hardcoded** in `season_tracker.py` (not configurable, to
+avoid leaking the token to a wrong host — fork and edit the constant to
+self-host). Runtime files (gitignored): `.last-wtp`, `.tracker-pid`,
+`tracker.log`.
+
+## Building the installer
+On Windows with Inno Setup 6:
+
+```bat
+"C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer\installer.iss
+```
+
+This produces `dist\SeasonSprintTracker.exe` — a per-user, no-UAC installer that
+ships the Python sources (not a frozen binary); the venv is created on the user's
+machine during the wizard. Uninstalling removes the install dir, `.env`, state
+files, and `%USERPROFILE%\.season-sprint`.


### PR DESCRIPTION
## What

Adds the four missing READMEs so every package — and the repo as a whole — is documented. Previously `web`, `server`, `landing`, and `android` had READMEs but the root and the other three packages did not.

- **`README.md`** (root, new) — product overview, a package table, the shared `client → Worker → D1/Clerk/Durable-Object` architecture diagram, quick-start commands, and pointers into each package + deploy/release.
- **`packages/ios/README.md`** — SwiftUI + Apple Charts + ClerkKit stack, the `Sources/` layout (Views/State/Networking/Domain), the xtool build loop, and the ClerkKit-only caveat (ClerkKitUI can't cross-compile under xtool).
- **`packages/local-linux/README.md`** — how the C tracker + EasyOCR daemon capture/gate/read/sync, the install & Steam-launch flow, native/Python deps, the local-only `season-watcher`, and why the release ships source not a binary.
- **`packages/local-win/README.md`** — the Python tracker, EasyOCR/mss/CPU-torch stack, the Inno Setup installer plus Steam (`launch.bat`) and non-Steam (tray) launch paths, and config.

## Why

For a seven-package monorepo, the absence of a root README was the single biggest navigability gap — nothing explained what Season Sprint is, how the packages relate, or how to stand up the native/desktop toolchains. The new docs match the style and depth of the existing `android`/`server`/`landing` READMEs.

## Accuracy

Facts were gathered by reading each package's actual source (Package.swift/xtool.yml, the C tracker + `season-tracker.sh`, `season_tracker.py` + `installer.iss`), not assumed. The shared worker URL was confirmed identical across clients. Every cross-link and referenced path/workflow (`packages/*`, `.github/workflows/build-*.yml`, `WARP.md`, domain files) was verified to exist.

Third of the structure-cleanup PRs (follows the `local-linux` cleanup and the `LineGraph.vue` split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README documentation for Season Sprint, including main project overview and individual setup/usage guides for iOS, Linux, and Windows client platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->