### PR TITLE
feat(web): celebrate reaching the selected goal rank

### DIFF
--- a/packages/web/src/assets/rank-indicator.css
+++ b/packages/web/src/assets/rank-indicator.css
@@ -41,12 +41,23 @@
     color-mix(in oklab, var(--accent) 50%, var(--primary))
   );
 }
+.rank-progress .fill.achieved {
+  background: linear-gradient(90deg, #f5c542, #e8a317);
+}
 .rank-progress .labels {
   display: flex;
   justify-content: space-between;
   margin-top: 6px;
   color: var(--muted);
   font-size: 12px;
+}
+.rank-progress .labels.labels-achieved {
+  justify-content: center;
+}
+.rank-progress .goal-achieved {
+  color: #f5c542;
+  font-weight: 700;
+  letter-spacing: 0.02em;
 }
 .rank-note {
   margin-top: 8px;

--- a/packages/web/src/components/GoalControls.vue
+++ b/packages/web/src/components/GoalControls.vue
@@ -20,6 +20,8 @@
         :to-next-label="toNextLabel"
         :unit="unit"
         :progress-pct="progressPct"
+        :goal-achieved="goalAchieved"
+        :goal-label="goalLabel"
       />
     </template>
     <template v-else>
@@ -62,6 +64,23 @@ const onNumericInput = (e) => {
 const reversedGoalOptions = computed(() =>
   [...props.goalOptions].map((opt, i) => ({ ...opt, originalIndex: i })).reverse()
 )
+
+// The selected goal rank (if any). Used to celebrate reaching the goal rather
+// than silently rolling the progress bar over toward the next rank up.
+const selectedGoal = computed(() => {
+  const idx = Number(props.selectedGoalIndex)
+  if (Array.isArray(props.goalOptions) && idx >= 0 && idx < props.goalOptions.length) {
+    return props.goalOptions[idx]
+  }
+  return null
+})
+
+const goalAchieved = computed(() => {
+  const goal = Number(selectedGoal.value?.points)
+  return Number.isFinite(goal) && Number(props.currentWinPoints) >= goal
+})
+
+const goalLabel = computed(() => selectedGoal.value?.badge || '')
 
 const pointsLabel = computed(() => `${(props.currentWinPoints?.toLocaleString?.() || props.currentWinPoints)} ${props.unit}`)
 const floorLabel = computed(() => `${(props.rankInfo.currentFloor?.toLocaleString?.() || props.rankInfo.currentFloor)} ${props.unit}`)

--- a/packages/web/src/components/RankIndicator.vue
+++ b/packages/web/src/components/RankIndicator.vue
@@ -6,14 +6,23 @@
     </div>
     <div class="rank-progress">
       <div class="bar">
-        <div class="fill" :style="{ width: progressPct + '%' }"></div>
+        <div
+          class="fill"
+          :class="{ achieved: goalAchieved }"
+          :style="{ width: (goalAchieved ? 100 : progressPct) + '%' }"
+        ></div>
       </div>
-      <div class="labels">
-        <span>{{ currentFloorLabel }}</span>
-        <span v-if="nextTarget !== null">
-          Next rank: {{ nextBadge }} at {{ nextTargetLabel }} • {{ toNextLabel }} more {{ unit }} needed
+      <div class="labels" :class="{ 'labels-achieved': goalAchieved }">
+        <span v-if="goalAchieved" class="goal-achieved">
+          🎉 Goal reached<template v-if="goalLabel">: {{ goalLabel }}</template>
         </span>
-        <span v-else>Max rank reached</span>
+        <template v-else>
+          <span>{{ currentFloorLabel }}</span>
+          <span v-if="nextTarget !== null">
+            Next rank: {{ nextBadge }} at {{ nextTargetLabel }} • {{ toNextLabel }} more {{ unit }} needed
+          </span>
+          <span v-else>Max rank reached</span>
+        </template>
       </div>
     </div>
   </div>
@@ -34,6 +43,10 @@ defineProps({
   toNextLabel: { type: String, default: '' },
   unit: { type: String, default: 'WP' },
   progressPct: { type: Number, default: 0 },
+  // When the player has reached their selected goal rank, the bar fills and a
+  // celebratory label replaces the "distance to next rank" copy.
+  goalAchieved: { type: Boolean, default: false },
+  goalLabel: { type: String, default: '' },
 })
 </script>
 


### PR DESCRIPTION
## Problem

When the player reached their selected goal rank, the rank indicator rolled the progress bar over toward the *next* rank up — showing a nearly empty bar as if a fresh climb had just started, rather than recognizing the goal had been achieved.

This happened because `RankIndicator` only tracked rank progression (`useRankInfo`), not the user's selected goal. Hitting the goal rank crosses that rank's floor, so `progressPct` reset to ~0% and the label pointed at the rank above.

## Change

Make the indicator goal-aware:

- **`GoalControls.vue`** — derive `goalAchieved` (current points ≥ the selected goal rank's threshold) and `goalLabel` (the goal rank's badge), passed down to `RankIndicator`. Gated on `selectedGoalIndex >= 0` so the default numeric goal never triggers a false "achieved" state.
- **`RankIndicator.vue`** — when the goal is reached, the progress bar fills to 100% and the "distance to next rank" copy is replaced with a centered **"🎉 Goal reached: {rank}"** label.
- **`rank-indicator.css`** — gold gradient for the achieved fill, centered achieved label, gold bold text.

Normal progression (no goal selected, or goal not yet reached) is unchanged.

## Notes

The celebratory state appears in the rank-dropdown view where `RankIndicator` renders. The plain numeric-goal input branch has no progress indicator, so there's nothing to change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)