### PR TITLE
feat(web): toggle points-earned-per-day between bars and a line

### DIFF
--- a/packages/web/src/components/GraphSettingsSection.vue
+++ b/packages/web/src/components/GraphSettingsSection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted } from "vue";
+import { computed, onMounted } from "vue";
 import { useGraphSettings } from "@/composables/useGraphSettings";
 
 // One mode's graph display settings. Binds directly to the per-mode
@@ -19,8 +19,17 @@ const {
   showAveragePace,
   showDeviationWedge,
   showPaceGraph,
+  paceEarnedStyle,
   loadSettings,
 } = useGraphSettings(props.storageKey);
+
+// Checkbox proxy over the 'bars' | 'line' style (checked = bars, the default).
+const earnedAsBars = computed({
+  get: () => paceEarnedStyle.value === "bars",
+  set: (v) => {
+    paceEarnedStyle.value = v ? "bars" : "line";
+  },
+});
 
 onMounted(loadSettings);
 </script>
@@ -128,6 +137,24 @@ onMounted(loadSettings);
           </label>
         </div>
       </div>
+
+      <Transition name="setting-slide">
+        <div v-if="showPaceGraph" class="setting-group setting-child">
+          <div class="setting-info">
+            <div class="setting-title">Points earned as bars</div>
+            <div class="setting-desc">
+              Draw the points-earned-per-day series as bars (like the mobile
+              apps) instead of a line.
+            </div>
+          </div>
+          <div class="setting-control">
+            <label class="toggle-row">
+              <input class="toggle" type="checkbox" v-model="earnedAsBars" />
+              <span class="toggle-text">Show earned points as bars</span>
+            </label>
+          </div>
+        </div>
+      </Transition>
     </div>
   </div>
 </template>

--- a/packages/web/src/components/LineGraph.css
+++ b/packages/web/src/components/LineGraph.css
@@ -412,6 +412,11 @@ svg.nav-disabled {
   filter: drop-shadow(0 0 4px color-mix(in oklab, var(--accent) 50%, transparent));
 }
 
