### PR TITLE
feat(web): make the pace bar width data-driven

### DIFF
--- a/packages/web/src/composables/useChartGeometry.js
+++ b/packages/web/src/composables/useChartGeometry.js
@@ -217,14 +217,29 @@ export function useChartGeometry({
   const paceEarnedPath = computed(() => buildPathD(scaledPaceEarned.value));
 
   // Bar variant of the "points earned per day" series: a rect per day, grown
-  // from the zero line up (gain) or down (loss). Matches the mobile apps.
-  const PACE_BAR_WIDTH = 5;
+  // from the zero line up (gain) or down (loss). Matches the mobile apps. Width
+  // tracks one day of the season axis (with a fill gap) so bars stay proportional
+  // — thinner on long seasons, wider on short ones — clamped to stay visible
+  // without overlapping.
+  const PACE_BAR_MIN_WIDTH = 2;
+  const PACE_BAR_MAX_WIDTH = 14;
+  const PACE_BAR_FILL = 0.7;
+  const paceBarWidth = computed(() => {
+    const [minMs, maxMs] = xDomain.value;
+    const seasonDays = Math.max(1, (maxMs - minMs) / MS_PER_DAY);
+    const dayWidth = (width - padding * 2) / seasonDays;
+    return Math.max(
+      PACE_BAR_MIN_WIDTH,
+      Math.min(PACE_BAR_MAX_WIDTH, dayWidth * PACE_BAR_FILL)
+    );
+  });
   const scaledPaceEarnedBars = computed(() => {
     const zeroY = paceScaleY(0);
+    const w = paceBarWidth.value;
     return scaledPaceEarned.value.map((p) => ({
-      x: p.x - PACE_BAR_WIDTH / 2,
+      x: p.x - w / 2,
       y: Math.min(p.y, zeroY),
-      width: PACE_BAR_WIDTH,
+      width: w,
       height: Math.abs(p.y - zeroY),
     }));
   });

--- a/packages/web/tests/pace-earned.spec.js
+++ b/packages/web/tests/pace-earned.spec.js
@@ -42,7 +42,7 @@ describe('pace "points earned" style setting', () => {
 })
 
 describe('pace "points earned" bar geometry', () => {
-  function geometryFor(points) {
+  function geometryFor(points, { start = '2025-01-01', end = '2025-01-31' } = {}) {
     const sorted = [...points].sort((a, b) => a.date.localeCompare(b.date))
     return useChartGeometry({
       width: 600, height: 400, padding: 40,
@@ -50,8 +50,8 @@ describe('pace "points earned" bar geometry', () => {
       today: new Date('2025-01-15T00:00:00Z'),
       mode: 'world-tour',
       goalOptions: () => [],
-      seasonStart: ref('2025-01-01'),
-      seasonEnd: ref('2025-01-31'),
+      seasonStart: ref(start),
+      seasonEnd: ref(end),
       goalWinPoints: ref(1000),
       isSeasonValid: computed(() => true),
       points,
@@ -59,7 +59,7 @@ describe('pace "points earned" bar geometry', () => {
     })
   }
 
-  it('emits one bar per earned point, aligned to the line points and the zero baseline', () => {
+  it('emits one bar per earned point, uniform width, centered on the line points and zero baseline', () => {
     const g = geometryFor([{ date: '2025-01-05', y: 100 }, { date: '2025-01-10', y: 120 }])
     const bars = g.scaledPaceEarnedBars.value
     const line = g.scaledPaceEarned.value
@@ -67,12 +67,27 @@ describe('pace "points earned" bar geometry', () => {
 
     expect(bars.length).toBe(line.length)
     expect(bars.length).toBeGreaterThan(0)
+    const w = bars[0].width
+    expect(w).toBeGreaterThanOrEqual(2)
+    expect(w).toBeLessThanOrEqual(14)
     bars.forEach((b, i) => {
-      expect(b.width).toBe(5)
-      expect(b.x).toBeCloseTo(line[i].x - 2.5, 6) // centered on the same x as the line point
+      expect(b.width).toBeCloseTo(w, 6) // uniform across bars
+      expect(b.x).toBeCloseTo(line[i].x - w / 2, 6) // centered on the same x as the line point
       expect(b.y).toBeCloseTo(Math.min(line[i].y, zeroY), 6)
       expect(b.height).toBeCloseTo(Math.abs(line[i].y - zeroY), 6)
     })
+  })
+
+  it('scales bar width to the season length: longer season → narrower bars', () => {
+    const pts = [{ date: '2025-01-05', y: 100 }]
+    const short = geometryFor(pts, { start: '2025-01-01', end: '2025-01-09' })
+      .scaledPaceEarnedBars.value[0].width
+    const long = geometryFor(pts, { start: '2025-01-01', end: '2025-04-30' })
+      .scaledPaceEarnedBars.value[0].width
+
+    expect(long).toBeLessThan(short)
+    expect(long).toBeGreaterThanOrEqual(2)
+    expect(short).toBeLessThanOrEqual(14)
   })
 
   it('grows a positive daily gain upward from the zero line', () => {


### PR DESCRIPTION
## What

Makes the points-earned bar width scale with the season axis instead of a fixed 5px: one day of plot width × a 0.7 fill gap, clamped to `[2, 14]`px. Bars stay proportional — thinner on long seasons, wider on short ones — without overlapping on dense data or ballooning on sparse data.

## Why a separate PR

This change was committed to the #129 branch (`51a3d61`), but #129 **auto-merged at the previous commit** (the bars/line toggle) the moment its CI passed, so the data-driven commit never made it onto `main`. This PR cherry-picks that stranded commit onto a fresh branch so it lands.

## Verification

- Lint clean, web suite **103/103**, build succeeds.
- The geometry test asserts uniform, in-bounds, centered widths, **plus** a case proving a longer season yields narrower bars than a short one (the data-driven behavior itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced "points earned per day" bar visualization with responsive scaling. Bars now automatically adjust their width based on season length and available chart space, providing better visibility and preventing overlap across different time periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->