### PR TITLE
feat(web): gate season comparison on available data

### DIFF
--- a/packages/web/src/components/LineGraph.vue
+++ b/packages/web/src/components/LineGraph.vue
@@ -17,12 +17,14 @@
     <Teleport v-if="teleportControls" :to="seasonControlsTo">
       <SeasonControls
         :seasons="seasons"
-        :seasons-desc="seasonsDesc"
+        :season-options="seasonOptions"
         :overlay-options="overlayOptions"
         :current-season-key="currentSeasonKey"
         :selected="selectedSeasonKey"
         :overlay="overlaySeasonKey"
         :overlay-season="overlaySeason"
+        :disabled="seasonModuleDisabled"
+        :disabled-message="seasonDisabledMessage"
         @update:selected="selectedSeasonKey = $event"
         @update:overlay="overlaySeasonKey = $event"
       />
@@ -30,12 +32,14 @@
     <SeasonControls
       v-else-if="!seasonControlsTo"
       :seasons="seasons"
-      :seasons-desc="seasonsDesc"
+      :season-options="seasonOptions"
       :overlay-options="overlayOptions"
       :current-season-key="currentSeasonKey"
       :selected="selectedSeasonKey"
       :overlay="overlaySeasonKey"
       :overlay-season="overlaySeason"
+      :disabled="seasonModuleDisabled"
+      :disabled-message="seasonDisabledMessage"
       @update:selected="selectedSeasonKey = $event"
       @update:overlay="overlaySeasonKey = $event"
     />
@@ -443,6 +447,7 @@ import {
   formatDate,
 } from "@/utils/date";
 import { buildCSV } from "@/utils/csv";
+import { seasonsWithDataKeys } from "@/utils/chart";
 import { useRankInfo } from "@/composables/useRankInfo";
 import { usePanZoom } from "@/composables/usePanZoom";
 import { useGraphSettings } from "@/composables/useGraphSettings";
@@ -570,10 +575,34 @@ const overlayEnd = computed(() =>
   overlaySeason.value ? overlaySeason.value.end : null
 );
 
-// Season picker option lists.
+// Which seasons the user actually has logged data in (≥1 point in the season's
+// date window). Drives the picker so we never offer a previous season that
+// would render an empty graph.
+const dataSeasonKeys = computed(() => seasonsWithDataKeys(points, seasons.value));
+
+// Previous seasons (not the live one) the user has data for. When this is
+// empty there's nothing to explore yet, so the whole module is disabled.
+const pastSeasonsWithData = computed(() =>
+  seasons.value.filter(
+    (s) => s.key !== currentSeasonKey.value && dataSeasonKeys.value.has(s.key)
+  )
+);
+const seasonModuleDisabled = computed(() => pastSeasonsWithData.value.length === 0);
+const seasonDisabledMessage =
+  "Log points across more than the current season to unlock historical comparisons.";
+
+// Season picker option lists (newest first). The current season is always
+// selectable; past seasons appear only once they have data.
 const seasonsDesc = computed(() => [...seasons.value].reverse());