+.pace-bar-earned {
+  fill: var(--accent);
+  opacity: 0.55;
+}
+
 .pace-point-required circle {
   fill: color-mix(in oklab, var(--primary) 55%, #9ca3af);
 }

--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -296,11 +296,24 @@
             :x2="width - padding"
             :y2="scaledPaceRequired[scaledPaceRequired.length - 1].y"
           />
-          <!-- Points earned line -->
-          <path v-if="paceEarnedPath" :d="paceEarnedPath" class="pace-line pace-line-earned" />
-          <g v-for="(p, i) in scaledPaceEarned" :key="'ppe-' + i" class="pace-point pace-point-earned">
-            <circle :cx="p.x" :cy="p.y" r="2.5" />
-          </g>
+          <!-- Points earned per day: bars (default) or line -->
+          <template v-if="paceEarnedStyle === 'bars'">
+            <rect
+              v-for="(b, i) in scaledPaceEarnedBars"
+              :key="'peb-' + i"
+              class="pace-bar-earned"
+              :x="b.x"
+              :y="b.y"
+              :width="b.width"
+              :height="b.height"
+            />
+          </template>
+          <template v-else>
+            <path v-if="paceEarnedPath" :d="paceEarnedPath" class="pace-line pace-line-earned" />
+            <g v-for="(p, i) in scaledPaceEarned" :key="'ppe-' + i" class="pace-point pace-point-earned">
+              <circle :cx="p.x" :cy="p.y" r="2.5" />
+            </g>
+          </template>
           <!-- Pace Y axis label -->
           <text
             class="axis-label"
@@ -314,7 +327,7 @@
             <tspan class="pace-legend-required">-- required</tspan>
           </text>
           <text class="pace-legend" :x="width - padding - 4" :y="paceTop + 22" text-anchor="end">
-            <tspan class="pace-legend-earned">-- earned</tspan>
+            <tspan class="pace-legend-earned">{{ paceEarnedStyle === 'bars' ? '▮ earned' : '-- earned' }}</tspan>
           </text>
         </g>
 
@@ -442,6 +455,7 @@ const {
   showAveragePace,
   showDeviationWedge,
   showPaceGraph,
+  paceEarnedStyle,
   loadSettings,
 } = useGraphSettings(props.storageKey);
 
@@ -497,6 +511,7 @@ const {
   paceScaleY,
   scaledPaceRequired,
   scaledPaceEarned,
+  scaledPaceEarnedBars,
   paceRequiredPath,
   paceEarnedPath,
   requiredPerDayZero,

--- a/packages/web/src/composables/useChartGeometry.js
+++ b/packages/web/src/composables/useChartGeometry.js
@@ -216,6 +216,19 @@ export function useChartGeometry({
   const paceRequiredPath = computed(() => buildPathD(scaledPaceRequired.value));
   const paceEarnedPath = computed(() => buildPathD(scaledPaceEarned.value));
 
+  // Bar variant of the "points earned per day" series: a rect per day, grown
+  // from the zero line up (gain) or down (loss). Matches the mobile apps.
+  const PACE_BAR_WIDTH = 5;
+  const scaledPaceEarnedBars = computed(() => {
+    const zeroY = paceScaleY(0);
+    return scaledPaceEarned.value.map((p) => ({
+      x: p.x - PACE_BAR_WIDTH / 2,
+      y: Math.min(p.y, zeroY),
+      width: PACE_BAR_WIDTH,
+      height: Math.abs(p.y - zeroY),
+    }));
+  });
+
   // Pace stats
   const requiredPerDayZero = computed(() => {
     // Slope of the baseline→goal projection per day, matching pathGoalFromZero.
@@ -270,6 +283,7 @@ export function useChartGeometry({
     paceScaleY,
     scaledPaceRequired,
     scaledPaceEarned,
+    scaledPaceEarnedBars,
     paceRequiredPath,
     paceEarnedPath,
     requiredPerDayZero,

--- a/packages/web/src/composables/useGraphSettings.js
+++ b/packages/web/src/composables/useGraphSettings.js
@@ -25,6 +25,9 @@ export function useGraphSettings(storageKey) {
   const showAveragePace = ref(false)
   const showDeviationWedge = ref(false)
   const showPaceGraph = ref(true)
+  // How the "points earned per day" series renders in the pace graph: 'bars'
+  // (default, matching the mobile apps) or 'line'.
+  const paceEarnedStyle = ref('bars')
 
   function buildKey() {
     return storageKey
@@ -45,6 +48,7 @@ export function useGraphSettings(storageKey) {
       showAveragePace: showAveragePace.value,
       showDeviationWedge: showDeviationWedge.value,
       showPaceGraph: showPaceGraph.value,
+      paceEarnedStyle: paceEarnedStyle.value,
     }
     saveStateWithKey(buildKey(), state)
   }
@@ -74,6 +78,8 @@ export function useGraphSettings(storageKey) {
       showDeviationWedge.value = parsed.showDeviationWedge
     if (typeof parsed.showPaceGraph === 'boolean')
       showPaceGraph.value = parsed.showPaceGraph
+    if (parsed.paceEarnedStyle === 'bars' || parsed.paceEarnedStyle === 'line')
+      paceEarnedStyle.value = parsed.paceEarnedStyle
   }
 
   // Auto-persist on changes
@@ -81,7 +87,7 @@ export function useGraphSettings(storageKey) {
     [seasonStart, seasonEnd, goalWinPoints, autoSetSeasonFromImport, simplifyImport],
     saveSettings
   )
-  watch([navSensitivity, enableNavigation, showRankOverlay, showAveragePace, showDeviationWedge, showPaceGraph], saveSettings)
+  watch([navSensitivity, enableNavigation, showRankOverlay, showAveragePace, showDeviationWedge, showPaceGraph, paceEarnedStyle], saveSettings)
 
   return {
     seasonStart,
@@ -97,6 +103,7 @@ export function useGraphSettings(storageKey) {
     showAveragePace,
     showDeviationWedge,
     showPaceGraph,
+    paceEarnedStyle,
     saveSettings,
     loadSettings,
   }

--- a/packages/web/tests/pace-earned.spec.js
+++ b/packages/web/tests/pace-earned.spec.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref, computed } from 'vue'
+
+// Minimal in-memory localStorage for the node test env (storage.js is a guarded
+// facade, so without this the persistence paths are simply no-ops).
+const store = {}
+global.localStorage = {
+  getItem: (k) => (k in store ? store[k] : null),
+  setItem: (k, v) => { store[k] = String(v) },
+  removeItem: (k) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+}
+
+import { useGraphSettings } from '@/composables/useGraphSettings'
+import { useChartGeometry } from '@/composables/useChartGeometry'
+
+describe('pace "points earned" style setting', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('defaults to bars when the user has no saved preference', () => {
+    const s = useGraphSettings('default-test')
+    s.loadSettings()
+    expect(s.paceEarnedStyle.value).toBe('bars')
+  })
+
+  it('persists a chosen style and reloads it', () => {
+    const a = useGraphSettings('persist-test')
+    a.paceEarnedStyle.value = 'line'
+    a.saveSettings()
+
+    const b = useGraphSettings('persist-test')
+    b.loadSettings()
+    expect(b.paceEarnedStyle.value).toBe('line')
+  })
+
+  it('ignores an invalid stored value and keeps the bars default', () => {
+    localStorage.setItem('season-sprint:bad-test:v1', JSON.stringify({ paceEarnedStyle: 'pie' }))
+    const s = useGraphSettings('bad-test')
+    s.loadSettings()
+    expect(s.paceEarnedStyle.value).toBe('bars')
+  })
+})
+
+describe('pace "points earned" bar geometry', () => {
+  function geometryFor(points) {
+    const sorted = [...points].sort((a, b) => a.date.localeCompare(b.date))
+    return useChartGeometry({
+      width: 600, height: 400, padding: 40,
+      paceTop: 372, paceHeight: 70, pacePadY: 6,
+      today: new Date('2025-01-15T00:00:00Z'),
+      mode: 'world-tour',
+      goalOptions: () => [],
+      seasonStart: ref('2025-01-01'),
+      seasonEnd: ref('2025-01-31'),
+      goalWinPoints: ref(1000),
+      isSeasonValid: computed(() => true),
+      points,
+      sortedPoints: computed(() => sorted),
+    })
+  }
+
+  it('emits one bar per earned point, aligned to the line points and the zero baseline', () => {
+    const g = geometryFor([{ date: '2025-01-05', y: 100 }, { date: '2025-01-10', y: 120 }])
+    const bars = g.scaledPaceEarnedBars.value
+    const line = g.scaledPaceEarned.value
+    const zeroY = g.paceScaleY(0)
+
+    expect(bars.length).toBe(line.length)
+    expect(bars.length).toBeGreaterThan(0)
+    bars.forEach((b, i) => {
+      expect(b.width).toBe(5)
+      expect(b.x).toBeCloseTo(line[i].x - 2.5, 6) // centered on the same x as the line point
+      expect(b.y).toBeCloseTo(Math.min(line[i].y, zeroY), 6)
+      expect(b.height).toBeCloseTo(Math.abs(line[i].y - zeroY), 6)
+    })
+  })
+
+  it('grows a positive daily gain upward from the zero line', () => {
+    // First in-season point is a +100 gain from the World Tour baseline of 0.
+    const g = geometryFor([{ date: '2025-01-05', y: 100 }, { date: '2025-01-10', y: 120 }])
+    const zeroY = g.paceScaleY(0)
+    const firstBar = g.scaledPaceEarnedBars.value[0]
+    expect(firstBar.y).toBeLessThan(zeroY) // top of the bar is above the zero line
+    expect(firstBar.height).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## What

Adds a per-user setting to render the **points-earned-per-day** series (in the pace sub-graph) as **bars** or a **line**, defaulting to bars — matching the iOS/Android apps, which already use bars.

| Variant | Looks like |
|---------|-----------|
| **Bars** (new default) | a bar per day, grown up from the zero line for a gain, down for a loss — same as mobile (`BarMark`) |
| **Line** (previous web behavior) | the line + dots, still available |

The required-pace series stays a line in both modes (it's a target), consistent with mobile.

## Changes
- **`useGraphSettings`** — new `paceEarnedStyle` (`'bars' | 'line'`), default `'bars'`, persisted/loaded/validated next to the other graph settings. Defaulting in the ref means any user without a saved preference gets bars.
- **`useChartGeometry`** — `scaledPaceEarnedBars`: a rect per day anchored to the zero line, centered on the same x as the line points (keeps the geometry in the composable, per the earlier `LineGraph` split).
- **`LineGraph`** — renders bars or line+dots from the setting; the pace legend marker follows.
- **`GraphSettingsSection`** — a "Points earned as bars" toggle nested under the existing **Pace graph** setting (only shown when the pace graph is on).

## Scope

Web only, per the request — this brings web's default in line with mobile. Giving the mobile apps their own toggle (they're currently bars-only) is a natural follow-up; the setting name/shape here would port directly.

## Verification
- Lint clean; **web suite 102/102** (5 new); production build succeeds.
- The new test exercises the **real composable**, not a reimplementation: asserts the setting defaults to bars / persists / rejects invalid values, and that each bar aligns with its line point and the zero baseline (a positive daily gain grows upward). I couldn't do a full browser screenshot here (needs Clerk auth + live data), so I verified the geometry directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)