### PR TITLE
test: add cross-client golden vectors for the rank/pace math

### DIFF
--- a/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/GoldenVectorsTest.kt
+++ b/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/GoldenVectorsTest.kt
@@ -1,0 +1,89 @@
+package com.lcarthur.seasonsprint.domain
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Duration
+
+/**
+ * Golden-vector guard for the rank + pace math, shared with the web suite.
+ *
+ * The vectors are the cross-client contract: every implementation (web
+ * useRankInfo/chart.js, iOS Domain/, Android domain/) must reproduce these
+ * input→output pairs. This reads the same canonical JSON (kept byte-identical
+ * to packages/web/src/data/domainVectors.json — the web test asserts that) from
+ * test resources and checks computeRank/computePace against it, so a Kotlin port
+ * that drifts from the web/iOS math fails here.
+ */
+class GoldenVectorsTest {
+    @Serializable
+    private data class RankVec(
+        val points: Int,
+        val badge: String,
+        val currentFloor: Int,
+        val nextTarget: Int? = null,
+        val nextBadge: String? = null,
+        val toNext: Int,
+        val progressFraction: Float,
+    )
+
+    @Serializable
+    private data class PaceVec(
+        val goal: Int,
+        val baselineY: Int,
+        val days: Int,
+        val expected: Double,
+    )
+
+    @Serializable
+    private data class Vectors(val rank: List<RankVec>, val requiredPerDay: List<PaceVec>)
+
+    private val vectors: Vectors = run {
+        val text = javaClass.getResourceAsStream("/domainVectors.json")!!
+            .bufferedReader()
+            .use { it.readText() }
+        Json { ignoreUnknownKeys = true }.decodeFromString<Vectors>(text)
+    }
+
+    @Test
+    fun rankVectorsMatchComputeRank() {
+        assertTrue("expected rank vectors to check", vectors.rank.isNotEmpty())
+        for (v in vectors.rank) {
+            val r = computeRank(v.points)
+            assertEquals("badge @ ${v.points}", v.badge, r.badge)
+            assertEquals("currentFloor @ ${v.points}", v.currentFloor, r.currentFloor)
+            assertEquals("nextTarget @ ${v.points}", v.nextTarget, r.nextTarget)
+            assertEquals("nextBadge @ ${v.points}", v.nextBadge, r.nextBadge)
+            assertEquals("toNext @ ${v.points}", v.toNext, r.toNext)
+            assertEquals("progressFraction @ ${v.points}", v.progressFraction, r.progressFraction, 1e-6f)
+        }
+    }
+
+    @Test
+    fun requiredPerDayVectorsMatchComputePace() {
+        assertTrue("expected pace vectors to check", vectors.requiredPerDay.isNotEmpty())
+        val start = DateKey.parseUtc("2025-01-01")!!
+        for (v in vectors.requiredPerDay) {
+            val end = start.plus(Duration.ofDays(v.days.toLong()))
+            // A single point at season start carrying the baseline score makes
+            // requiredPerDayFromLast == (goal - baselineY) / days for every vector;
+            // baselineY == 0 reduces to the "from zero" case.
+            val baseline = Point(
+                remoteId = "baseline",
+                day = "2025-01-01",
+                winPoints = v.baselineY,
+                instant = start,
+            )
+            val pace = computePace(goal = v.goal, seasonPoints = listOf(baseline), start = start, end = end)
+            assertEquals(
+                "requiredPerDay goal=${v.goal} baseline=${v.baselineY} days=${v.days}",
+                v.expected,
+                pace.requiredPerDayFromLast,
+                1e-6,
+            )
+        }
+    }
+}