+const seasonOptions = computed(() =>
+  seasonsDesc.value.filter(
+    (s) => s.key === currentSeasonKey.value || dataSeasonKeys.value.has(s.key)
+  )
+);
 const overlayOptions = computed(() =>
-  seasonsDesc.value.filter((s) => s.key !== selectedSeasonKey.value)
+  seasonsDesc.value.filter(
+    (s) => s.key !== selectedSeasonKey.value && dataSeasonKeys.value.has(s.key)
+  )
 );
 
 const displayTitle = computed(() => {
@@ -594,6 +623,26 @@ const isSeasonValid = computed(
 // a season on itself).
 watch(selectedSeasonKey, (key) => {
   if (overlaySeasonKey.value === key) overlaySeasonKey.value = "";
+});
+
+// Keep selection/overlay valid if the available options change (e.g. data
+// loads in): fall back to the current season / no overlay.
+watch(seasonOptions, (opts) => {
+  if (
+    selectedSeasonKey.value &&
+    currentSeasonKey.value &&
+    !opts.some((s) => s.key === selectedSeasonKey.value)
+  ) {
+    selectedSeasonKey.value = currentSeasonKey.value;
+  }
+});
+watch(overlayOptions, (opts) => {
+  if (
+    overlaySeasonKey.value &&
+    !opts.some((s) => s.key === overlaySeasonKey.value)
+  ) {
+    overlaySeasonKey.value = "";
+  }
 });
 
 watch(isViewingPastSeason, (v) => emit("read-only", v), { immediate: true });

--- a/packages/web/src/components/SeasonControls.vue
+++ b/packages/web/src/components/SeasonControls.vue
@@ -1,32 +1,35 @@
 <template>
   <div v-if="seasons.length" class="lg-season-controls">
-    <label class="season-select">
-      <span>Season</span>
-      <select
-        :value="selected"
-        @change="$emit('update:selected', $event.target.value)"
-      >
-        <option v-for="s in seasonsDesc" :key="s.key" :value="s.key">
-          {{ s.name }}{{ s.key === currentSeasonKey ? " (current)" : "" }}
-        </option>
-      </select>
-    </label>
-    <label class="season-select">
-      <span>Compare</span>
-      <select
-        :value="overlay"
-        @change="$emit('update:overlay', $event.target.value)"
-      >
-        <option value="">None</option>
-        <option v-for="s in overlayOptions" :key="s.key" :value="s.key">
-          {{ s.name }}
-        </option>
-      </select>
-    </label>
-    <span v-if="overlaySeason" class="overlay-legend">
-      <span class="overlay-swatch"></span>{{ overlaySeason.name }} (overlay,
-      aligned by day)
-    </span>
+    <p v-if="disabled" class="season-locked">{{ disabledMessage }}</p>
+    <template v-else>
+      <label class="season-select">
+        <span>Season</span>
+        <select
+          :value="selected"
+          @change="$emit('update:selected', $event.target.value)"
+        >
+          <option v-for="s in seasonOptions" :key="s.key" :value="s.key">
+            {{ s.name }}{{ s.key === currentSeasonKey ? " (current)" : "" }}
+          </option>
+        </select>
+      </label>
+      <label class="season-select">
+        <span>Compare</span>
+        <select
+          :value="overlay"
+          @change="$emit('update:overlay', $event.target.value)"
+        >
+          <option value="">None</option>
+          <option v-for="s in overlayOptions" :key="s.key" :value="s.key">
+            {{ s.name }}
+          </option>
+        </select>
+      </label>
+      <span v-if="overlaySeason" class="overlay-legend">
+        <span class="overlay-swatch"></span>{{ overlaySeason.name }} (overlay,
+        aligned by day)
+      </span>
+    </template>
   </div>
 </template>
 
@@ -34,15 +37,21 @@
 // Presentational season picker + previous-season overlay selector. All state
 // lives in LineGraph; this is bound via :selected/:overlay and update events so
 // it can be teleported into the aside without owning any logic.
+//
+// `seasonOptions` / `overlayOptions` are pre-filtered by the parent to seasons
+// the user actually has data for. When there's no prior-season data at all the
+// module is `disabled` and only the explanatory message shows.
 // eslint-disable-next-line no-undef
 defineProps({
   seasons: { type: Array, default: () => [] },
-  seasonsDesc: { type: Array, default: () => [] },
+  seasonOptions: { type: Array, default: () => [] },
   overlayOptions: { type: Array, default: () => [] },
   currentSeasonKey: { type: String, default: "" },
   selected: { type: String, default: "" },
   overlay: { type: String, default: "" },
   overlaySeason: { type: Object, default: null },
+  disabled: { type: Boolean, default: false },
+  disabledMessage: { type: String, default: "" },
 })
 
 // eslint-disable-next-line no-undef
@@ -55,6 +64,13 @@ defineEmits(["update:selected", "update:overlay"])
   flex-direction: column;
   align-items: stretch;
   gap: 10px;
+}
+
+.season-locked {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--muted);
 }
 
 .season-select {

--- a/packages/web/src/utils/chart.js
+++ b/packages/web/src/utils/chart.js
@@ -203,6 +203,21 @@ export function buildPointsEarnedData(sortedPoints, baselineY = 0) {
   })
 }
 
