### PR TITLE
feat(landing): update copy for Ranked alongside World Tour

### DIFF
--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Season Sprint — Track your THE FINALS World Tour climb</title>
+    <title>Season Sprint — Track your THE FINALS rank climb</title>
     <meta
       name="description"
       content="Season Sprint logs your THE FINALS win points, charts your run toward the next rank, and syncs it live across web, desktop, and mobile."
@@ -16,23 +16,23 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Season Sprint" />
     <meta property="og:locale" content="en_US" />
-    <meta property="og:title" content="Season Sprint — Track your THE FINALS World Tour climb" />
+    <meta property="og:title" content="Season Sprint — Track your THE FINALS rank climb" />
     <meta
       property="og:description"
-      content="Track your THE FINALS World Tour climb — log win points, watch your rank, sync everywhere."
+      content="Track your THE FINALS rank climb — World Tour or Ranked — log win points, watch your rank, sync everywhere."
     />
     <meta property="og:url" content="https://www.seasonsprint.com/" />
     <meta property="og:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
     <meta property="og:image:width" content="1400" />
     <meta property="og:image:height" content="758" />
-    <meta property="og:image:alt" content="Season Sprint web app showing a THE FINALS World Tour rank chart" />
+    <meta property="og:image:alt" content="Season Sprint web app showing a THE FINALS rank chart" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Season Sprint — Track your THE FINALS World Tour climb" />
+    <meta name="twitter:title" content="Season Sprint — Track your THE FINALS rank climb" />
     <meta
       name="twitter:description"
-      content="Track your THE FINALS World Tour climb — log win points, watch your rank, sync everywhere."
+      content="Track your THE FINALS rank climb — World Tour or Ranked — log win points, watch your rank, sync everywhere."
     />
     <meta name="twitter:image" content="https://www.seasonsprint.com/assets/shot-web.png" />
 
@@ -55,7 +55,7 @@
         "operatingSystem": "Web, Windows, Linux, Android",
         "url": "https://www.seasonsprint.com/",
         "downloadUrl": "https://www.seasonsprint.com/downloads",
-        "description": "Track your THE FINALS World Tour climb — log win points, watch your rank, and sync it live across web, desktop, and mobile.",
+        "description": "Track your THE FINALS rank climb — World Tour or Ranked — log win points, watch your rank, and sync it live across web, desktop, and mobile.",
         "offers": {
           "@type": "Offer",
           "price": "0",
@@ -87,8 +87,8 @@
       <!-- Hero -->
       <section class="hero">
         <div class="hero-copy">
-          <p class="eyebrow">THE FINALS · World Tour tracker</p>
-          <h1>Track your<br /><span class="hl">World&nbsp;Tour</span> climb.</h1>
+          <p class="eyebrow">THE FINALS · World Tour &amp; Ranked tracker</p>
+          <h1>Track your<br /><span class="hl">rank</span> climb.</h1>
           <p class="lede">
             Season Sprint logs your win points, charts your run toward the next
             rank, and keeps it in sync across every device — live.
@@ -108,7 +108,7 @@
           <figure class="hero-shot">
             <img
               src="/assets/shot-chart.png"
-              alt="Season Sprint chart of total win points climbing through the World Tour rank bands toward Emerald"
+              alt="Season Sprint chart of total win points climbing through the rank bands toward Emerald"
               width="612"
               height="482"
             />
@@ -123,8 +123,9 @@
           <article class="feature">
             <h3>Chart your season</h3>
             <p>
-              Watch your win points trend over time against every World Tour
-              rank threshold, so you always know if you're on pace.
+              Watch your win points trend over time against every rank
+              threshold — World Tour or Ranked — so you always know if
+              you're on pace.
             </p>
           </article>
           <article class="feature">


### PR DESCRIPTION
## Summary
- Now that the `ranked` feature flag is enabled globally, updated the static landing page (title, OG/Twitter tags, JSON-LD, hero, and feature copy) so it no longer reads as if World Tour is the only trackable mode.

## Test plan
- [x] Reviewed rendered copy for remaining "World Tour"-exclusive language — none found (grep confirms only paired "World Tour or Ranked" mentions remain).
- [ ] Visually spot-check `/` on the deployed preview once live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated landing page messaging to highlight both **World Tour** and **Ranked** play.
  * Refreshed headline, hero copy, and feature text to better reflect rank climbing and season planning.

* **Bug Fixes**
  * Improved page metadata and structured data so search and social previews match the updated positioning.

* **Style**
  * Revised image alt text and marketing wording for consistency across the landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->