--- a/packages/android/app/src/test/resources/domainVectors.json
+++ b/packages/android/app/src/test/resources/domainVectors.json
@@ -1,0 +1,19 @@
+{
+  "_about": "Cross-client golden vectors for the World Tour rank + pace math. Every client (web useRankInfo/chart.js, iOS Domain/, Android domain/) must reproduce these input->output pairs, so the hand-ported math can't silently diverge. Enforced in CI by packages/web/tests/domain-vectors.spec.js; mirrored for the Android JUnit suite at packages/android/app/src/test/resources/domainVectors.json (the web test asserts that copy stays identical). Inputs are non-negative points only: web toNext uses floor(points) while native clamps to >=0, so they intentionally differ for negative inputs, which never occur for cumulative scores.",
+  "rank": [
+    { "points": 10,   "badge": "Unranked",   "currentFloor": 0,    "nextTarget": 25,   "nextBadge": "Bronze 4",   "toNext": 15, "progressFraction": 0.4 },
+    { "points": 25,   "badge": "Bronze 4",   "currentFloor": 25,   "nextTarget": 50,   "nextBadge": "Bronze 3",   "toNext": 25, "progressFraction": 0.0 },
+    { "points": 820,  "badge": "Platinum 3", "currentFloor": 800,  "nextTarget": 900,  "nextBadge": "Platinum 2", "toNext": 80, "progressFraction": 0.2 },
+    { "points": 850,  "badge": "Platinum 3", "currentFloor": 800,  "nextTarget": 900,  "nextBadge": "Platinum 2", "toNext": 50, "progressFraction": 0.5 },
+    { "points": 0,    "badge": "Unranked",   "currentFloor": 0,    "nextTarget": 25,   "nextBadge": "Bronze 4",   "toNext": 25, "progressFraction": 0.0 },
+    { "points": 2400, "badge": "Emerald 1",  "currentFloor": 2400, "nextTarget": null, "nextBadge": null,         "toNext": 0,  "progressFraction": 0.0 },
+    { "points": 3000, "badge": "Emerald 1",  "currentFloor": 2400, "nextTarget": null, "nextBadge": null,         "toNext": 0,  "progressFraction": 0.0 }
+  ],
+  "requiredPerDay": [
+    { "goal": 1000, "baselineY": 0,   "days": 10, "expected": 100 },
+    { "goal": 2400, "baselineY": 0,   "days": 30, "expected": 80 },
+    { "goal": 1000, "baselineY": 400, "days": 5,  "expected": 120 },
+    { "goal": 600,  "baselineY": 600, "days": 5,  "expected": 0 },
+    { "goal": 1000, "baselineY": 0,   "days": 1,  "expected": 1000 }
+  ]
+}

--- a/packages/web/src/data/domainVectors.json
+++ b/packages/web/src/data/domainVectors.json
@@ -1,0 +1,19 @@
+{
+  "_about": "Cross-client golden vectors for the World Tour rank + pace math. Every client (web useRankInfo/chart.js, iOS Domain/, Android domain/) must reproduce these input->output pairs, so the hand-ported math can't silently diverge. Enforced in CI by packages/web/tests/domain-vectors.spec.js; mirrored for the Android JUnit suite at packages/android/app/src/test/resources/domainVectors.json (the web test asserts that copy stays identical). Inputs are non-negative points only: web toNext uses floor(points) while native clamps to >=0, so they intentionally differ for negative inputs, which never occur for cumulative scores.",
+  "rank": [
+    { "points": 10,   "badge": "Unranked",   "currentFloor": 0,    "nextTarget": 25,   "nextBadge": "Bronze 4",   "toNext": 15, "progressFraction": 0.4 },
+    { "points": 25,   "badge": "Bronze 4",   "currentFloor": 25,   "nextTarget": 50,   "nextBadge": "Bronze 3",   "toNext": 25, "progressFraction": 0.0 },
+    { "points": 820,  "badge": "Platinum 3", "currentFloor": 800,  "nextTarget": 900,  "nextBadge": "Platinum 2", "toNext": 80, "progressFraction": 0.2 },
+    { "points": 850,  "badge": "Platinum 3", "currentFloor": 800,  "nextTarget": 900,  "nextBadge": "Platinum 2", "toNext": 50, "progressFraction": 0.5 },
+    { "points": 0,    "badge": "Unranked",   "currentFloor": 0,    "nextTarget": 25,   "nextBadge": "Bronze 4",   "toNext": 25, "progressFraction": 0.0 },
+    { "points": 2400, "badge": "Emerald 1",  "currentFloor": 2400, "nextTarget": null, "nextBadge": null,         "toNext": 0,  "progressFraction": 0.0 },
+    { "points": 3000, "badge": "Emerald 1",  "currentFloor": 2400, "nextTarget": null, "nextBadge": null,         "toNext": 0,  "progressFraction": 0.0 }
+  ],
+  "requiredPerDay": [
+    { "goal": 1000, "baselineY": 0,   "days": 10, "expected": 100 },
+    { "goal": 2400, "baselineY": 0,   "days": 30, "expected": 80 },
+    { "goal": 1000, "baselineY": 400, "days": 5,  "expected": 120 },
+    { "goal": 600,  "baselineY": 600, "days": 5,  "expected": 0 },
+    { "goal": 1000, "baselineY": 0,   "days": 1,  "expected": 1000 }
+  ]
+}