+// Keys of the seasons the user has at least one point inside, where each
+// season is { key, startMs, endMs } and the window is inclusive. Used to gate
+// the season picker so we never offer a previous season with no data.
+export function seasonsWithDataKeys(points, seasons) {
+  const keys = new Set()
+  for (const s of seasons) {
+    const has = points.some((p) => {
+      const ms = dateToMs(p.date)
+      return isFinite(ms) && ms >= s.startMs && ms <= s.endMs
+    })
+    if (has) keys.add(s.key)
+  }
+  return keys
+}
+
 // Re-maps a previous season's points onto the viewed season's x-axis by
 // day-of-season, so day 0 of each season lines up (e.g. "where was I on day 12
 // last season vs this one"). Returns raw { date, y } pairs the caller scales

--- a/packages/web/tests/overlay.spec.js
+++ b/packages/web/tests/overlay.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { mapOverlayByDayOfSeason } from '@/utils/chart'
+import { mapOverlayByDayOfSeason, seasonsWithDataKeys } from '@/utils/chart'
 import { dateToMs } from '@/utils/date'
 
 // Two seasons on different calendar dates. The overlay should be re-mapped so
@@ -49,5 +49,36 @@ describe('mapOverlayByDayOfSeason', () => {
     ]
     const out = mapOverlayByDayOfSeason(overlay, prevStart, viewedStart, viewedEnd)
     expect(out.map((p) => p.y)).toEqual([7])
+  })
+})
+
+describe('seasonsWithDataKeys', () => {
+  const seasons = [
+    { key: 'S1', startMs: dateToMs('2025-01-01'), endMs: dateToMs('2025-01-31') },
+    { key: 'S2', startMs: dateToMs('2025-02-01'), endMs: dateToMs('2025-02-28') },
+    { key: 'S3', startMs: dateToMs('2025-03-01'), endMs: dateToMs('2025-03-31') },
+  ]
+
+  it('returns only seasons containing at least one point', () => {
+    const points = [
+      { date: '2025-01-10', y: 5 }, // S1
+      { date: '2025-03-15', y: 9 }, // S3
+    ]
+    const keys = seasonsWithDataKeys(points, seasons)
+    expect([...keys].sort()).toEqual(['S1', 'S3'])
+  })
+
+  it('is inclusive of season boundaries', () => {
+    const keys = seasonsWithDataKeys([{ date: '2025-01-31', y: 1 }], seasons)
+    expect(keys.has('S1')).toBe(true)
+  })
+
+  it('returns an empty set when there are no points', () => {
+    expect(seasonsWithDataKeys([], seasons).size).toBe(0)
+  })
+
+  it('ignores points outside every season window', () => {
+    const keys = seasonsWithDataKeys([{ date: '2024-12-15', y: 1 }], seasons)
+    expect(keys.size).toBe(0)
   })
 })


### PR DESCRIPTION
Follow-up to #131 (which is already merged). That PR's branch had merged before this commit landed, so this opens a fresh PR for it.

## What

The season comparison module now only offers seasons the user actually has data for, and disables itself entirely when there's nothing to compare yet.

- **Picker only lists seasons with data.** A pure helper `seasonsWithDataKeys(points, seasons)` detects which seasons contain ≥1 logged point (window-inclusive). The **Season** dropdown shows the current season (always) plus past seasons with data; **Compare** shows only seasons with data, minus the selected one.
- **No prior-season data → module disabled with a message:** *"Log points across more than the current season to unlock historical comparisons."*
- **Safety watches** reset the selection to the current season / clear the overlay if a chosen season ever leaves the available options (e.g. as data loads in).

Detection reacts to the live `points` array, so the module unlocks automatically once data spanning a previous season is present or imported.

## Files
- `utils/chart.js` — `seasonsWithDataKeys` helper
- `components/LineGraph.vue` — data-aware option lists + disabled state + watches
- `components/SeasonControls.vue` — disabled message UI
- `tests/overlay.spec.js` — 4 new tests for the helper

## Verification
- `pnpm test` → 112 passed
- `pnpm lint` → clean
- `pnpm build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Season selector now intelligently filters to display only seasons containing available data.
  * Added messaging to inform users when season selection is unavailable.

* **Bug Fixes**
  * Improved data integrity by automatically correcting stale season selections when available options change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->