### PR TITLE
feat(web): view & overlay previous seasons

### DIFF
--- a/packages/web/src/assets/rank-indicator.css
+++ b/packages/web/src/assets/rank-indicator.css
@@ -3,7 +3,12 @@
   border: 1px solid color-mix(in oklab, var(--primary) 20%, var(--surface));
   border-radius: 10px;
   padding: 10px 12px;
-  background: color-mix(in oklab, var(--surface) 92%, black);
+  background: #000;
+  /* Span the full width of the controls area (its own row when sharing a flex
+     container with the goal-rank select). */
+  width: 100%;
+  flex: 1 0 100%;
+  box-sizing: border-box;
 }
 .rank-header {
   display: flex;

--- a/packages/web/src/components/LineGraph.css
+++ b/packages/web/src/components/LineGraph.css
@@ -92,6 +92,19 @@
   color: var(--muted);
 }
 
+.readonly-badge {
+  margin-left: 10px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: color-mix(in oklab, var(--primary) 16%, transparent);
+  vertical-align: middle;
+}
+
 .controls {
   display: flex;
   gap: 12px;
@@ -376,6 +389,20 @@ svg.nav-disabled {
 .point circle {
   fill: var(--danger);
   filter: drop-shadow(0 0 4px rgba(255, 61, 127, 0.65));
+}
+
+/* Previous-season overlay line + points (faint, dashed, behind current line) */
+.overlay-line {
+  fill: none;
+  stroke: var(--primary);
+  stroke-width: 2;
+  stroke-dasharray: 5 5;
+  opacity: 0.55;
+}
+
+.overlay-point circle {
+  fill: var(--primary);
+  opacity: 0.5;
 }
 
 /* Pace graph */

--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -3,15 +3,52 @@
     <header class="lg-header">
       <h2 v-if="gamemode" class="lg-gamemode">{{ gamemode }}</h2>
       <h2 class="lg-season-title">
-        {{ headerTitle || seasonTitle || "Interactive Line Graph" }}
+        {{ displayTitle }}
+        <span v-if="isViewingPastSeason" class="readonly-badge">read-only</span>
       </h2>
       <div v-if="headerDisclaimer" class="lg-disclaimer">
         {{ headerDisclaimer }}
       </div>
     </header>
 
+    <!-- Season picker + previous-season overlay. Teleported into the aside
+         (under the points controls) when a target is provided; rendered inline
+         otherwise. State stays here — only the DOM moves. -->
+    <Teleport v-if="teleportControls" :to="seasonControlsTo">
+      <SeasonControls
+        :seasons="seasons"
+        :seasons-desc="seasonsDesc"
+        :overlay-options="overlayOptions"
+        :current-season-key="currentSeasonKey"
+        :selected="selectedSeasonKey"
+        :overlay="overlaySeasonKey"
+        :overlay-season="overlaySeason"
+        @update:selected="selectedSeasonKey = $event"
+        @update:overlay="overlaySeasonKey = $event"
+      />
+    </Teleport>
+    <SeasonControls
+      v-else-if="!seasonControlsTo"
+      :seasons="seasons"
+      :seasons-desc="seasonsDesc"
+      :overlay-options="overlayOptions"
+      :current-season-key="currentSeasonKey"
+      :selected="selectedSeasonKey"
+      :overlay="overlaySeasonKey"
+      :overlay-season="overlaySeason"
+      @update:selected="selectedSeasonKey = $event"
+      @update:overlay="overlaySeasonKey = $event"
+    />
+
     <div v-if="!isAuthenticated && !isLoading" class="status-banner auth-banner">
       Sign in to save and sync your data.
+    </div>
+
+    <div
+      v-if="isViewingPastSeason && isAuthenticated && !scaledPoints.length && !isLoading"
+      class="status-banner"
+    >
+      No data logged for {{ selectedSeason && selectedSeason.name }}.
     </div>
 
     <!-- Unified status: goal/progress + required pace. Today's gain and live DB
@@ -60,6 +97,7 @@
       v-if="showPointsModal"
       :points="points"
       :sorted-points-reverse="sortedPointsReverse"
+      :read-only="isViewingPastSeason"
       @save-edit="onSaveEdit"
       @remove-point="removePoint"
       @close="closePointsModal"
@@ -249,6 +287,16 @@
             class="placement-baseline"
           />
 
+          <!-- Previous-season overlay (aligned by day-of-season) -->
+          <path v-if="overlayPathD" :d="overlayPathD" class="overlay-line" />
+          <g
+            v-for="(p, idx) in overlayScaledPoints"
+            :key="'ov-' + idx"
+            class="overlay-point"
+          >
+            <circle :cx="p.x" :cy="p.y" r="2.5" />
+          </g>
+
           <!-- Path -->
           <path v-if="pathD" :d="pathD" class="line" />
 
@@ -369,13 +417,16 @@
         <button @click="exportCSV" :disabled="points.length === 0">
           Export CSV
         </button>
-        <button @click="openImportModal" :disabled="!isAuthenticated">
+        <button
+          @click="openImportModal"
+          :disabled="!isAuthenticated || isViewingPastSeason"
+        >
           Import CSV
         </button>
         <button
           class="btn-danger"
           @click="clearPoints"
-          :disabled="points.length === 0 || !isAuthenticated"
+          :disabled="points.length === 0 || !isAuthenticated || isViewingPastSeason"
         >
           Clear
         </button>
@@ -385,27 +436,27 @@
 </template>
 
 <script setup>
-import { computed, ref, watch, onMounted } from "vue";
+import { computed, ref, watch, onMounted, nextTick } from "vue";
 import { useAuth } from "@clerk/vue";
 import {
   dateToMs,
-  msToDateInput,
   formatDate,
 } from "@/utils/date";
 import { buildCSV } from "@/utils/csv";
-import { loadSeasonJson } from "@/utils/season";
 import { useRankInfo } from "@/composables/useRankInfo";
 import { usePanZoom } from "@/composables/usePanZoom";
 import { useGraphSettings } from "@/composables/useGraphSettings";
+import { useSeasons } from "@/composables/useSeasons";
 import { usePointsData } from "@/composables/usePointsData";
 import { useChartGeometry } from "@/composables/useChartGeometry";
 import GoalControls from "@/components/GoalControls.vue";
 import StatsPanel from "@/components/StatsPanel.vue";
+import SeasonControls from "@/components/SeasonControls.vue";
 import ImportModal from "@/components/modals/ImportModal.vue";
 import PointsModal from "@/components/modals/PointsModal.vue";
 
 // eslint-disable-next-line no-undef
-const emit = defineEmits(["win-points"]);
+const emit = defineEmits(["win-points", "read-only"]);
 
 // eslint-disable-next-line no-undef
 const props = defineProps({
@@ -422,6 +473,9 @@ const props = defineProps({
   // Y-axis label and progress unit (e.g. "Rank Score" / "RS" for Ranked).
   yAxisLabel: { type: String, default: "Total Win Points" },
   unit: { type: String, default: "WP" },
+  // CSS selector of an element (in the aside) to teleport the season controls
+  // into. When empty, the controls render inline under the header.
+  seasonControlsTo: { type: String, default: "" },
 });
 
 // Config
@@ -461,13 +515,88 @@ const {
 
 const svgHeight = computed(() => showPaceGraph.value ? svgHeightPace : height);
 
+// Season list (current + historical) for the picker and overlay.
+const { seasons, currentSeasonKey, load: loadSeasons } = useSeasons();
+
+// Which season the graph is centered on, and which (if any) is overlaid for
+// comparison. Not persisted — the graph always opens on the live season.
+const selectedSeasonKey = ref("");
+const overlaySeasonKey = ref("");
+
+// The teleport target (in the aside) is rendered by the parent and may not
+// exist until after this component mounts, so gate the Teleport on a post-mount
+// flag to avoid "failed to locate target" warnings.
+const controlsMounted = ref(false);
+const teleportControls = computed(
+  () => !!props.seasonControlsTo && controlsMounted.value
+);
+
+const currentSeason = computed(
+  () => seasons.value.find((s) => s.key === currentSeasonKey.value) || null
+);
+const selectedSeason = computed(
+  () => seasons.value.find((s) => s.key === selectedSeasonKey.value) || null
+);
+const overlaySeason = computed(
+  () => seasons.value.find((s) => s.key === overlaySeasonKey.value) || null
+);
+
+// True when looking at any season other than the live one — the graph becomes
+// read-only (a historical look-back, not an editable log).
+const isViewingPastSeason = computed(
+  () =>
+    !!selectedSeasonKey.value &&
+    !!currentSeasonKey.value &&
+    selectedSeasonKey.value !== currentSeasonKey.value
+);
+
+// The window the chart actually renders. For the live season this is the
+// persisted seasonStart/seasonEnd (unchanged behavior); for a past season it's
+// that season's fixed window.
+const viewedStart = computed(() =>
+  isViewingPastSeason.value && selectedSeason.value
+    ? selectedSeason.value.start
+    : seasonStart.value
+);
+const viewedEnd = computed(() =>
+  isViewingPastSeason.value && selectedSeason.value
+    ? selectedSeason.value.end
+    : seasonEnd.value
+);
+const overlayStart = computed(() =>
+  overlaySeason.value ? overlaySeason.value.start : null
+);
+const overlayEnd = computed(() =>
+  overlaySeason.value ? overlaySeason.value.end : null
+);
+
+// Season picker option lists.
+const seasonsDesc = computed(() => [...seasons.value].reverse());
+const overlayOptions = computed(() =>
+  seasonsDesc.value.filter((s) => s.key !== selectedSeasonKey.value)
+);
+
+const displayTitle = computed(() => {
+  if (isViewingPastSeason.value && selectedSeason.value)
+    return selectedSeason.value.name;
+  return props.headerTitle || seasonTitle.value || "Interactive Line Graph";
+});
+
 // Domains
 const isSeasonValid = computed(
   () =>
-    seasonStart.value &&
-    seasonEnd.value &&
-    dateToMs(seasonStart.value) < dateToMs(seasonEnd.value)
+    viewedStart.value &&
+    viewedEnd.value &&
+    dateToMs(viewedStart.value) < dateToMs(viewedEnd.value)
 );
+
+// Clear an overlay that collides with the newly selected season (can't overlay
+// a season on itself).
+watch(selectedSeasonKey, (key) => {
+  if (overlaySeasonKey.value === key) overlaySeasonKey.value = "";
+});
+
+watch(isViewingPastSeason, (v) => emit("read-only", v), { immediate: true });
 
 // Points data (API-backed CRUD)
 const {
@@ -489,7 +618,7 @@ const {
   onImportedRows,
   addWinPoints,
   incrementWinPoints,
-} = usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode: props.mode });
+} = usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode: props.mode, isReadOnly: isViewingPastSeason });
 
 // Modal state
 const showImportModal = ref(false);
@@ -502,6 +631,8 @@ const {
   rankBands,
   scaledPoints,
   pathD,
+  overlayScaledPoints,
+  overlayPathD,
   placementBaselinePath,
   pathGoalFromZero,
   pathGoalFromLast,
@@ -527,12 +658,14 @@ const {
   today,
   mode: props.mode,
   goalOptions: () => props.goalOptions,
-  seasonStart,
-  seasonEnd,
+  seasonStart: viewedStart,
+  seasonEnd: viewedEnd,
   goalWinPoints,
   isSeasonValid,
   points,
   sortedPoints,
+  overlayStart,
+  overlayEnd,
 });
 
 // Rank info based on goalOptions thresholds
@@ -653,30 +786,23 @@ watch(currentWinPoints, (v) => emit("win-points", v));
 onMounted(async () => {
   loadSettings();
   try {
-    const data = await loadSeasonJson();
-    if (
-      data &&
-      data.currentSeason &&
-      data.currentSeason.start &&
-      data.currentSeason.end
-    ) {
-      const startMs = new Date(data.currentSeason.start).getTime();
-      const endMs = new Date(data.currentSeason.end).getTime();
-      if (!isNaN(startMs) && !isNaN(endMs)) {
-        seasonStart.value = msToDateInput(startMs);
-        seasonEnd.value = msToDateInput(endMs);
-      }
-      if (
-        typeof data.currentSeason.name === "string" &&
-        data.currentSeason.name.trim()
-      ) {
-        const nm = String(data.currentSeason.name).trim();
-        seasonTitle.value = nm.startsWith("Season") ? nm : `Season ${nm}`;
-      }
+    await loadSeasons();
+    // Default the live season's window to the current season (unchanged
+    // behavior) and open the picker on it.
+    const cur = currentSeason.value;
+    if (cur) {
+      seasonStart.value = cur.start;
+      seasonEnd.value = cur.end;
+      seasonTitle.value = cur.name;
     }
+    selectedSeasonKey.value = currentSeasonKey.value;
   } catch (e) {
     // If fetch fails (e.g., CORS), keep existing defaults/state
   }
+  // Wait for the full tree (incl. the aside teleport target) to render before
+  // enabling the teleport.
+  await nextTick();
+  controlsMounted.value = true;
   // Load points from D1
   await loadPointsFromAPI();
   // Emit initial after load tick

--- a/packages/web/src/components/SeasonControls.vue
+++ b/packages/web/src/components/SeasonControls.vue
@@ -1,0 +1,93 @@
+<template>
+  <div v-if="seasons.length" class="lg-season-controls">
+    <label class="season-select">
+      <span>Season</span>
+      <select
+        :value="selected"
+        @change="$emit('update:selected', $event.target.value)"
+      >
+        <option v-for="s in seasonsDesc" :key="s.key" :value="s.key">
+          {{ s.name }}{{ s.key === currentSeasonKey ? " (current)" : "" }}
+        </option>
+      </select>
+    </label>
+    <label class="season-select">
+      <span>Compare</span>
+      <select
+        :value="overlay"
+        @change="$emit('update:overlay', $event.target.value)"
+      >
+        <option value="">None</option>
+        <option v-for="s in overlayOptions" :key="s.key" :value="s.key">
+          {{ s.name }}
+        </option>
+      </select>
+    </label>
+    <span v-if="overlaySeason" class="overlay-legend">
+      <span class="overlay-swatch"></span>{{ overlaySeason.name }} (overlay,
+      aligned by day)
+    </span>
+  </div>
+</template>
+
+<script setup>
+// Presentational season picker + previous-season overlay selector. All state
+// lives in LineGraph; this is bound via :selected/:overlay and update events so
+// it can be teleported into the aside without owning any logic.
+// eslint-disable-next-line no-undef
+defineProps({
+  seasons: { type: Array, default: () => [] },
+  seasonsDesc: { type: Array, default: () => [] },
+  overlayOptions: { type: Array, default: () => [] },
+  currentSeasonKey: { type: String, default: "" },
+  selected: { type: String, default: "" },
+  overlay: { type: String, default: "" },
+  overlaySeason: { type: Object, default: null },
+})
+
+// eslint-disable-next-line no-undef
+defineEmits(["update:selected", "update:overlay"])
+</script>
+
+<style scoped>
+.lg-season-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.season-select {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.season-select select {
+  font: inherit;
+  width: 100%;
+  color: var(--text-strong);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--primary) 30%, transparent);
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.overlay-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.overlay-swatch {
+  display: inline-block;
+  width: 18px;
+  height: 0;
+  border-top: 2px dashed var(--primary);
+  opacity: 0.7;
+}
+</style>

--- a/packages/web/src/components/modals/PointsModal.vue
+++ b/packages/web/src/components/modals/PointsModal.vue
@@ -37,7 +37,7 @@
             </template>
             <template v-else>
               <span>({{ pt.date }} , {{ pt.y }} pts)</span>
-              <div class="row-actions">
+              <div class="row-actions" v-if="!readOnly">
                 <button
                   class="btn-primary"
                   @click="openEdit(getOriginalIndex(pt))"
@@ -70,6 +70,8 @@ import { isValidDateStr } from '@/utils/date'
 const props = defineProps({
   points: { type: Array, required: true },
   sortedPointsReverse: { type: Array, required: true },
+  // When true (viewing a past season), the list is view-only: edit/remove hidden.
+  readOnly: { type: Boolean, default: false },
 })
 
 // eslint-disable-next-line no-undef

--- a/packages/web/src/composables/useChartGeometry.js
+++ b/packages/web/src/composables/useChartGeometry.js
@@ -14,6 +14,7 @@ import {
   buildRequiredPaceData,
   buildPointsEarnedData,
   requiredPerDayFromBaseline,
+  mapOverlayByDayOfSeason,
 } from "@/utils/chart";
 import { buildRankBands } from "@/utils/rankColors";
 
@@ -30,6 +31,9 @@ import { buildRankBands } from "@/utils/rankColors";
  * - seasonStart/seasonEnd/goalWinPoints: persisted graph settings (refs)
  * - isSeasonValid: ref, true when start < end
  * - points: reactive raw point array; sortedPoints: date-sorted computed
+ * - overlayStart/overlayEnd: optional refs for a previous season to overlay,
+ *   aligned by day-of-season onto the viewed (seasonStart/seasonEnd) window.
+ *   Null/undefined when no overlay is active.
  */
 export function useChartGeometry({
   width,
@@ -47,6 +51,8 @@ export function useChartGeometry({
   isSeasonValid,
   points,
   sortedPoints,
+  overlayStart,
+  overlayEnd,
 }) {
   const xDomain = computed(() =>
     calcXDomain(seasonStart.value, seasonEnd.value, today)
@@ -61,8 +67,28 @@ export function useChartGeometry({
     });
   });
 
+  // Previous-season points filtered to the overlay window (raw, date-sorted).
+  // These get re-mapped by day-of-season for display, but their y-values also
+  // feed the y-domain so a higher past season isn't clipped off the top.
+  const overlayPointsRaw = computed(() => {
+    const start = overlayStart?.value;
+    const end = overlayEnd?.value;
+    if (!start || !end) return [];
+    const min = dateToMs(start);
+    const max = dateToMs(end);
+    return points
+      .filter((p) => {
+        const ms = dateToMs(p.date);
+        return isFinite(ms) && ms >= min && ms <= max;
+      })
+      .sort((a, b) => dateToMs(a.date) - dateToMs(b.date));
+  });
+
   const yDomain = computed(() =>
-    calcYDomain(pointsInSeason.value, goalWinPoints.value)
+    calcYDomain(
+      [...pointsInSeason.value, ...overlayPointsRaw.value],
+      goalWinPoints.value
+    )
   );
 
   // Scales
@@ -117,6 +143,36 @@ export function useChartGeometry({
   });
 
   const pathD = computed(() => buildPathD(scaledPathPoints.value));
+
+  // Overlay: a previous season's line, re-mapped so its day 0 sits at the
+  // viewed season's start, then scaled with the same axes. World Tour gets the
+  // same synthetic day-0 baseline (y=0) the main line uses; ranked starts at
+  // its first recorded point.
+  const overlayMapped = computed(() =>
+    mapOverlayByDayOfSeason(
+      overlayPointsRaw.value,
+      dateToMs(overlayStart?.value),
+      dateToMs(seasonStart.value),
+      dateToMs(seasonEnd.value)
+    )
+  );
+
+  const overlayScaledPoints = computed(() =>
+    overlayMapped.value.map((p) => ({ x: scaleX(p.date), y: scaleY(p.y) }))
+  );
+
+  const overlayPathPoints = computed(() => {
+    const sp = overlayScaledPoints.value;
+    if (!sp.length || mode === "ranked") return sp;
+    const overlayStartMs = dateToMs(overlayStart?.value);
+    const firstMs = dateToMs(overlayPointsRaw.value[0]?.date);
+    if (isFinite(overlayStartMs) && isFinite(firstMs) && firstMs > overlayStartMs) {
+      return [{ x: scaleX(seasonStart.value), y: scaleY(0) }, ...sp];
+    }
+    return sp;
+  });
+
+  const overlayPathD = computed(() => buildPathD(overlayPathPoints.value));
 
   // Ranked only: a flat line from season start across to the placement point at
   // the placement RS, making it clear the climb begins at placement (not 0).
@@ -286,6 +342,8 @@ export function useChartGeometry({
     paceBaseline,
     scaledPathPoints,
     pathD,
+    overlayScaledPoints,
+    overlayPathD,
     placementBaselinePath,
     pathGoalFromZero,
     pathGoalFromLast,

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -19,7 +19,10 @@ import { connectLiveUpdates } from '@/services/liveUpdates'
  * @param {import('vue').Ref<string>} opts.seasonEnd
  * @param {import('vue').Ref<boolean>} opts.autoSetSeasonFromImport
  */
-export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode = 'world-tour' }) {
+export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode = 'world-tour', isReadOnly }) {
+  // When viewing a previous (read-only) season, all mutations are inert — the
+  // graph still shows that season's data, but nothing can be edited or saved.
+  const readOnly = () => !!(isReadOnly && isReadOnly.value)
   // Live events carry a `mode`; ignore any that belong to a different graph.
   // Treat a missing mode as 'world-tour' for backward-compat with old payloads.
   const matchesMode = (payload) => (payload?.mode ?? 'world-tour') === mode
@@ -152,6 +155,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function addPointAtDate(dateStr, yVal) {
+    if (readOnly()) return
     if (!isSeasonValid.value) return
     if (!isValidDateStr(dateStr)) return
     const yNum = Number(yVal)
@@ -172,6 +176,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function removePoint(index) {
+    if (readOnly()) return
     const point = points[index]
     points.splice(index, 1)
     if (point?.remoteId) {
@@ -185,6 +190,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function onSaveEdit({ index, date, y }) {
+    if (readOnly()) return
     const yNum = Number(y)
     if (!isFinite(yNum)) return
     points[index] = { ...points[index], date, y: yNum }
@@ -198,6 +204,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function clearPoints() {
+    if (readOnly()) return
     points.splice(0, points.length)
     try {
       const authHeader = await getAuthorizationHeader()
@@ -208,6 +215,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function onImportedRows(rows) {
+    if (readOnly()) return
     if (!Array.isArray(rows) || !rows.length) return
     points.splice(0, points.length, ...rows)
     if (autoSetSeasonFromImport.value) {
@@ -238,6 +246,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function addWinPoints(value) {
+    if (readOnly()) return
     const val = Number(value)
     if (!isFinite(val)) return
     const today = formatDate(new Date())
@@ -257,6 +266,7 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   }
 
   async function incrementWinPoints(increment) {
+    if (readOnly()) return
     const inc = Number(increment)
     if (!isFinite(inc)) return
     const today = formatDate(new Date())

--- a/packages/web/src/composables/useSeasons.js
+++ b/packages/web/src/composables/useSeasons.js
@@ -1,0 +1,78 @@
+import { ref } from 'vue'
+import { loadSeasonJson } from '@/utils/season'
+import { msToDateInput, dateToMs } from '@/utils/date'
+
+/**
+ * Loads the full season list (current + historical) once and exposes it in a
+ * normalized, date-input-friendly shape for the graph to point at.
+ *
+ * The backend already returns every season from the wiki, and the user's
+ * records span all of them, so "viewing a past season" is just pointing the
+ * existing chart geometry at a different [start, end] window.
+ */
+export function useSeasons() {
+  const seasons = ref([]) // normalized, ascending by start date
+  const currentSeasonKey = ref('')
+  const loading = ref(false)
+  const error = ref('')
+
+  function displayName(name) {
+    const nm = String(name || '').trim()
+    if (!nm) return ''
+    return nm.toLowerCase().startsWith('season') ? nm : `Season ${nm}`
+  }
+
+  // Convert a wiki season ({ name, start, end }) into a window the chart can
+  // consume directly. Dates are normalized to YYYY-MM-DD the same way the
+  // current-season default is (new Date(iso) -> msToDateInput) so a selected
+  // past season lines up with the existing seasonStart/seasonEnd handling.
+  function normalize(s) {
+    if (!s || !s.start || !s.end) return null
+    const startMs = new Date(s.start).getTime()
+    const endMs = new Date(s.end).getTime()
+    if (isNaN(startMs) || isNaN(endMs)) return null
+    const start = msToDateInput(startMs)
+    const end = msToDateInput(endMs)
+    return {
+      key: String(s.name),
+      name: displayName(s.name),
+      start,
+      end,
+      startMs: dateToMs(start),
+      endMs: dateToMs(end),
+    }
+  }
+
+  async function load(signal) {
+    loading.value = true
+    error.value = ''
+    try {
+      const data = await loadSeasonJson(signal)
+      const list = Array.isArray(data?.seasons)
+        ? data.seasons.map(normalize).filter(Boolean)
+        : []
+      list.sort((a, b) => a.startMs - b.startMs)
+      seasons.value = list
+
+      const cs = data?.currentSeason
+      const match = cs?.name
+        ? list.find((s) => s.key === String(cs.name))
+        : null
+      // Fall back to the latest known season if the wiki reports no active
+      // season (e.g. between seasons) — there's always something to show.
+      currentSeasonKey.value = match
+        ? match.key
+        : list.length
+          ? list[list.length - 1].key
+          : ''
+      return data
+    } catch (e) {
+      error.value = 'Failed to load seasons'
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { seasons, currentSeasonKey, loading, error, load }
+}

--- a/packages/web/src/utils/chart.js
+++ b/packages/web/src/utils/chart.js
@@ -203,6 +203,24 @@ export function buildPointsEarnedData(sortedPoints, baselineY = 0) {
   })
 }
 
+// Re-maps a previous season's points onto the viewed season's x-axis by
+// day-of-season, so day 0 of each season lines up (e.g. "where was I on day 12
+// last season vs this one"). Returns raw { date, y } pairs the caller scales
+// with the viewed season's scaleX/scaleY. Points whose elapsed day falls past
+// the viewed season's end are dropped rather than clamped to the right edge.
+export function mapOverlayByDayOfSeason(overlayPoints, overlayStartMs, viewedStartMs, viewedEndMs) {
+  const out = []
+  if (!isFinite(overlayStartMs) || !isFinite(viewedStartMs)) return out
+  for (const p of overlayPoints) {
+    const ms = dateToMs(p.date)
+    if (!isFinite(ms)) continue
+    const mappedMs = viewedStartMs + (ms - overlayStartMs)
+    if (isFinite(viewedEndMs) && mappedMs > viewedEndMs) continue
+    out.push({ date: msToDateInput(mappedMs), y: p.y })
+  }
+  return out
+}
+
 export function buildXTicks(xDomain, width, padding, n = 4) {
   const plotWidth = width - padding * 2
   const [min, max] = xDomain

--- a/packages/web/src/views/Ranked.vue
+++ b/packages/web/src/views/Ranked.vue
@@ -10,11 +10,26 @@
           yAxisLabel="Rank Score"
           unit="RS"
           :goalOptions="rankedThresholds"
+          season-controls-to="#season-controls-ranked"
           @win-points="onRankScore"
+          @read-only="onReadOnly"
         />
       </template>
       <template #aside>
-        <SetPointsCard @add-at-date="addCustom" @add-today="addToday" />
+        <!-- Season picker + overlay teleport here from LineGraph -->
+        <div class="season-card">
+          <div class="season-card-header">Seasons</div>
+          <div id="season-controls-ranked"></div>
+        </div>
+        <SetPointsCard
+          v-if="!readOnly"
+          @add-at-date="addCustom"
+          @add-today="addToday"
+        />
+        <p v-else class="past-season-note">
+          Viewing a past season — read-only. Switch back to the current season to
+          log points.
+        </p>
       </template>
     </ModeLayout>
   </section>
@@ -62,9 +77,15 @@ export default {
     const { rankInfo, toNext, progressPct } = useRankInfo(rankScore, thresholds)
     return { rankScore, rankedThresholds: RANKED_THRESHOLDS, rankInfo, toNext, progressPct }
   },
+  data() {
+    return { readOnly: false }
+  },
   methods: {
     onRankScore(v) {
       this.rankScore = Number(v) || 0
+    },
+    onReadOnly(v) {
+      this.readOnly = !!v
     },
     addCustom({ date, y }) {
       const graph = this.$refs.graphRef
@@ -81,3 +102,25 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.past-season-note {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  line-height: 1.4;
+}
+.season-card {
+  border: 1px solid color-mix(in oklab, var(--primary) 18%, var(--surface));
+  border-radius: 12px;
+  padding: 12px;
+  background: color-mix(in oklab, var(--surface) 90%, #000);
+}
+.season-card-header {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 900;
+  margin-bottom: 8px;
+}
+</style>

--- a/packages/web/src/views/WorldTour.vue
+++ b/packages/web/src/views/WorldTour.vue
@@ -8,12 +8,25 @@
           gamemode="World Tour"
           :goalOptions="thresholds"
           headerDisclaimer="Based on World Tour wiki thresholds."
+          season-controls-to="#season-controls-world-tour"
           @win-points="onWinPoints"
+          @read-only="onReadOnly"
         />
       </template>
       <template #aside>
-        <PointsCheatsheet :values="quickAddValues" @quick-add="onQuickAdd" />
-        <SetPointsCard @add-at-date="addCustom" @add-today="addToday" />
+        <!-- Season picker + overlay teleport here from LineGraph -->
+        <div class="season-card">
+          <div class="season-card-header">Seasons</div>
+          <div id="season-controls-world-tour"></div>
+        </div>
+        <template v-if="!readOnly">
+          <PointsCheatsheet :values="quickAddValues" @quick-add="onQuickAdd" />
+          <SetPointsCard @add-at-date="addCustom" @add-today="addToday" />
+        </template>
+        <p v-else class="past-season-note">
+          Viewing a past season — read-only. Switch back to the current season to
+          log points.
+        </p>
       </template>
     </ModeLayout>
   </section>
@@ -39,11 +52,15 @@ export default {
   data() {
     return {
       quickAddValues: { round1: 2, round2: 6, finalLose: 14, finalWin: 25 },
+      readOnly: false,
     };
   },
   methods: {
     onWinPoints(v) {
       this.winPoints = Number(v) || 0;
+    },
+    onReadOnly(v) {
+      this.readOnly = !!v;
     },
     onQuickAdd(inc) {
       const graph = this.$refs.graphRef;
@@ -68,3 +85,25 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.past-season-note {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  line-height: 1.4;
+}
+.season-card {
+  border: 1px solid color-mix(in oklab, var(--primary) 18%, var(--surface));
+  border-radius: 12px;
+  padding: 12px;
+  background: color-mix(in oklab, var(--surface) 90%, #000);
+}
+.season-card-header {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 900;
+  margin-bottom: 8px;
+}
+</style>

--- a/packages/web/tests/overlay.spec.js
+++ b/packages/web/tests/overlay.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { mapOverlayByDayOfSeason } from '@/utils/chart'
+import { dateToMs } from '@/utils/date'
+
+// Two seasons on different calendar dates. The overlay should be re-mapped so
+// "day N of season" lines up regardless of the real dates.
+const prevStart = dateToMs('2025-01-01')
+const viewedStart = dateToMs('2026-03-01')
+const viewedEnd = dateToMs('2026-03-31')
+
+describe('mapOverlayByDayOfSeason', () => {
+  it('aligns day 0 of both seasons', () => {
+    const overlay = [{ date: '2025-01-01', y: 100 }]
+    const out = mapOverlayByDayOfSeason(overlay, prevStart, viewedStart, viewedEnd)
+    expect(out).toHaveLength(1)
+    // Day 0 of the previous season maps to day 0 (start) of the viewed season.
+    expect(out[0].date).toBe('2026-03-01')
+    expect(out[0].y).toBe(100)
+  })
+
+  it('preserves elapsed-day offset, not the calendar date', () => {
+    // 11 days into the previous season -> 11 days into the viewed season.
+    const overlay = [{ date: '2025-01-12', y: 250 }]
+    const out = mapOverlayByDayOfSeason(overlay, prevStart, viewedStart, viewedEnd)
+    expect(out[0].date).toBe('2026-03-12')
+    expect(out[0].y).toBe(250)
+  })
+
+  it('drops points that fall past the viewed season end', () => {
+    // The previous season was longer; a point on its day 40 has no day 40 in a
+    // 30-day viewed window, so it is dropped rather than clamped to the edge.
+    const overlay = [
+      { date: '2025-01-15', y: 1 }, // day 14 -> in range
+      { date: '2025-02-15', y: 2 }, // day 45 -> past viewed end
+    ]
+    const out = mapOverlayByDayOfSeason(overlay, prevStart, viewedStart, viewedEnd)
+    expect(out.map((p) => p.y)).toEqual([1])
+  })
+
+  it('returns nothing when anchors are invalid', () => {
+    expect(mapOverlayByDayOfSeason([{ date: '2025-01-01', y: 1 }], NaN, viewedStart, viewedEnd)).toEqual([])
+    expect(mapOverlayByDayOfSeason([{ date: '2025-01-01', y: 1 }], prevStart, NaN, viewedEnd)).toEqual([])
+  })
+
+  it('skips points with unparseable dates', () => {
+    const overlay = [
+      { date: 'not-a-date', y: 9 },
+      { date: '2025-01-05', y: 7 },
+    ]
+    const out = mapOverlayByDayOfSeason(overlay, prevStart, viewedStart, viewedEnd)
+    expect(out.map((p) => p.y)).toEqual([7])
+  })
+})


### PR DESCRIPTION
## What

Adds a way to look back at progress in previous seasons and overlay a previous season on the current graph. Web app only.

The key realization: this is almost entirely additive frontend work. `GET /me/records` already returns **every** record (the graph just filters client-side by the season window), and `GET /seasons` already lists all historical seasons. So a "season" is just a `[start, end]` window we point the existing chart geometry at — no backend or data-model changes.

## How it works

- **Season picker + Compare (overlay)** controls live in a new "Seasons" card at the top of the aside (right column). They're a presentational `SeasonControls.vue` teleported out of `LineGraph` so all season state stays in one place.
- **Selecting a past season** repoints the graph at that season's window — you get the full read-only graph (line, pace sub-graph, rank bands, projections, stats).
- **Overlay** draws the comparison season as a faint dashed line **aligned by day-of-season** (day 0 = season start for both), so "where was I on day 12 last season vs this one" lines up regardless of calendar dates. Its y-values feed the y-domain so a taller past season isn't clipped; points past the viewed window's end are dropped rather than clamped.
- **Read-only enforcement** for past seasons: `usePointsData` mutations no-op, Import/Clear disabled, `PointsModal` hides edit/remove, and the aside logging cards swap for a short note. The Seasons card stays visible so you can switch back.
- **Rank indicator** restyled: black background, full width of the controls area.

## New / changed
- `composables/useSeasons.js` (new) — normalized season list + current-season key
- `components/SeasonControls.vue` (new) — presentational picker
- `utils/chart.js` — `mapOverlayByDayOfSeason` pure helper
- `composables/useChartGeometry.js` — overlay path + y-domain
- `LineGraph.vue`, `usePointsData.js`, `PointsModal.vue`, `views/WorldTour.vue`, `views/Ranked.vue`, `rank-indicator.css`
- `tests/overlay.spec.js` (new)

## Notes
- Selection isn't persisted across reloads (always opens on the live season).
- Goal projections still render on past seasons using the current goal.

## Verification
- `pnpm test` → 108 passed (incl. 5 new overlay-mapping tests)
- `pnpm lint` → clean
- `pnpm build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)