--- a/packages/web/tests/domain-vectors.spec.js
+++ b/packages/web/tests/domain-vectors.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve, dirname } from 'node:path'
+import vectors from '@/data/domainVectors.json'
+import thresholds from '@/data/worldTourRanks.json'
+import { useRankInfo } from '@/composables/useRankInfo'
+import { requiredPerDayFromBaseline, MS_PER_DAY } from '@/utils/chart'
+
+/**
+ * Golden-vector guard for the World Tour *math* (the computed logic), extending
+ * the data-table parity check in rank-parity.spec.js. The rank and pace formulas
+ * are hand-ported into JS, Swift, and Kotlin; these vectors pin the expected
+ * outputs so the three implementations can't silently disagree on a result.
+ *
+ * This file enforces the JS implementation in CI. The same vectors are consumed
+ * by the Android JUnit suite via a copy under app/src/test/resources/ — the last
+ * test here asserts that copy is identical, so the canonical contract and the
+ * Android-side copy cannot drift apart (CI only runs web/server, not native).
+ */
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+
+describe('rank math golden vectors (web useRankInfo)', () => {
+  it('has vectors to check', () => {
+    expect(vectors.rank.length).toBeGreaterThan(0)
+  })
+
+  for (const v of vectors.rank) {
+    it(`points=${v.points} → ${v.badge}`, () => {
+      const { rankInfo, toNext, progressPct } = useRankInfo(ref(v.points), ref(thresholds))
+      expect(rankInfo.value.badge).toBe(v.badge)
+      expect(rankInfo.value.currentFloor).toBe(v.currentFloor)
+      expect(rankInfo.value.nextTarget).toBe(v.nextTarget)
+      expect(rankInfo.value.nextBadge).toBe(v.nextBadge)
+      expect(toNext.value).toBe(v.toNext)
+      // web reports 0..100; the canonical fraction is 0..1
+      expect(progressPct.value / 100).toBeCloseTo(v.progressFraction, 6)
+    })
+  }
+})
+
+describe('required-per-day math golden vectors (web chart.js)', () => {
+  it('has vectors to check', () => {
+    expect(vectors.requiredPerDay.length).toBeGreaterThan(0)
+  })
+
+  for (const v of vectors.requiredPerDay) {
+    it(`goal=${v.goal} baseline=${v.baselineY} over ${v.days}d → ${v.expected}/day`, () => {
+      const endMs = v.days * MS_PER_DAY // baselineMs = 0
+      expect(requiredPerDayFromBaseline(v.goal, v.baselineY, 0, endMs)).toBeCloseTo(
+        v.expected,
+        6
+      )
+    })
+  }
+})
+
+describe('Android golden-vector copy stays in sync with the canonical source', () => {
+  it('app/src/test/resources/domainVectors.json is identical to the canonical vectors', () => {
+    const androidCopy = JSON.parse(
+      readFileSync(
+        resolve(repoRoot, 'packages/android/app/src/test/resources/domainVectors.json'),
+        'utf8'
+      )
+    )
+    expect(androidCopy).toEqual(vectors)
+  })
+})


### PR DESCRIPTION
## What

Extends the parity guard from the **data tables** (#126) to the **computed logic**. The rank and pace formulas are hand-ported into JS, Swift, and Kotlin; this pins their outputs with a shared set of `input → expected` vectors so the three implementations can't silently disagree on a result.

| File | Role |
|------|------|
| `web/src/data/domainVectors.json` | The canonical cross-client contract — rank cases + required-per-day cases |
| `web/tests/domain-vectors.spec.js` | **CI-enforced**: asserts the JS math reproduces every vector, and that the Android copy stays identical |
| `android/.../test/resources/domainVectors.json` | Byte-identical copy the Android suite reads (kept in sync by the web test) |
| `android/.../domain/GoldenVectorsTest.kt` | Android JUnit suite consuming the same vectors via `computeRank`/`computePace` |

## Design

Mirrors the #126 philosophy — **web is the CI enforcement hub**. CI only runs web/server, so the web test both (a) checks the JS implementation against the vectors and (b) asserts the Android-side copy is identical to the canonical JSON, making the two impossible to drift apart. The Android JUnit test then consumes the same vectors so the Kotlin port is checked whenever gradle runs.

A real divergence surfaced while choosing inputs: web `toNext` uses `floor(points)` while native clamps to `≥0`, so they disagree for **negative** points. Cumulative scores are never negative, so the vectors deliberately use non-negative inputs only (documented in the JSON), sidestepping a latent inconsistency rather than papering over it.

iOS `computePace`/`computeRank` have the same shape but the package has **no test target** — the canonical JSON is ready to wire into one as a follow-up.

## Verification

- Full web suite **97/97**, lint clean.
- **Proved the guards bite** (a golden test that can't fail is worthless): perturbing a vector's expected `toNext` (`80`→`81`) fails the math test; changing only the Android copy fails the sync test — both revert green.
- **Honest limitation:** the Android JUnit test was **not executed here** (no Android SDK in this environment). It mirrors the existing `RankTest`/`PaceTest` idioms and the app's `kotlinx-serialization`, and should be confirmed by a `./gradlew :app:testDebugUnitTest` run.

Follow-up to #126 — completes the rank/pace divergence guard from data into logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)