### PR TITLE
feat(android, ios): add Ranked mode and previous-seasons viewing

### DIFF
--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/GameMode.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/GameMode.kt
@@ -1,0 +1,7 @@
+package com.lcarthur.seasonsprint
+
+/** Which game mode a records/season view is scoped to. Mirrors the server's `GameMode` type. */
+enum class GameMode(val wireValue: String, val prefsSuffix: String, val label: String) {
+    WorldTour("world-tour", "worldTour", "World Tour"),
+    Ranked("ranked", "ranked", "Ranked"),
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/ApiClient.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/ApiClient.kt
@@ -1,10 +1,12 @@
 package com.lcarthur.seasonsprint.data
 
 import com.lcarthur.seasonsprint.Config
+import com.lcarthur.seasonsprint.GameMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -20,7 +22,7 @@ class ApiException(val code: Int) : Exception("HTTP $code")
  * the live WebSocket (Phase 7).
  */
 object ApiClient {
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = Json { ignoreUnknownKeys = true; explicitNulls = false }
     private val jsonMedia = "application/json".toMediaType()
     private val emptyBody = ByteArray(0).toRequestBody(null)
 
@@ -30,9 +32,12 @@ object ApiClient {
 
     private fun url(path: String) = "${Config.SERVER_URL}/$path"
 
-    /** `GET /me/records` */
-    suspend fun getRecords(): List<ApiRecord> = withContext(Dispatchers.IO) {
-        val req = Request.Builder().url(url("me/records")).get().build()
+    private fun urlWithMode(path: String, mode: GameMode) =
+        url(path).toHttpUrl().newBuilder().addQueryParameter("mode", mode.wireValue).build()
+
+    /** `GET /me/records?mode=...` */
+    suspend fun getRecords(mode: GameMode): List<ApiRecord> = withContext(Dispatchers.IO) {
+        val req = Request.Builder().url(urlWithMode("me/records", mode)).get().build()
         httpClient.newCall(req).execute().use { resp ->
             check(resp)
             json.decodeFromString<List<ApiRecord>>(resp.body.string())
@@ -40,8 +45,8 @@ object ApiClient {
     }
 
     /** `POST /me/records` — upsert a record by date; returns the saved record. */
-    suspend fun upsertRecord(date: String, winPoints: Int): ApiRecord = withContext(Dispatchers.IO) {
-        val body = json.encodeToString(RecordWrite(date, winPoints)).toRequestBody(jsonMedia)
+    suspend fun upsertRecord(date: String, winPoints: Int, mode: GameMode): ApiRecord = withContext(Dispatchers.IO) {
+        val body = json.encodeToString(RecordWrite(date, winPoints, mode.wireValue)).toRequestBody(jsonMedia)
         val req = Request.Builder().url(url("me/records")).post(body).build()
         httpClient.newCall(req).execute().use { resp ->
             check(resp)
@@ -49,7 +54,7 @@ object ApiClient {
         }
     }
 
-    /** `PUT /me/records/:id` — edit a record in place; returns the updated record. */
+    /** `PUT /me/records/:id` — edit a record in place; returns the updated record. Mode is fixed at creation. */
     suspend fun updateRecord(id: String, date: String, winPoints: Int): ApiRecord = withContext(Dispatchers.IO) {
         val body = json.encodeToString(RecordWrite(date, winPoints)).toRequestBody(jsonMedia)
         val req = Request.Builder().url(url("me/records/$id")).put(body).build()
@@ -67,10 +72,15 @@ object ApiClient {
 
     /** `GET /seasons` — public (no auth); returns the current season window, or null. */
     suspend fun getSeasons(): SeasonDto? = withContext(Dispatchers.IO) {
+        getAllSeasons().currentSeason
+    }
+
+    /** `GET /seasons` — public (no auth); the full payload (every season + the current one). */
+    suspend fun getAllSeasons(): SeasonsResponse = withContext(Dispatchers.IO) {
         val req = Request.Builder().url(url("seasons")).get().build()
         httpClient.newCall(req).execute().use { resp ->
             check(resp)
-            json.decodeFromString<SeasonsResponse>(resp.body.string()).currentSeason
+            json.decodeFromString<SeasonsResponse>(resp.body.string())
         }
     }
 

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/LiveUpdates.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/LiveUpdates.kt
@@ -121,9 +121,12 @@ class LiveUpdates(private val scope: CoroutineScope) {
             "record:delete" -> data?.jsonObject?.get("id")?.jsonPrimitive?.content?.let {
                 RecordEvent.Delete(it)
             }
-            "record:delete-all" -> RecordEvent.DeleteAll
+            "record:delete-all" -> RecordEvent.DeleteAll(data?.jsonObject?.get("mode")?.jsonPrimitive?.content)
             "record:bulk-upsert" -> data?.jsonObject?.get("records")?.let {
-                RecordEvent.BulkUpsert(json.decodeFromJsonElement(ListSerializer(ApiRecord.serializer()), it))
+                RecordEvent.BulkUpsert(
+                    json.decodeFromJsonElement(ListSerializer(ApiRecord.serializer()), it),
+                    data.jsonObject["mode"]?.jsonPrimitive?.content,
+                )
             }
             else -> null
         }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/Models.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/data/Models.kt
@@ -8,6 +8,8 @@ data class ApiRecord(
     val id: String,
     val date: String,
     val winPoints: Int,
+    /** Missing/null means `"world-tour"`, matching the server default. */
+    val mode: String? = null,
 )
 
 /** Request body for creating/updating a record (`POST`/`PUT /me/records`). */
@@ -15,6 +17,7 @@ data class ApiRecord(
 data class RecordWrite(
     val date: String,
     val winPoints: Int,
+    val mode: String? = null,
 )
 
 /** Response from `POST /me/records`. */
@@ -38,9 +41,10 @@ data class SeasonDto(
     val end: String,
 )
 
-/** `GET /seasons` payload (we only need `currentSeason`). */
+/** `GET /seasons` payload — the full scraped list, same for every mode. */
 @Serializable
 data class SeasonsResponse(
+    val seasons: List<SeasonDto> = emptyList(),
     val currentSeason: SeasonDto? = null,
 )
 
@@ -50,7 +54,8 @@ data class SeasonsResponse(
  */
 sealed interface RecordEvent {
     data class Upsert(val record: ApiRecord) : RecordEvent
-    data class Delete(val id: String) : RecordEvent
-    data object DeleteAll : RecordEvent
-    data class BulkUpsert(val records: List<ApiRecord>) : RecordEvent
+    /** [mode] is missing/null for `"world-tour"`, matching the server's broadcast payload. */
+    data class Delete(val id: String, val mode: String? = null) : RecordEvent
+    data class DeleteAll(val mode: String? = null) : RecordEvent
+    data class BulkUpsert(val records: List<ApiRecord>, val mode: String? = null) : RecordEvent
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Pace.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Pace.kt
@@ -1,5 +1,6 @@
 package com.lcarthur.seasonsprint.domain
 
+import com.lcarthur.seasonsprint.GameMode
 import java.time.Instant
 import kotlin.math.abs
 import kotlin.math.roundToLong
@@ -12,11 +13,29 @@ private fun roundedDays(from: Instant, to: Instant): Int {
     return (seconds / SECONDS_PER_DAY).roundToLong().toInt()
 }
 
+/**
+ * The anchor pace/projection math is measured from. World Tour anchors at
+ * (seasonStart, 0); Ranked anchors at the first recorded point in the season (the
+ * placement point), since a Ranked season starts at a placement rank, not zero.
+ * Mirrors `paceBaseline` in packages/web/src/composables/useChartGeometry.js.
+ */
+data class PaceBaseline(val instant: Instant, val value: Double)
+
+/** [sortedSeasonPoints] must already be sorted ascending by [Point.instant]. */
+fun paceBaselineFor(mode: GameMode, sortedSeasonPoints: List<Point>, seasonStart: Instant): PaceBaseline {
+    val first = sortedSeasonPoints.firstOrNull()
+    return if (mode == GameMode.Ranked && first != null) {
+        PaceBaseline(first.instant, first.winPoints.toDouble())
+    } else {
+        PaceBaseline(seasonStart, 0.0)
+    }
+}
+
 /** Goal-pace statistics over a season window. Ports computePace from iOS Pace.swift. */
 data class PaceStats(
     val daysInSeason: Int,
     val daysRemaining: Int,
-    /** Slope of the zero → goal projection, points per day. */
+    /** Slope of the baseline → goal projection, points per day. */
     val requiredPerDayZero: Double,
     /** Whether a "last point → goal" pace is meaningful. */
     val isFromLastDefined: Boolean,
@@ -29,6 +48,8 @@ data class PaceStats(
  * @param seasonPoints points whose day falls within [start, end], any order.
  * @param start season start, @param end season end.
  * @param now current instant (for days-remaining).
+ * @param baseline the zero-point anchor; defaults to (start, 0) — pass [paceBaselineFor]'s
+ *   result to get Ranked's placement-point measurement.
  */
 fun computePace(
     goal: Int,
@@ -36,9 +57,11 @@ fun computePace(
     start: Instant,
     end: Instant,
     now: Instant = Instant.now(),
+    baseline: PaceBaseline = PaceBaseline(start, 0.0),
 ): PaceStats {
     val daysInSeason = maxOf(1, roundedDays(start, end))
-    val requiredPerDayZero = goal.toDouble() / daysInSeason.toDouble()
+    val baselineDays = maxOf(1, roundedDays(baseline.instant, end))
+    val requiredPerDayZero = (goal - baseline.value) / baselineDays.toDouble()
 
     val sorted = seasonPoints.sortedBy { it.instant }
     val last = sorted.lastOrNull()
@@ -68,39 +91,58 @@ fun computePace(
 /** A dated value for the pace sub-graph. */
 data class PaceSeriesPoint(val instant: Instant, val value: Double)
 
-/** Through-origin least-squares slope (points/day): Σ(x·y)/Σ(x²), x = day offset from start. */
-private fun throughOriginSlope(seasonPoints: List<Point>, start: Instant): Double? {
+/**
+ * Through-origin least-squares slope (points/day): Σ(x·y)/Σ(x²), where x/y are day/value
+ * offsets *relative to [baseline]*. A point that coincides with the baseline itself (the
+ * Ranked placement point) is skipped so it isn't counted twice against the synthetic origin.
+ */
+private fun throughOriginSlope(seasonPoints: List<Point>, baseline: PaceBaseline): Double? {
     var sumXX = 0.0
     var sumXY = 0.0
     for (p in seasonPoints) {
-        val x = (p.instant.epochSecond - start.epochSecond) / SECONDS_PER_DAY
-        val y = p.winPoints.toDouble()
+        val x = (p.instant.epochSecond - baseline.instant.epochSecond) / SECONDS_PER_DAY
+        val y = p.winPoints - baseline.value
+        if (x == 0.0 && y == 0.0) continue
         sumXX += x * x
         sumXY += x * y
     }
     return if (sumXX == 0.0) null else sumXY / sumXX
 }
 
-/** Average-pace value projected to season end: slope · totalDays. */
-fun averagePaceProjectedEnd(seasonPoints: List<Point>, start: Instant, end: Instant): Double? {
+/** Average-pace value projected to season end: baseline value + slope · daysFromBaseline. */
+fun averagePaceProjectedEnd(
+    seasonPoints: List<Point>,
+    start: Instant,
+    end: Instant,
+    baseline: PaceBaseline = PaceBaseline(start, 0.0),
+): Double? {
     if (seasonPoints.isEmpty()) return null
-    val slope = throughOriginSlope(seasonPoints, start) ?: return null
-    val totalDays = (end.epochSecond - start.epochSecond) / SECONDS_PER_DAY
-    return slope * totalDays
+    val slope = throughOriginSlope(seasonPoints, baseline) ?: return null
+    val totalDays = (end.epochSecond - baseline.instant.epochSecond) / SECONDS_PER_DAY
+    return baseline.value + slope * totalDays
 }
 
 /** Deviation half-width at season end for the confidence wedge. */
-fun deviationAtEnd(seasonPoints: List<Point>, start: Instant, end: Instant): Double? {
+fun deviationAtEnd(
+    seasonPoints: List<Point>,
+    start: Instant,
+    end: Instant,
+    baseline: PaceBaseline = PaceBaseline(start, 0.0),
+): Double? {
     if (seasonPoints.size < 2) return null
-    val slope = throughOriginSlope(seasonPoints, start) ?: return null
+    val slope = throughOriginSlope(seasonPoints, baseline) ?: return null
 
     var sumResidualSq = 0.0
+    var n = 0
     for (p in seasonPoints) {
-        val x = (p.instant.epochSecond - start.epochSecond) / SECONDS_PER_DAY
-        val residual = p.winPoints - slope * x
+        val x = (p.instant.epochSecond - baseline.instant.epochSecond) / SECONDS_PER_DAY
+        val y = p.winPoints - baseline.value
+        if (x == 0.0 && y == 0.0) continue
+        val residual = y - slope * x
         sumResidualSq += residual * residual
+        n++
     }
-    val n = seasonPoints.size
+    if (n == 0) return null
     val stdDev = if (n > 1) sqrt(sumResidualSq / (n - 1)) else sqrt(sumResidualSq)
     val tFactor = when {
         n <= 2 -> 4.303
@@ -109,7 +151,7 @@ fun deviationAtEnd(seasonPoints: List<Point>, start: Instant, end: Instant): Dou
         n <= 10 -> 2.228
         else -> 1.96
     }
-    val totalDays = (end.epochSecond - start.epochSecond) / SECONDS_PER_DAY
+    val totalDays = (end.epochSecond - baseline.instant.epochSecond) / SECONDS_PER_DAY
     val projectedMag = abs(slope * totalDays)
     val minDeviation = when {
         n <= 3 -> projectedMag * 0.3
@@ -127,12 +169,16 @@ fun requiredPaceSeries(seasonPoints: List<Point>, goal: Int, end: Instant): List
         else PaceSeriesPoint(p.instant, (goal - p.winPoints) / daysRemaining)
     }
 
-/** Points earned per entry: delta of the cumulative total. */
-fun earnedPaceSeries(seasonPoints: List<Point>): List<PaceSeriesPoint> {
-    var prev = 0
+/**
+ * Points earned per entry: delta of the cumulative total. [baselineY] seeds the running
+ * total — 0 for World Tour, the placement value for Ranked, so the placement point itself
+ * doesn't read as a giant "earned" spike on day one.
+ */
+fun earnedPaceSeries(seasonPoints: List<Point>, baselineY: Double = 0.0): List<PaceSeriesPoint> {
+    var prev = baselineY
     return seasonPoints.sortedBy { it.instant }.map { p ->
         val delta = p.winPoints - prev
-        prev = p.winPoints
-        PaceSeriesPoint(p.instant, delta.toDouble())
+        prev = p.winPoints.toDouble()
+        PaceSeriesPoint(p.instant, delta)
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Rank.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/Rank.kt
@@ -1,7 +1,15 @@
 package com.lcarthur.seasonsprint.domain
 
+import com.lcarthur.seasonsprint.GameMode
+
 /** A rank threshold: reach [points] to earn [badge]. */
 data class Threshold(val badge: String, val points: Int)
+
+/** The rank/RS threshold table for a mode. */
+fun thresholdsFor(mode: GameMode): List<Threshold> = when (mode) {
+    GameMode.WorldTour -> worldTourThresholds
+    GameMode.Ranked -> rankedThresholds
+}
 
 /** Derived rank state. Ported from packages/web/src/composables/useRankInfo.js + iOS Rank.swift. */
 data class RankInfo(
@@ -66,6 +74,34 @@ val worldTourThresholds: List<Threshold> = listOf(
     Threshold("Emerald 3", 2000),
     Threshold("Emerald 2", 2200),
     Threshold("Emerald 1", 2400),
+)
+
+/**
+ * Ranked RS thresholds, verbatim from packages/web/src/views/Ranked.vue (RANKED_THRESHOLDS).
+ * Bronze (0 → 7,500), Silver (10,000 → 17,500), Gold (20,000 → 27,500), Platinum
+ * (30,000 → 37,500), Diamond (40,000 → 47,500). Ruby = Top 500, not threshold-based.
+ */
+val rankedThresholds: List<Threshold> = listOf(
+    Threshold("Bronze 4", 0),
+    Threshold("Bronze 3", 2500),
+    Threshold("Bronze 2", 5000),
+    Threshold("Bronze 1", 7500),
+    Threshold("Silver 4", 10000),
+    Threshold("Silver 3", 12500),
+    Threshold("Silver 2", 15000),
+    Threshold("Silver 1", 17500),
+    Threshold("Gold 4", 20000),
+    Threshold("Gold 3", 22500),
+    Threshold("Gold 2", 25000),
+    Threshold("Gold 1", 27500),
+    Threshold("Platinum 4", 30000),
+    Threshold("Platinum 3", 32500),
+    Threshold("Platinum 2", 35000),
+    Threshold("Platinum 1", 37500),
+    Threshold("Diamond 4", 40000),
+    Threshold("Diamond 3", 42500),
+    Threshold("Diamond 2", 45000),
+    Threshold("Diamond 1", 47500),
 )
 
 /** World Tour win-points cheatsheet, from packages/web/src/components/PointsCheatsheet.vue. */

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/SeasonPicker.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/domain/SeasonPicker.kt
@@ -1,0 +1,52 @@
+package com.lcarthur.seasonsprint.domain
+
+import com.lcarthur.seasonsprint.data.SeasonDto
+import java.time.Instant
+
+/** A selectable season in the picker: [key] is the raw season name (as `/seasons` returns it). */
+data class SeasonOption(val key: String, val displayName: String, val season: Season)
+
+/** "8" -> "Season 8"; "Season 8" stays as-is. Mirrors displayName() in useSeasons.js. */
+private fun displayNameFor(rawName: String): String {
+    val trimmed = rawName.trim()
+    if (trimmed.isEmpty()) return trimmed
+    return if (trimmed.lowercase().startsWith("season")) trimmed else "Season $trimmed"
+}
+
+/** Normalizes the full `GET /seasons` payload into pickable options, ascending by start date. */
+fun seasonOptionsFrom(dtos: List<SeasonDto>): List<SeasonOption> =
+    dtos.mapNotNull { dto ->
+        Season.from(dto)?.let { season -> SeasonOption(key = dto.name, displayName = displayNameFor(dto.name), season = season) }
+    }.sortedBy { it.season.start }
+
+/** A record re-mapped onto another season's timeline for the "compare" overlay — not a real record. */
+data class OverlayPoint(val instant: Instant, val winPoints: Int)
+
+/**
+ * Keys of the seasons the user has at least one point inside (inclusive window). Gates the
+ * season picker so we never offer a past season with no data.
+ * Mirrors seasonsWithDataKeys in packages/web/src/utils/chart.js.
+ */
+fun seasonsWithDataKeys(points: List<Point>, seasons: List<SeasonOption>): Set<String> =
+    seasons.filter { option ->
+        points.any { !it.instant.isBefore(option.season.start) && !it.instant.isAfter(option.season.end) }
+    }.map { it.key }.toSet()
+
+/**
+ * Re-maps a previous season's points onto the viewed season's x-axis by day-of-season, so day
+ * 0 of each season lines up (e.g. "where was I on day 12 last season vs this one"). Points
+ * whose elapsed day falls past the viewed season's end are dropped rather than clamped.
+ * Mirrors mapOverlayByDayOfSeason in packages/web/src/utils/chart.js.
+ */
+fun mapOverlayByDayOfSeason(
+    overlayPoints: List<Point>,
+    overlaySeasonStart: Instant,
+    viewedSeasonStart: Instant,
+    viewedSeasonEnd: Instant,
+): List<OverlayPoint> {
+    val offsetSeconds = viewedSeasonStart.epochSecond - overlaySeasonStart.epochSecond
+    return overlayPoints.mapNotNull { p ->
+        val mapped = p.instant.plusSeconds(offsetSeconds)
+        if (mapped.isAfter(viewedSeasonEnd)) null else OverlayPoint(mapped, p.winPoints)
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
@@ -3,19 +3,30 @@ package com.lcarthur.seasonsprint.state
 import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.lcarthur.seasonsprint.GameMode
 import com.lcarthur.seasonsprint.data.ApiClient
 import com.lcarthur.seasonsprint.data.ApiRecord
 import com.lcarthur.seasonsprint.data.LiveStatus
 import com.lcarthur.seasonsprint.data.LiveUpdates
 import com.lcarthur.seasonsprint.data.RecordEvent
+import com.lcarthur.seasonsprint.domain.DateKey
+import com.lcarthur.seasonsprint.domain.OverlayPoint
+import com.lcarthur.seasonsprint.domain.PaceBaseline
 import com.lcarthur.seasonsprint.domain.PaceStats
 import com.lcarthur.seasonsprint.domain.Point
 import com.lcarthur.seasonsprint.domain.RankInfo
 import com.lcarthur.seasonsprint.domain.Season
-import com.lcarthur.seasonsprint.domain.DateKey
+import com.lcarthur.seasonsprint.domain.SeasonOption
+import com.lcarthur.seasonsprint.domain.Threshold
 import com.lcarthur.seasonsprint.domain.computePace
 import com.lcarthur.seasonsprint.domain.computeRank
+import com.lcarthur.seasonsprint.domain.mapOverlayByDayOfSeason
+import com.lcarthur.seasonsprint.domain.paceBaselineFor
+import com.lcarthur.seasonsprint.domain.seasonOptionsFrom
+import com.lcarthur.seasonsprint.domain.seasonsWithDataKeys
+import com.lcarthur.seasonsprint.domain.thresholdsFor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -23,11 +34,21 @@ import kotlinx.coroutines.launch
 
 /**
  * Immutable dashboard state with derived values, mirroring iOS DashboardStore's computeds.
- * Records are *cumulative* season totals, so "current points" is the latest-dated record.
+ * Records are *cumulative* season totals, so "current points" is the latest-dated record
+ * for [mode] — independent of which season is being *viewed* (only the chart/pace look back).
  */
 data class DashboardState(
+    val mode: GameMode,
     val points: List<Point> = emptyList(),
+    /** The live/current season window (unaffected by [viewedSeasonKey]). */
     val season: Season? = null,
+    /** The full `/seasons` list, same for every mode. */
+    val seasonOptionsAll: List<SeasonOption> = emptyList(),
+    /** Raw season name the server reports as current (matches a [SeasonOption.key]). */
+    val currentSeasonKey: String? = null,
+    /** null = viewing the live/current season. */
+    val viewedSeasonKey: String? = null,
+    val overlaySeasonKey: String? = null,
     val isLoading: Boolean = false,
     val hasLoaded: Boolean = false,
     val isWriting: Boolean = false,
@@ -35,21 +56,28 @@ data class DashboardState(
     val liveStatus: LiveStatus = LiveStatus.Disconnected,
     val goalOverride: Int? = null,
 ) {
+    val thresholds: List<Threshold> get() = thresholdsFor(mode)
+
     val sortedPoints: List<Point> get() = points.sortedBy { it.instant }
 
-    /** Latest-dated record's win points (the season total so far). */
+    /** Latest-dated record's win points (the season total so far) — always the live total. */
     val currentPoints: Int get() = sortedPoints.lastOrNull()?.winPoints ?: 0
 
-    val rank: RankInfo get() = computeRank(currentPoints)
+    val rank: RankInfo get() = computeRank(currentPoints, thresholds)
 
-    /** Points gained today = today's total minus the most recent prior day's total. */
+    /**
+     * Points gained today = today's total minus the most recent prior day's total. In Ranked,
+     * a today-entry with no prior point is the placement itself, not earned progress, so it
+     * reads as 0 gain rather than a jump from 0 (World Tour genuinely starts at 0).
+     */
     val todayGain: Int?
         get() {
             val today = DateKey.today()
             val sorted = sortedPoints
             val todayPoint = sorted.firstOrNull { it.day == today } ?: return null
             val prev = sorted.lastOrNull { it.day < today }
-            return todayPoint.winPoints - (prev?.winPoints ?: 0)
+            val prevValue = prev?.winPoints ?: (if (mode == GameMode.Ranked) todayPoint.winPoints else 0)
+            return todayPoint.winPoints - prevValue
         }
 
     private val defaultGoal: Int get() = rank.nextTarget ?: maxOf(1, rank.currentFloor)
@@ -59,20 +87,70 @@ data class DashboardState(
 
     val hasCustomGoal: Boolean get() = goalOverride != null
 
-    /** Points that fall within the current season window (all points if no season). */
+    private val dataSeasonKeys: Set<String> get() = seasonsWithDataKeys(points, seasonOptionsAll)
+
+    /** Season picker entries, newest first: the current season, plus any past season with data. */
+    val seasonOptions: List<SeasonOption>
+        get() = seasonOptionsAll.sortedByDescending { it.season.start }
+            .filter { it.key == currentSeasonKey || dataSeasonKeys.contains(it.key) }
+
+    /** Compare-overlay entries, newest first: any season with data, excluding the viewed one. */
+    val overlayOptions: List<SeasonOption>
+        get() {
+            val viewed = viewedSeasonKey ?: currentSeasonKey
+            return seasonOptionsAll.sortedByDescending { it.season.start }
+                .filter { it.key != viewed && dataSeasonKeys.contains(it.key) }
+        }
+
+    /** True once there's at least one past season with data — otherwise the picker has nothing to offer. */
+    val seasonModuleDisabled: Boolean
+        get() = seasonOptionsAll.none { it.key != currentSeasonKey && dataSeasonKeys.contains(it.key) }
+
+    val viewedSeason: Season?
+        get() = viewedSeasonKey?.let { key -> seasonOptionsAll.firstOrNull { it.key == key }?.season } ?: season
+
+    /** Read-only: looking at any season other than the live one. */
+    val isViewingPastSeason: Boolean
+        get() = viewedSeasonKey != null && currentSeasonKey != null && viewedSeasonKey != currentSeasonKey
+
+    val overlaySeason: Season?
+        get() = overlaySeasonKey?.let { key -> seasonOptionsAll.firstOrNull { it.key == key }?.season }
+
+    /** Points that fall within the *viewed* season window (all points if no season known). */
     val seasonPoints: List<Point>
-        get() = season?.let { s -> points.filter { !it.instant.isBefore(s.start) && !it.instant.isAfter(s.end) } }
+        get() = viewedSeason?.let { s -> points.filter { !it.instant.isBefore(s.start) && !it.instant.isAfter(s.end) } }
             ?: points
 
+    /** The compare season's points, re-mapped onto the viewed season's day-of-season axis. */
+    val overlayPoints: List<OverlayPoint>
+        get() {
+            val overlay = overlaySeason ?: return emptyList()
+            val viewed = viewedSeason ?: return emptyList()
+            val overlayRecords = points.filter { !it.instant.isBefore(overlay.start) && !it.instant.isAfter(overlay.end) }
+            return mapOverlayByDayOfSeason(overlayRecords, overlay.start, viewed.start, viewed.end)
+        }
+
+    val paceBaseline: PaceBaseline?
+        get() = viewedSeason?.let { s -> paceBaselineFor(mode, seasonPoints.sortedBy { it.instant }, s.start) }
+
     val pace: PaceStats?
-        get() = season?.let { computePace(goal, seasonPoints, it.start, it.end) }
+        get() = viewedSeason?.let { s -> computePace(goal, seasonPoints, s.start, s.end, baseline = paceBaseline ?: PaceBaseline(s.start, 0.0)) }
 }
 
-class DashboardViewModel(app: Application) : AndroidViewModel(app) {
-    private val prefs = app.getSharedPreferences("dashboard", Context.MODE_PRIVATE)
+class DashboardViewModel(private val mode: GameMode, app: Application) : AndroidViewModel(app) {
+    // World Tour keeps the original "dashboard" file/key so existing installs don't lose their
+    // saved goal; Ranked gets its own file, matching the web's per-mode storageKey.
+    private val prefs = app.getSharedPreferences(
+        if (mode == GameMode.WorldTour) "dashboard" else "dashboard.${mode.prefsSuffix}",
+        Context.MODE_PRIVATE,
+    )
+    private val goalKey = if (mode == GameMode.WorldTour) "goal.worldTour" else "goal.${mode.prefsSuffix}"
 
     private val _state = MutableStateFlow(
-        DashboardState(goalOverride = if (prefs.contains(KEY_GOAL)) prefs.getInt(KEY_GOAL, 0) else null),
+        DashboardState(
+            mode = mode,
+            goalOverride = if (prefs.contains(goalKey)) prefs.getInt(goalKey, 0) else null,
+        ),
     )
     val state = _state.asStateFlow()
 
@@ -86,14 +164,18 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
     fun load() {
         _state.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
-            // Season is public + best-effort; don't let its failure block records.
-            val season = runCatching { ApiClient.getSeasons() }.getOrNull()?.let { Season.from(it) }
+            // Seasons are public + best-effort; don't let their failure block records.
+            val seasonsPayload = runCatching { ApiClient.getAllSeasons() }.getOrNull()
+            val seasonOptions = seasonsPayload?.seasons?.let { seasonOptionsFrom(it) }
+            val currentSeason = seasonsPayload?.currentSeason?.let { Season.from(it) }
             try {
-                val records = ApiClient.getRecords()
+                val records = ApiClient.getRecords(mode)
                 _state.update {
                     it.copy(
                         points = records.map(Point::from),
-                        season = season ?: it.season,
+                        season = currentSeason ?: it.season,
+                        seasonOptionsAll = seasonOptions ?: it.seasonOptionsAll,
+                        currentSeasonKey = seasonsPayload?.currentSeason?.name ?: it.currentSeasonKey,
                         isLoading = false,
                         hasLoaded = true,
                     )
@@ -102,7 +184,9 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
             } catch (e: Exception) {
                 _state.update {
                     it.copy(
-                        season = season ?: it.season,
+                        season = currentSeason ?: it.season,
+                        seasonOptionsAll = seasonOptions ?: it.seasonOptionsAll,
+                        currentSeasonKey = seasonsPayload?.currentSeason?.name ?: it.currentSeasonKey,
                         isLoading = false,
                         hasLoaded = true,
                         error = "Couldn't load your data. Pull to refresh.",
@@ -112,12 +196,32 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    /** Add or overwrite the record for a day (`POST /me/records`). */
+    /** Resume the live-update connection (call when this mode becomes the active tab). */
+    fun resumeLive() = live.start()
+
+    /** Pause the live-update connection (call when this mode is backgrounded, to avoid a
+     * dangling socket for a mode the user isn't looking at). */
+    fun pauseLive() = live.stop()
+
+    /** View a past season read-only, or pass null to return to the live season. */
+    fun viewSeason(key: String?) {
+        _state.update {
+            it.copy(
+                viewedSeasonKey = key,
+                overlaySeasonKey = if (it.overlaySeasonKey == key) null else it.overlaySeasonKey,
+            )
+        }
+    }
+
+    fun overlaySeason(key: String?) = _state.update { it.copy(overlaySeasonKey = key) }
+
+    /** Add or overwrite the record for a day (`POST /me/records`). No-op while read-only. */
     fun addOrSet(date: String, winPoints: Int) {
+        if (_state.value.isViewingPastSeason) return
         _state.update { it.copy(isWriting = true) }
         viewModelScope.launch {
             try {
-                val record = ApiClient.upsertRecord(date, winPoints)
+                val record = ApiClient.upsertRecord(date, winPoints, mode)
                 _state.update { it.copy(points = it.points.upserted(record), isWriting = false) }
             } catch (e: Exception) {
                 _state.update { it.copy(isWriting = false, error = "Couldn't save that point.") }
@@ -125,8 +229,9 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    /** Edit an existing record in place (`PUT /me/records/:id`). */
+    /** Edit an existing record in place (`PUT /me/records/:id`). No-op while read-only. */
     fun updatePoint(point: Point, date: String, winPoints: Int) {
+        if (_state.value.isViewingPastSeason) return
         _state.update { it.copy(isWriting = true) }
         viewModelScope.launch {
             try {
@@ -145,8 +250,9 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    /** Delete a record (`DELETE /me/records/:id`), optimistically removing it locally. */
+    /** Delete a record (`DELETE /me/records/:id`), optimistically removing it locally. No-op while read-only. */
     fun deletePoint(point: Point) {
+        if (_state.value.isViewingPastSeason) return
         _state.update { it.copy(points = it.points.filterNot { p -> p.remoteId == point.remoteId }) }
         viewModelScope.launch {
             try {
@@ -159,29 +265,39 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun setGoal(value: Int) {
-        prefs.edit().putInt(KEY_GOAL, value).apply()
+        prefs.edit().putInt(goalKey, value).apply()
         _state.update { it.copy(goalOverride = value) }
     }
 
     fun clearGoal() {
-        prefs.edit().remove(KEY_GOAL).apply()
+        prefs.edit().remove(goalKey).apply()
         _state.update { it.copy(goalOverride = null) }
     }
 
     fun clearError() = _state.update { it.copy(error = null) }
 
-    /** Merge a live event into local state (mirrors iOS DashboardStore.apply). */
+    /** Whether a live event (missing `mode` means `"world-tour"`) belongs to this VM's mode. */
+    private fun matchesMode(raw: String?): Boolean {
+        val eventMode = if (raw == GameMode.Ranked.wireValue) GameMode.Ranked else GameMode.WorldTour
+        return eventMode == mode
+    }
+
+    /** Merge a live event into local state (mirrors iOS DashboardStore.apply). Cross-mode events are ignored. */
     private fun applyEvent(event: RecordEvent) {
         _state.update { s ->
             when (event) {
-                is RecordEvent.Upsert -> s.copy(points = s.points.upserted(event.record))
-                is RecordEvent.Delete -> s.copy(points = s.points.filterNot { it.remoteId == event.id })
-                RecordEvent.DeleteAll -> s.copy(points = emptyList())
-                is RecordEvent.BulkUpsert -> {
-                    var list = s.points
-                    event.records.forEach { list = list.upserted(it) }
-                    s.copy(points = list)
-                }
+                is RecordEvent.Upsert ->
+                    if (matchesMode(event.record.mode)) s.copy(points = s.points.upserted(event.record)) else s
+                is RecordEvent.Delete ->
+                    if (matchesMode(event.mode)) s.copy(points = s.points.filterNot { it.remoteId == event.id }) else s
+                is RecordEvent.DeleteAll ->
+                    if (matchesMode(event.mode)) s.copy(points = emptyList()) else s
+                is RecordEvent.BulkUpsert ->
+                    if (matchesMode(event.mode)) {
+                        var list = s.points
+                        event.records.forEach { list = list.upserted(it) }
+                        s.copy(points = list)
+                    } else s
             }
         }
     }
@@ -198,7 +314,10 @@ class DashboardViewModel(app: Application) : AndroidViewModel(app) {
         return if (idx >= 0) toMutableList().also { it[idx] = point } else this + point
     }
 
-    private companion object {
-        const val KEY_GOAL = "goal.worldTour"
+    /** Custom factory since [DashboardViewModel] needs a [GameMode] the default AndroidViewModel factory can't supply. */
+    class Factory(private val mode: GameMode, private val app: Application) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T =
+            DashboardViewModel(mode, app) as T
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/SettingsViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package com.lcarthur.seasonsprint.state
 import android.app.Application
 import android.content.Context
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.lcarthur.seasonsprint.GameMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -15,8 +17,13 @@ data class AppSettingsState(
     val showPaceGraph: Boolean = false,
 )
 
-class SettingsViewModel(app: Application) : AndroidViewModel(app) {
-    private val prefs = app.getSharedPreferences("settings", Context.MODE_PRIVATE)
+/** Display toggles are saved per mode, matching the web's per-mode `storageKey`. */
+class SettingsViewModel(mode: GameMode, app: Application) : AndroidViewModel(app) {
+    // World Tour keeps the original "settings" file so existing installs don't lose their toggles.
+    private val prefs = app.getSharedPreferences(
+        if (mode == GameMode.WorldTour) "settings" else "settings.${mode.prefsSuffix}",
+        Context.MODE_PRIVATE,
+    )
 
     private val _state = MutableStateFlow(
         AppSettingsState(
@@ -50,5 +57,12 @@ class SettingsViewModel(app: Application) : AndroidViewModel(app) {
         const val K_AVG = "settings.showAveragePace"
         const val K_DEV = "settings.showDeviationWedge"
         const val K_PACE = "settings.showPaceGraph"
+    }
+
+    /** Custom factory since [SettingsViewModel] needs a [GameMode] the default AndroidViewModel factory can't supply. */
+    class Factory(private val mode: GameMode, private val app: Application) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T =
+            SettingsViewModel(mode, app) as T
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DashboardScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DashboardScreen.kt
@@ -21,10 +21,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.domain.PaceBaseline
 import com.lcarthur.seasonsprint.state.AppSettingsState
 import com.lcarthur.seasonsprint.state.DashboardState
 import com.lcarthur.seasonsprint.state.DashboardViewModel
 import com.lcarthur.seasonsprint.ui.theme.rankColor
+import java.time.Instant
 
 /** Graph tab: compact rank summary + cumulative points chart + optional pace sub-graph. */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -49,19 +51,30 @@ fun DashboardScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             RankSummaryCard(state)
+            if (state.isViewingPastSeason) {
+                Text(
+                    "Viewing a past season — read-only",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            val baseline = state.paceBaseline ?: PaceBaseline(state.viewedSeason?.start ?: state.season?.start ?: Instant.EPOCH, 0.0)
             PointsChart(
                 points = state.seasonPoints,
                 goal = state.goal,
-                season = state.season,
+                season = state.viewedSeason,
+                thresholds = state.thresholds,
+                baseline = baseline,
+                overlayPoints = state.overlayPoints,
                 rank = state.rank,
                 pace = state.pace,
-                todayGain = state.todayGain,
+                todayGain = if (state.isViewingPastSeason) null else state.todayGain,
                 showRankOverlay = settings.showRankOverlay,
                 showAveragePace = settings.showAveragePace,
                 showDeviationWedge = settings.showDeviationWedge,
             )
             if (settings.showPaceGraph) {
-                PaceChart(points = state.seasonPoints, goal = state.goal, season = state.season)
+                PaceChart(points = state.seasonPoints, goal = state.goal, season = state.viewedSeason, baseline = baseline)
             }
             if (state.error != null) {
                 Text(

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DetailsScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/DetailsScreen.kt
@@ -44,9 +44,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.GameMode
 import com.lcarthur.seasonsprint.domain.Season
+import com.lcarthur.seasonsprint.domain.SeasonOption
 import com.lcarthur.seasonsprint.domain.worldTourCheatsheet
-import com.lcarthur.seasonsprint.domain.worldTourThresholds
 import com.lcarthur.seasonsprint.state.DashboardState
 import com.lcarthur.seasonsprint.state.DashboardViewModel
 import com.lcarthur.seasonsprint.ui.theme.FinalsGold
@@ -74,10 +75,11 @@ fun DetailsScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         state.season?.let { SeasonBanner(it) }
+        SeasonsCard(state, viewModel)
         StatsGrid(state)
         GoalControl(state, viewModel)
         RankReference(state)
-        Cheatsheet()
+        if (state.mode == GameMode.WorldTour) Cheatsheet()
         if (state.error != null) {
             Text(
                 state.error!!,
@@ -179,6 +181,83 @@ private fun StatCard(label: String, value: String, accent: Color, modifier: Modi
     }
 }
 
+/**
+ * Season picker + compare overlay. Mirrors SeasonControls.vue: the current season is always
+ * selectable, past seasons appear once they have data, and the whole module explains itself
+ * (rather than showing empty dropdowns) until there's a past season to look at.
+ */
+@Composable
+private fun SeasonsCard(state: DashboardState, viewModel: DashboardViewModel) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("Seasons", style = MaterialTheme.typography.titleMedium)
+            if (state.seasonModuleDisabled) {
+                Text(
+                    "Log points across more than the current season to unlock historical comparisons.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                SeasonPickerRow(
+                    label = "Season",
+                    options = state.seasonOptions,
+                    selectedKey = state.viewedSeasonKey ?: state.currentSeasonKey,
+                    placeholder = null,
+                    onSelect = { viewModel.viewSeason(if (it == state.currentSeasonKey) null else it) },
+                )
+                SeasonPickerRow(
+                    label = "Compare",
+                    options = state.overlayOptions,
+                    selectedKey = state.overlaySeasonKey,
+                    placeholder = "None",
+                    onSelect = { viewModel.overlaySeason(it) },
+                )
+                if (state.isViewingPastSeason) {
+                    Text(
+                        "Viewing a past season — read-only. Switch back to the current season to log points.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeasonPickerRow(
+    label: String,
+    options: List<SeasonOption>,
+    selectedKey: String?,
+    placeholder: String?,
+    onSelect: (String?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLabel = options.firstOrNull { it.key == selectedKey }?.displayName ?: placeholder ?: "—"
+
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+        Box {
+            OutlinedButton(onClick = { expanded = true }) {
+                Text(selectedLabel)
+                Spacer(Modifier.width(4.dp))
+                Icon(Icons.Filled.ExpandMore, contentDescription = null)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                if (placeholder != null) {
+                    DropdownMenuItem(text = { Text(placeholder) }, onClick = { onSelect(null); expanded = false })
+                }
+                options.forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.displayName) },
+                        onClick = { onSelect(option.key); expanded = false },
+                    )
+                }
+            }
+        }
+    }
+}
+
 @Composable
 private fun GoalControl(state: DashboardState, viewModel: DashboardViewModel) {
     var expanded by remember { mutableStateOf(false) }
@@ -206,7 +285,7 @@ private fun GoalControl(state: DashboardState, viewModel: DashboardViewModel) {
                         Icon(Icons.Filled.ExpandMore, contentDescription = null)
                     }
                     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-                        worldTourThresholds.reversed().forEach { t ->
+                        state.thresholds.reversed().forEach { t ->
                             DropdownMenuItem(
                                 text = { Text("${t.badge} — ${t.points}") },
                                 onClick = {
@@ -257,7 +336,7 @@ private fun GoalControl(state: DashboardState, viewModel: DashboardViewModel) {
 @Composable
 private fun RankReference(state: DashboardState) {
     ExpandableCard(title = "Rank thresholds") {
-        worldTourThresholds.reversed().forEach { t ->
+        state.thresholds.reversed().forEach { t ->
             val isCurrent = t.points == state.rank.currentFloor && state.rank.badge == t.badge
             Row(
                 modifier = Modifier

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
@@ -1,5 +1,8 @@
 package com.lcarthur.seasonsprint.ui
 
+import android.app.Application
+import android.content.Context
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ShowChart
@@ -22,8 +25,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lcarthur.seasonsprint.GameMode
 import com.lcarthur.seasonsprint.state.DashboardViewModel
 import com.lcarthur.seasonsprint.state.SettingsViewModel
 
@@ -33,18 +38,49 @@ private enum class Tab(val label: String, val icon: ImageVector) {
     Details("Details", Icons.AutoMirrored.Filled.ListAlt),
 }
 
+private const val UI_PREFS = "ui"
+private const val KEY_LAST_MODE = "lastMode"
+
 /**
- * Signed-in shell: branded loading until the first fetch completes, then a 3-tab layout
- * (Graph / Log / Details) with an app-wide Settings sheet behind the toolbar gear.
+ * Signed-in shell: branded loading until the first fetch completes, then a mode switcher
+ * (World Tour / Ranked) above a 3-tab layout (Graph / Log / Details), with an app-wide
+ * Settings sheet behind the toolbar gear.
+ *
+ * Both modes get their own [DashboardViewModel]/[SettingsViewModel] instance (keyed by mode,
+ * mirroring the web app's separate WorldTour.vue/Ranked.vue view instances) so each mode keeps
+ * its own goal, settings, and loaded records independently. Only the *active* mode's live
+ * connection is kept open.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MainScreen(
-    onSignOut: () -> Unit,
-    dashboardViewModel: DashboardViewModel = viewModel(),
-    settingsViewModel: SettingsViewModel = viewModel(),
-) {
-    LaunchedEffect(Unit) { dashboardViewModel.load() }
+fun MainScreen(onSignOut: () -> Unit) {
+    val context = LocalContext.current
+    val app = context.applicationContext as Application
+    val uiPrefs = remember { context.getSharedPreferences(UI_PREFS, Context.MODE_PRIVATE) }
+
+    var mode by remember {
+        val saved = uiPrefs.getString(KEY_LAST_MODE, null)?.let { runCatching { GameMode.valueOf(it) }.getOrNull() }
+        mutableStateOf(saved ?: GameMode.WorldTour)
+    }
+
+    val dashboardViewModels = GameMode.entries.associateWith { m ->
+        viewModel<DashboardViewModel>(key = "dashboard-${m.name}", factory = DashboardViewModel.Factory(m, app))
+    }
+    val settingsViewModels = GameMode.entries.associateWith { m ->
+        viewModel<SettingsViewModel>(key = "settings-${m.name}", factory = SettingsViewModel.Factory(m, app))
+    }
+
+    val dashboardViewModel = dashboardViewModels.getValue(mode)
+    val settingsViewModel = settingsViewModels.getValue(mode)
+
+    // Only the active mode's VM keeps its records fresh and its WebSocket open; the inactive
+    // one is paused (it still holds its last-loaded state, so switching back is instant).
+    LaunchedEffect(mode) {
+        dashboardViewModels.forEach { (m, vm) -> if (m != mode) vm.pauseLive() }
+        dashboardViewModel.load()
+        dashboardViewModel.resumeLive()
+    }
+
     val state by dashboardViewModel.state.collectAsStateWithLifecycle()
     val settings by settingsViewModel.state.collectAsStateWithLifecycle()
     var selected by remember { mutableStateOf(Tab.Graph) }
@@ -79,11 +115,20 @@ fun MainScreen(
             }
         },
     ) { innerPadding ->
-        val contentModifier = Modifier.padding(innerPadding)
-        when (selected) {
-            Tab.Graph -> DashboardScreen(dashboardViewModel, settings, contentModifier)
-            Tab.Log -> LogScreen(dashboardViewModel, contentModifier)
-            Tab.Details -> DetailsScreen(dashboardViewModel, contentModifier)
+        Column(modifier = Modifier.padding(innerPadding)) {
+            ModeSwitcher(
+                selected = mode,
+                onSelect = { next ->
+                    mode = next
+                    uiPrefs.edit().putString(KEY_LAST_MODE, next.name).apply()
+                },
+            )
+            val contentModifier = Modifier
+            when (selected) {
+                Tab.Graph -> DashboardScreen(dashboardViewModel, settings, contentModifier)
+                Tab.Log -> LogScreen(dashboardViewModel, contentModifier)
+                Tab.Details -> DetailsScreen(dashboardViewModel, contentModifier)
+            }
         }
     }
 

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/ModeSwitcher.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/ModeSwitcher.kt
@@ -1,0 +1,81 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.lcarthur.seasonsprint.GameMode
+import com.lcarthur.seasonsprint.ui.theme.FinalsBg
+import com.lcarthur.seasonsprint.ui.theme.FinalsGold
+import com.lcarthur.seasonsprint.ui.theme.FinalsGoldBright
+
+/** Segmented World Tour / Ranked pill, mirroring the web's ModeSwitcher.vue. */
+@Composable
+fun ModeSwitcher(
+    selected: GameMode,
+    onSelect: (GameMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        GameMode.entries.forEach { mode ->
+            ModeSegment(
+                label = mode.label,
+                isSelected = mode == selected,
+                onClick = { onSelect(mode) },
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ModeSegment(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .height(38.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .then(
+                if (isSelected) {
+                    Modifier.background(Brush.verticalGradient(listOf(FinalsGold, FinalsGoldBright)))
+                } else {
+                    Modifier
+                },
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Black,
+            color = if (isSelected) FinalsBg else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PaceChart.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PaceChart.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.lcarthur.seasonsprint.domain.PaceBaseline
 import com.lcarthur.seasonsprint.domain.Point
 import com.lcarthur.seasonsprint.domain.Season
 import com.lcarthur.seasonsprint.domain.earnedPaceSeries
@@ -33,6 +34,7 @@ fun PaceChart(
     points: List<Point>,
     goal: Int,
     season: Season?,
+    baseline: PaceBaseline,
     modifier: Modifier = Modifier,
 ) {
     Card(modifier = modifier.fillMaxWidth()) {
@@ -45,7 +47,7 @@ fun PaceChart(
             }
 
             val required = requiredPaceSeries(points, goal, season.end)
-            val earned = earnedPaceSeries(points)
+            val earned = earnedPaceSeries(points, baseline.value)
             if (required.isEmpty() && earned.isEmpty()) {
                 Placeholder("No pace data yet.")
                 return@Column

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
@@ -168,22 +168,29 @@ private fun ChartCanvas(
             }
 
             // --- Deviation wedge ---
+            // A straight-line fan from the baseline anchor (season start at 0 for World
+            // Tour; the placement point for Ranked) to the projected upper/lower bound at
+            // season end — sampled so the Canvas Path can render it as a filled band.
             if (showAveragePace && showDeviationWedge && season != null) {
                 val proj = averagePaceProjectedEnd(sorted, season.start, season.end, baseline)
                 val dev = deviationAtEnd(sorted, season.start, season.end, baseline)
                 if (proj != null && dev != null) {
+                    val baselineSec = baseline.instant.epochSecond.toDouble()
+                    val totalSecFromBaseline = endSec - baselineSec
+                    val yUpperEnd = proj + dev
+                    val yLowerEnd = maxOf(0.0, proj - dev)
                     val steps = 24
                     val path = Path()
                     for (i in 0..steps) {
                         val f = i.toDouble() / steps
-                        val x = xAtFrac(f)
-                        val hi = yOf(minOf(yMax, f * (proj + dev)))
+                        val x = xAtFrac((baselineSec + f * totalSecFromBaseline - startSec) / xSpan)
+                        val hi = yOf(minOf(yMax, baseline.value + f * (yUpperEnd - baseline.value)))
                         if (i == 0) path.moveTo(x, hi) else path.lineTo(x, hi)
                     }
                     for (i in steps downTo 0) {
                         val f = i.toDouble() / steps
-                        val x = xAtFrac(f)
-                        val lo = yOf(minOf(yMax, maxOf(0.0, f * (proj - dev))))
+                        val x = xAtFrac((baselineSec + f * totalSecFromBaseline - startSec) / xSpan)
+                        val lo = yOf(minOf(yMax, maxOf(0.0, baseline.value + f * (yLowerEnd - baseline.value))))
                         path.lineTo(x, lo)
                     }
                     path.close()

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/PointsChart.kt
@@ -26,14 +26,17 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.lcarthur.seasonsprint.domain.OverlayPoint
+import com.lcarthur.seasonsprint.domain.PaceBaseline
 import com.lcarthur.seasonsprint.domain.PaceStats
 import com.lcarthur.seasonsprint.domain.Point
 import com.lcarthur.seasonsprint.domain.RankInfo
 import com.lcarthur.seasonsprint.domain.Season
+import com.lcarthur.seasonsprint.domain.Threshold
 import com.lcarthur.seasonsprint.domain.averagePaceProjectedEnd
 import com.lcarthur.seasonsprint.domain.deviationAtEnd
-import com.lcarthur.seasonsprint.domain.worldTourThresholds
 import com.lcarthur.seasonsprint.ui.theme.ChartAvgPace
+import com.lcarthur.seasonsprint.ui.theme.FinalsGold
 import com.lcarthur.seasonsprint.ui.theme.GainNegative
 import com.lcarthur.seasonsprint.ui.theme.GainPositive
 import com.lcarthur.seasonsprint.ui.theme.rankColor
@@ -41,13 +44,17 @@ import java.time.Instant
 
 /**
  * The hero chart: cumulative points over time with optional rank overlay, goal line,
- * pace projections, average-pace line, and deviation wedge. Ports iOS PointsChartView.
+ * pace projections, average-pace line, deviation wedge, and a past-season compare overlay.
+ * Ports iOS PointsChartView.
  */
 @Composable
 fun PointsChart(
     points: List<Point>,
     goal: Int,
     season: Season?,
+    thresholds: List<Threshold>,
+    baseline: PaceBaseline,
+    overlayPoints: List<OverlayPoint>,
     rank: RankInfo,
     pace: PaceStats?,
     todayGain: Int?,
@@ -74,13 +81,16 @@ fun PointsChart(
                 sorted = sorted,
                 goal = goal,
                 season = season,
+                thresholds = thresholds,
+                baseline = baseline,
+                overlayPoints = overlayPoints,
                 showRankOverlay = showRankOverlay,
                 showAveragePace = showAveragePace,
                 showDeviationWedge = showDeviationWedge,
                 isFromLastDefined = pace?.isFromLastDefined == true,
                 todayGain = todayGain,
             )
-            Legend(showAveragePace = showAveragePace, showLast = pace?.isFromLastDefined == true)
+            Legend(showAveragePace = showAveragePace, showLast = pace?.isFromLastDefined == true, showOverlay = overlayPoints.isNotEmpty())
         }
     }
 }
@@ -90,6 +100,9 @@ private fun ChartCanvas(
     sorted: List<Point>,
     goal: Int,
     season: Season?,
+    thresholds: List<Threshold>,
+    baseline: PaceBaseline,
+    overlayPoints: List<OverlayPoint>,
     showRankOverlay: Boolean,
     showAveragePace: Boolean,
     showDeviationWedge: Boolean,
@@ -102,10 +115,11 @@ private fun ChartCanvas(
     val xSpan = (endSec - startSec).coerceAtLeast(1.0)
 
     // Y domain: cap at the goal unless the data exceeds it (then 5% headroom).
-    val maxPoint = sorted.maxOf { it.winPoints }.toDouble()
+    val maxPoint = maxOf(sorted.maxOf { it.winPoints }, overlayPoints.maxOfOrNull { it.winPoints } ?: 0).toDouble()
     val yMax = if (maxPoint > goal) maxOf(1.0, maxPoint * 1.05) else maxOf(1.0, goal.toDouble())
 
     val lineColor = MaterialTheme.colorScheme.secondary       // cyan
+    val overlayColor = FinalsGold.copy(alpha = 0.55f)          // faint gold, dashed — the compared season
     val lastProjectionColor = MaterialTheme.colorScheme.tertiary // mint
     val projectionColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
     val axisColor = MaterialTheme.colorScheme.outlineVariant
@@ -134,7 +148,7 @@ private fun ChartCanvas(
             // --- Rank overlay bands (back layer) ---
             if (showRankOverlay) {
                 var lower = 0
-                for (t in worldTourThresholds) {
+                for (t in thresholds) {
                     if (lower < yMax) {
                         val upper = minOf(t.points.toDouble(), yMax)
                         val top = yOf(upper)
@@ -148,15 +162,15 @@ private fun ChartCanvas(
                     lower = t.points
                 }
                 // Faint tier-zone labels at each grouped tier's vertical midpoint (right-aligned).
-                for (zone in tierZones(yMax)) {
+                for (zone in tierZones(yMax, thresholds)) {
                     drawZoneLabel(zone.first, padLeft + plotW, yOf(zone.second) + 4.dp.toPx(), rankColor(zone.third).copy(alpha = 0.18f).toArgb())
                 }
             }
 
             // --- Deviation wedge ---
             if (showAveragePace && showDeviationWedge && season != null) {
-                val proj = averagePaceProjectedEnd(sorted, season.start, season.end)
-                val dev = deviationAtEnd(sorted, season.start, season.end)
+                val proj = averagePaceProjectedEnd(sorted, season.start, season.end, baseline)
+                val dev = deviationAtEnd(sorted, season.start, season.end, baseline)
                 if (proj != null && dev != null) {
                     val steps = 24
                     val path = Path()
@@ -181,13 +195,13 @@ private fun ChartCanvas(
 
             // --- Average pace line ---
             if (showAveragePace && season != null) {
-                val proj = averagePaceProjectedEnd(sorted, season.start, season.end)
-                if (proj != null && proj > 0) {
-                    val endFrac = if (proj > yMax) yMax / proj else 1.0
+                val proj = averagePaceProjectedEnd(sorted, season.start, season.end, baseline)
+                if (proj != null && proj > baseline.value) {
+                    val endFrac = if (proj > yMax) (yMax - baseline.value) / (proj - baseline.value) else 1.0
                     val endVal = if (proj > yMax) yMax else proj
                     drawLine(
                         color = avgColor,
-                        start = Offset(xAtFrac(0.0), yOf(0.0)),
+                        start = Offset(xOf(baseline.instant), yOf(baseline.value)),
                         end = Offset(xAtFrac(endFrac), yOf(endVal)),
                         strokeWidth = 1.5.dp.toPx(),
                         pathEffect = PathEffect.dashPathEffect(floatArrayOf(4f, 4f)),
@@ -195,13 +209,13 @@ private fun ChartCanvas(
                 }
             }
 
-            // Baseline (y = 0).
+            // Baseline (y = 0) — a fixed zero reference, distinct from the pace/projection anchor.
             drawLine(axisColor, Offset(padLeft, yOf(0.0)), Offset(padLeft + plotW, yOf(0.0)), strokeWidth = 1.dp.toPx())
 
-            // --- Zero → goal projection ---
+            // --- Baseline → goal projection ---
             drawLine(
                 color = projectionColor,
-                start = Offset(xAtFrac(0.0), yOf(0.0)),
+                start = Offset(xOf(baseline.instant), yOf(baseline.value)),
                 end = Offset(xAtFrac(1.0), yOf(goal.toDouble())),
                 strokeWidth = 1.5.dp.toPx(),
                 pathEffect = dash,
@@ -219,9 +233,38 @@ private fun ChartCanvas(
                 )
             }
 
+            // --- Placement baseline segment (Ranked only) ---
+            // A flat span from season start to the placement point, making it clear the climb
+            // begins at placement rather than zero. No-op for World Tour, whose baseline sits
+            // at season start already.
+            if (baseline.instant.epochSecond > startSec.toLong()) {
+                drawLine(
+                    color = lineColor.copy(alpha = 0.6f),
+                    start = Offset(xAtFrac(0.0), yOf(baseline.value)),
+                    end = Offset(xOf(baseline.instant), yOf(baseline.value)),
+                    strokeWidth = 2.5.dp.toPx(),
+                )
+            }
+
+            // --- Compare-season overlay (faint, dashed, behind the current line) ---
+            if (overlayPoints.isNotEmpty()) {
+                var prevOverlay: Offset? = null
+                for (p in overlayPoints) {
+                    val o = Offset(xOf(p.instant), yOf(p.winPoints.toDouble()))
+                    prevOverlay?.let {
+                        drawLine(overlayColor, it, o, strokeWidth = 2.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(5f, 5f)))
+                    }
+                    prevOverlay = o
+                }
+                for (p in overlayPoints) {
+                    drawCircle(overlayColor, radius = 2.5.dp.toPx(), center = Offset(xOf(p.instant), yOf(p.winPoints.toDouble())))
+                }
+            }
+
             // --- Cumulative line + dots ---
-            // Seed at the graph origin (x-start, 0) so the first point connects back to zero-zero.
-            var prev: Offset? = Offset(xAtFrac(0.0), yOf(0.0))
+            // Seed at the pace baseline (season start at 0 for World Tour; the placement point
+            // itself for Ranked) so the first point connects back to the anchor, not always zero.
+            var prev: Offset? = Offset(xOf(baseline.instant), yOf(baseline.value))
             for (p in sorted) {
                 val o = Offset(xOf(p.instant), yOf(p.winPoints.toDouble()))
                 prev?.let { drawLine(lineColor, it, o, strokeWidth = 2.5.dp.toPx()) }
@@ -252,11 +295,12 @@ private fun ChartCanvas(
 }
 
 @Composable
-private fun Legend(showAveragePace: Boolean, showLast: Boolean) {
+private fun Legend(showAveragePace: Boolean, showLast: Boolean, showOverlay: Boolean) {
     Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
         LegendItem(MaterialTheme.colorScheme.onSurfaceVariant, "Zero → goal")
         if (showLast) LegendItem(MaterialTheme.colorScheme.tertiary, "Last → goal")
         if (showAveragePace) LegendItem(ChartAvgPace, "Avg pace")
+        if (showOverlay) LegendItem(FinalsGold.copy(alpha = 0.55f), "Compare")
     }
 }
 
@@ -271,18 +315,17 @@ private fun LegendItem(color: Color, label: String) {
 }
 
 /** One label per grouped tier (adjacent same-tier sub-tiers merge), at the band midpoint. */
-private fun tierZones(yMax: Double): List<Triple<String, Double, String>> {
+private fun tierZones(yMax: Double, thresholds: List<Threshold>): List<Triple<String, Double, String>> {
     val zones = mutableListOf<Triple<String, Double, String>>()
-    val t = worldTourThresholds
     var lower = 0
     var i = 0
-    while (i < t.size) {
-        val tier = t[i].badge.substringBefore(' ')
+    while (i < thresholds.size) {
+        val tier = thresholds[i].badge.substringBefore(' ')
         var j = i
-        while (j + 1 < t.size && t[j + 1].badge.substringBefore(' ') == tier) j++
-        val upper = t[j].points
+        while (j + 1 < thresholds.size && thresholds[j + 1].badge.substringBefore(' ') == tier) j++
+        val upper = thresholds[j].points
         val mid = (lower + upper) / 2.0
-        if (mid < yMax) zones.add(Triple(tier, mid, t[i].badge))
+        if (mid < yMax) zones.add(Triple(tier, mid, thresholds[i].badge))
         lower = upper
         i = j + 1
     }

--- a/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/PaceTest.kt
+++ b/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/PaceTest.kt
@@ -1,5 +1,6 @@
 package com.lcarthur.seasonsprint.domain
 
+import com.lcarthur.seasonsprint.GameMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -44,5 +45,48 @@ class PaceTest {
         val now = Instant.parse("2025-02-01T00:00:00Z") // past season end
         val pace = computePace(goal = 1000, seasonPoints = emptyList(), start = start, end = end, now = now)
         assertEquals(0, pace.daysRemaining)
+    }
+
+    // --- Ranked placement baseline ---
+
+    @Test
+    fun requiredPerDayZeroUsesBaselineWhenProvided() {
+        val baseline = PaceBaseline(DateKey.parseUtc("2025-01-03")!!, 30_000.0)
+        val pace = computePace(goal = 40_000, seasonPoints = emptyList(), start = start, end = end, baseline = baseline)
+        // 8 days from the placement (01-03) to season end (01-11).
+        assertEquals(1250.0, pace.requiredPerDayZero, 0.0001)
+    }
+
+    @Test
+    fun paceBaselineForRankedUsesFirstSeasonPoint() {
+        val points = listOf(point("2025-01-03", 30_000), point("2025-01-05", 31_000))
+        val baseline = paceBaselineFor(GameMode.Ranked, points.sortedBy { it.instant }, start)
+        assertEquals(DateKey.parseUtc("2025-01-03"), baseline.instant)
+        assertEquals(30_000.0, baseline.value, 0.0001)
+    }
+
+    @Test
+    fun paceBaselineForWorldTourIsAlwaysSeasonStartZero() {
+        val points = listOf(point("2025-01-03", 200))
+        val baseline = paceBaselineFor(GameMode.WorldTour, points, start)
+        assertEquals(start, baseline.instant)
+        assertEquals(0.0, baseline.value, 0.0001)
+    }
+
+    @Test
+    fun paceBaselineForRankedFallsBackToSeasonStartZeroWhenNoPoints() {
+        val baseline = paceBaselineFor(GameMode.Ranked, emptyList(), start)
+        assertEquals(start, baseline.instant)
+        assertEquals(0.0, baseline.value, 0.0001)
+    }
+
+    @Test
+    fun averagePaceProjectedEndAnchorsAtBaseline() {
+        val baseline = PaceBaseline(DateKey.parseUtc("2025-01-03")!!, 30_000.0)
+        // Relative to baseline: (day 2, +1000), (day 4, +2000) -> slope 500/day.
+        val points = listOf(point("2025-01-05", 31_000), point("2025-01-07", 32_000))
+        val proj = averagePaceProjectedEnd(points, start, end, baseline)
+        // 8 days from baseline to season end: 30000 + 500 * 8 = 34000.
+        assertEquals(34_000.0, proj!!, 0.01)
     }
 }

--- a/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/RankTest.kt
+++ b/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/RankTest.kt
@@ -1,7 +1,9 @@
 package com.lcarthur.seasonsprint.domain
 
+import com.lcarthur.seasonsprint.GameMode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 
 /** Validates the ported rank logic matches the web/iOS source of truth (worldTourRanks.json). */
@@ -59,5 +61,36 @@ class RankTest {
         assertEquals("gold", tierKey("Gold 2"))
         assertEquals("emerald", tierKey("Emerald 1"))
         assertEquals("unranked", tierKey("Unranked"))
+    }
+
+    @Test
+    fun rankedStartsAtBronze4Immediately() {
+        // Unlike World Tour, Ranked's first threshold is 0 RS, so a placement of 0 is already
+        // Bronze 4, not Unranked.
+        val r = computeRank(0, rankedThresholds)
+        assertEquals("Bronze 4", r.badge)
+        assertEquals(0, r.currentFloor)
+        assertEquals(2500, r.nextTarget)
+    }
+
+    @Test
+    fun rankedMidBandReportsCurrentAndNext() {
+        val r = computeRank(26_000, rankedThresholds) // between Gold 2 (25000) and Gold 1 (27500)
+        assertEquals("Gold 2", r.badge)
+        assertEquals(25000, r.currentFloor)
+        assertEquals(27500, r.nextTarget)
+    }
+
+    @Test
+    fun rankedAtTopThereIsNoNext() {
+        val r = computeRank(47_500, rankedThresholds)
+        assertEquals("Diamond 1", r.badge)
+        assertNull(r.nextTarget)
+    }
+
+    @Test
+    fun thresholdsForPicksTheRightTable() {
+        assertSame(worldTourThresholds, thresholdsFor(GameMode.WorldTour))
+        assertSame(rankedThresholds, thresholdsFor(GameMode.Ranked))
     }
 }

--- a/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/SeasonPickerTest.kt
+++ b/packages/android/app/src/test/java/com/lcarthur/seasonsprint/domain/SeasonPickerTest.kt
@@ -1,0 +1,63 @@
+package com.lcarthur.seasonsprint.domain
+
+import com.lcarthur.seasonsprint.data.SeasonDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Validates the ported season-picker gating/remap logic matches utils/chart.js. */
+class SeasonPickerTest {
+    private fun point(day: String, winPoints: Int) =
+        Point(remoteId = day, day = day, winPoints = winPoints, instant = DateKey.parseUtc(day)!!)
+
+    private val season1 = SeasonDto(name = "1", start = "2024-01-01T00:00:00Z", end = "2024-01-10T00:00:00Z")
+    private val season2 = SeasonDto(name = "2", start = "2024-02-01T00:00:00Z", end = "2024-02-10T00:00:00Z")
+
+    @Test
+    fun seasonOptionsFromNormalizesNameAndSortsAscending() {
+        val options = seasonOptionsFrom(listOf(season2, season1))
+        assertEquals(listOf("1", "2"), options.map { it.key })
+        assertEquals("Season 1", options[0].displayName)
+    }
+
+    @Test
+    fun seasonOptionsFromKeepsAlreadyPrefixedNames() {
+        val named = SeasonDto(name = "Season 3", start = "2024-03-01T00:00:00Z", end = "2024-03-10T00:00:00Z")
+        val options = seasonOptionsFrom(listOf(named))
+        assertEquals("Season 3", options[0].displayName)
+    }
+
+    @Test
+    fun seasonsWithDataKeysOnlyIncludesSeasonsWithAtLeastOnePoint() {
+        val options = seasonOptionsFrom(listOf(season1, season2))
+        val points = listOf(point("2024-01-05", 100))
+        val keys = seasonsWithDataKeys(points, options)
+        assertEquals(setOf("1"), keys)
+    }
+
+    @Test
+    fun mapOverlayByDayOfSeasonShiftsPointsByStartOffset() {
+        val overlayStart = DateKey.parseUtc("2024-01-01")!!
+        val viewedStart = DateKey.parseUtc("2024-02-01")!!
+        val viewedEnd = DateKey.parseUtc("2024-02-10")!!
+        val overlayPoints = listOf(point("2024-01-03", 500)) // day offset 2 into its own season
+
+        val mapped = mapOverlayByDayOfSeason(overlayPoints, overlayStart, viewedStart, viewedEnd)
+
+        assertEquals(1, mapped.size)
+        assertEquals(DateKey.parseUtc("2024-02-03"), mapped[0].instant)
+        assertEquals(500, mapped[0].winPoints)
+    }
+
+    @Test
+    fun mapOverlayByDayOfSeasonDropsPointsPastViewedEnd() {
+        val overlayStart = DateKey.parseUtc("2024-01-01")!!
+        val viewedStart = DateKey.parseUtc("2024-02-01")!!
+        val viewedEnd = DateKey.parseUtc("2024-02-05")!! // shorter than the overlay season
+        val overlayPoints = listOf(point("2024-01-08", 999)) // day offset 7, past the viewed end
+
+        val mapped = mapOverlayByDayOfSeason(overlayPoints, overlayStart, viewedStart, viewedEnd)
+
+        assertTrue(mapped.isEmpty())
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Domain/Pace.swift
+++ b/packages/ios/Sources/SeasonSprint/Domain/Pace.swift
@@ -6,12 +6,29 @@ private func roundedDays(_ from: Date, _ to: Date) -> Int {
     Int((to.timeIntervalSince(from) / secondsPerDay).rounded())
 }
 
+/// The anchor pace/projection math is measured from. World Tour anchors at
+/// (seasonStart, 0); Ranked anchors at the first recorded point in the season (the
+/// placement point), since a Ranked season starts at a placement rank, not zero.
+/// Mirrors `paceBaseline` in packages/web/src/composables/useChartGeometry.js.
+struct PaceBaseline: Sendable, Equatable {
+    let date: Date
+    let value: Double
+}
+
+/// `sortedSeasonPoints` must already be sorted ascending by `Point.date`.
+func paceBaseline(for mode: GameMode, sortedSeasonPoints: [Point], seasonStart: Date) -> PaceBaseline {
+    if mode == .ranked, let first = sortedSeasonPoints.first {
+        return PaceBaseline(date: first.date, value: Double(first.winPoints))
+    }
+    return PaceBaseline(date: seasonStart, value: 0)
+}
+
 /// Goal-pace statistics over a season window. Ports the computeds in
 /// packages/web/src/components/LineGraph.vue (lines ~610-641) and StatsPanel.vue.
 struct PaceStats: Sendable, Equatable {
     let daysInSeason: Int
     let daysRemaining: Int
-    /// Slope of the zero -> goal projection, points per day.
+    /// Slope of the baseline -> goal projection, points per day.
     let requiredPerDayZero: Double
     /// Whether a "last point -> goal" pace is meaningful (≥1 point in season and the
     /// latest point predates the season end).
@@ -25,15 +42,20 @@ struct PaceStats: Sendable, Equatable {
 ///   - seasonPoints: points whose day falls within [start, end], any order.
 ///   - start, end: season window.
 ///   - today: current date (for days-remaining).
+///   - baseline: the zero-point anchor; defaults to (start, 0) — pass `paceBaseline(for:...)`'s
+///     result to get Ranked's placement-point measurement.
 func computePace(
     goal: Int,
     seasonPoints: [Point],
     start: Date,
     end: Date,
-    today: Date = Date()
+    today: Date = Date(),
+    baseline: PaceBaseline? = nil
 ) -> PaceStats {
+    let baseline = baseline ?? PaceBaseline(date: start, value: 0)
     let daysInSeason = max(1, roundedDays(start, end))
-    let requiredPerDayZero = Double(goal) / Double(daysInSeason)
+    let baselineDays = max(1, roundedDays(baseline.date, end))
+    let requiredPerDayZero = (Double(goal) - baseline.value) / Double(baselineDays)
 
     let sorted = seasonPoints.sorted { $0.date < $1.date }
     let last = sorted.last
@@ -61,14 +83,16 @@ func computePace(
 
 // MARK: - Chart overlay helpers (ported from packages/web/src/utils/chart.js)
 
-/// Through-origin least-squares slope (points/day): `Σ(x·y) / Σ(x²)` with x = day offset
-/// from season start, including the implicit origin (0,0). Returns nil if undefined.
-private func throughOriginSlope(_ seasonPoints: [Point], start: Date) -> Double? {
+/// Through-origin least-squares slope (points/day): `Σ(x·y) / Σ(x²)`, where x/y are day/value
+/// offsets *relative to `baseline`*. A point that coincides with the baseline itself (the
+/// Ranked placement point) is skipped so it isn't counted twice against the synthetic origin.
+private func throughOriginSlope(_ seasonPoints: [Point], baseline: PaceBaseline) -> Double? {
     var sumXX = 0.0
     var sumXY = 0.0
     for p in seasonPoints {
-        let x = p.date.timeIntervalSince(start) / secondsPerDay
-        let y = Double(p.winPoints)
+        let x = p.date.timeIntervalSince(baseline.date) / secondsPerDay
+        let y = Double(p.winPoints) - baseline.value
+        if x == 0, y == 0 { continue }
         sumXX += x * x
         sumXY += x * y
     }
@@ -76,28 +100,45 @@ private func throughOriginSlope(_ seasonPoints: [Point], start: Date) -> Double?
     return sumXY / sumXX
 }
 
-/// Average-pace value projected to season end: `slope · totalDays`. (`buildAveragePacePath`)
-func averagePaceProjectedEnd(seasonPoints: [Point], start: Date, end: Date) -> Double? {
-    guard !seasonPoints.isEmpty, let slope = throughOriginSlope(seasonPoints, start: start) else { return nil }
-    let totalDays = end.timeIntervalSince(start) / secondsPerDay
-    return slope * totalDays
+/// Average-pace value projected to season end: baseline value + `slope · daysFromBaseline`.
+/// (`buildAveragePacePath`)
+func averagePaceProjectedEnd(
+    seasonPoints: [Point],
+    start: Date,
+    end: Date,
+    baseline: PaceBaseline? = nil
+) -> Double? {
+    let baseline = baseline ?? PaceBaseline(date: start, value: 0)
+    guard !seasonPoints.isEmpty, let slope = throughOriginSlope(seasonPoints, baseline: baseline) else { return nil }
+    let totalDays = end.timeIntervalSince(baseline.date) / secondsPerDay
+    return baseline.value + slope * totalDays
 }
 
 /// Deviation half-width at season end for the confidence wedge. (`buildDeviationWedgePath`)
-func deviationAtEnd(seasonPoints: [Point], start: Date, end: Date) -> Double? {
-    guard seasonPoints.count >= 2, let slope = throughOriginSlope(seasonPoints, start: start) else { return nil }
+func deviationAtEnd(
+    seasonPoints: [Point],
+    start: Date,
+    end: Date,
+    baseline: PaceBaseline? = nil
+) -> Double? {
+    let baseline = baseline ?? PaceBaseline(date: start, value: 0)
+    guard seasonPoints.count >= 2, let slope = throughOriginSlope(seasonPoints, baseline: baseline) else { return nil }
 
     var sumResidualSq = 0.0
+    var n = 0
     for p in seasonPoints {
-        let x = p.date.timeIntervalSince(start) / secondsPerDay
-        let residual = Double(p.winPoints) - slope * x
+        let x = p.date.timeIntervalSince(baseline.date) / secondsPerDay
+        let y = Double(p.winPoints) - baseline.value
+        if x == 0, y == 0 { continue }
+        let residual = y - slope * x
         sumResidualSq += residual * residual
+        n += 1
     }
-    let n = seasonPoints.count
+    guard n > 0 else { return nil }
     let stdDev = n > 1 ? (sumResidualSq / Double(n - 1)).squareRoot() : sumResidualSq.squareRoot()
 
     let tFactor: Double = n <= 2 ? 4.303 : n <= 3 ? 3.182 : n <= 5 ? 2.776 : n <= 10 ? 2.228 : 1.96
-    let totalDays = end.timeIntervalSince(start) / secondsPerDay
+    let totalDays = end.timeIntervalSince(baseline.date) / secondsPerDay
     let projectedMag = abs(slope * totalDays)
     let minDeviation = n <= 3 ? projectedMag * 0.3 : n <= 6 ? projectedMag * 0.15 : projectedMag * 0.05
     return max(stdDev * tFactor, minDeviation)
@@ -120,12 +161,14 @@ func requiredPaceSeries(seasonPoints: [Point], goal: Int, end: Date) -> [PaceSer
     }
 }
 
-/// Points earned per entry: delta of the cumulative total. (`buildPointsEarnedData`)
-func earnedPaceSeries(seasonPoints: [Point]) -> [PaceSeriesPoint] {
-    var prev = 0
+/// Points earned per entry: delta of the cumulative total. `baselineY` seeds the running
+/// total — 0 for World Tour, the placement value for Ranked, so the placement point itself
+/// doesn't read as a giant "earned" spike on day one. (`buildPointsEarnedData`)
+func earnedPaceSeries(seasonPoints: [Point], baselineY: Double = 0) -> [PaceSeriesPoint] {
+    var prev = baselineY
     return seasonPoints.sorted { $0.date < $1.date }.map { p in
-        let delta = p.winPoints - prev
-        prev = p.winPoints
-        return PaceSeriesPoint(date: p.date, value: Double(delta))
+        let delta = Double(p.winPoints) - prev
+        prev = Double(p.winPoints)
+        return PaceSeriesPoint(date: p.date, value: delta)
     }
 }

--- a/packages/ios/Sources/SeasonSprint/Domain/Rank.swift
+++ b/packages/ios/Sources/SeasonSprint/Domain/Rank.swift
@@ -6,6 +6,14 @@ struct Threshold: Sendable, Equatable {
     let points: Int
 }
 
+/// The rank/RS threshold table for a mode.
+func thresholds(for mode: GameMode) -> [Threshold] {
+    switch mode {
+    case .worldTour: return worldTourThresholds
+    case .ranked: return rankedThresholds
+    }
+}
+
 /// Derived rank state for a given points total against a threshold table.
 /// Ported from packages/web/src/composables/useRankInfo.js.
 struct RankInfo: Sendable, Equatable {
@@ -85,6 +93,32 @@ let worldTourThresholds: [Threshold] = [
     Threshold(badge: "Emerald 3", points: 2000),
     Threshold(badge: "Emerald 2", points: 2200),
     Threshold(badge: "Emerald 1", points: 2400),
+]
+
+/// Ranked RS thresholds, verbatim from packages/web/src/views/Ranked.vue (RANKED_THRESHOLDS).
+/// Bronze (0 -> 7,500), Silver (10,000 -> 17,500), Gold (20,000 -> 27,500), Platinum
+/// (30,000 -> 37,500), Diamond (40,000 -> 47,500). Ruby = Top 500, not threshold-based.
+let rankedThresholds: [Threshold] = [
+    Threshold(badge: "Bronze 4", points: 0),
+    Threshold(badge: "Bronze 3", points: 2500),
+    Threshold(badge: "Bronze 2", points: 5000),
+    Threshold(badge: "Bronze 1", points: 7500),
+    Threshold(badge: "Silver 4", points: 10000),
+    Threshold(badge: "Silver 3", points: 12500),
+    Threshold(badge: "Silver 2", points: 15000),
+    Threshold(badge: "Silver 1", points: 17500),
+    Threshold(badge: "Gold 4", points: 20000),
+    Threshold(badge: "Gold 3", points: 22500),
+    Threshold(badge: "Gold 2", points: 25000),
+    Threshold(badge: "Gold 1", points: 27500),
+    Threshold(badge: "Platinum 4", points: 30000),
+    Threshold(badge: "Platinum 3", points: 32500),
+    Threshold(badge: "Platinum 2", points: 35000),
+    Threshold(badge: "Platinum 1", points: 37500),
+    Threshold(badge: "Diamond 4", points: 40000),
+    Threshold(badge: "Diamond 3", points: 42500),
+    Threshold(badge: "Diamond 2", points: 45000),
+    Threshold(badge: "Diamond 1", points: 47500),
 ]
 
 /// World Tour win-points cheatsheet, from packages/web/src/components/PointsCheatsheet.vue.

--- a/packages/ios/Sources/SeasonSprint/Domain/SeasonPicker.swift
+++ b/packages/ios/Sources/SeasonSprint/Domain/SeasonPicker.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// A selectable season in the picker: `key` is the raw season name (as `/seasons` returns it).
+struct SeasonOption: Identifiable, Sendable, Equatable {
+    let key: String
+    let displayName: String
+    let season: Season
+    var id: String { key }
+}
+
+/// "8" -> "Season 8"; "Season 8" stays as-is. Mirrors displayName() in useSeasons.js.
+private func displayName(for rawName: String) -> String {
+    let trimmed = rawName.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return trimmed }
+    return trimmed.lowercased().hasPrefix("season") ? trimmed : "Season \(trimmed)"
+}
+
+/// Normalizes the full `GET /seasons` payload into pickable options, ascending by start date.
+func seasonOptions(from seasons: [Season]) -> [SeasonOption] {
+    seasons
+        .map { SeasonOption(key: $0.name, displayName: displayName(for: $0.name), season: $0) }
+        .sorted { $0.season.start < $1.season.start }
+}
+
+/// A record re-mapped onto another season's timeline for the "compare" overlay — not a real record.
+struct OverlayPoint: Identifiable, Sendable {
+    let date: Date
+    let winPoints: Int
+    var id: Date { date }
+}
+
+/// Keys of the seasons the user has at least one point inside (inclusive window). Gates the
+/// season picker so we never offer a past season with no data.
+/// Mirrors seasonsWithDataKeys in packages/web/src/utils/chart.js.
+func seasonsWithDataKeys(points: [Point], seasons: [SeasonOption]) -> Set<String> {
+    Set(seasons.filter { option in
+        points.contains { $0.date >= option.season.start && $0.date <= option.season.end }
+    }.map(\.key))
+}
+
+/// Re-maps a previous season's points onto the viewed season's x-axis by day-of-season, so day
+/// 0 of each season lines up (e.g. "where was I on day 12 last season vs this one"). Points
+/// whose elapsed day falls past the viewed season's end are dropped rather than clamped.
+/// Mirrors mapOverlayByDayOfSeason in packages/web/src/utils/chart.js.
+func mapOverlayByDayOfSeason(
+    overlayPoints: [Point],
+    overlaySeasonStart: Date,
+    viewedSeasonStart: Date,
+    viewedSeasonEnd: Date
+) -> [OverlayPoint] {
+    let offset = viewedSeasonStart.timeIntervalSince(overlaySeasonStart)
+    return overlayPoints.compactMap { p in
+        let mapped = p.date.addingTimeInterval(offset)
+        guard mapped <= viewedSeasonEnd else { return nil }
+        return OverlayPoint(date: mapped, winPoints: p.winPoints)
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/GameMode.swift
+++ b/packages/ios/Sources/SeasonSprint/GameMode.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Which game mode a records/season view is scoped to. Mirrors the server's `GameMode` type.
+enum GameMode: String, Sendable, CaseIterable {
+    case worldTour = "world-tour"
+    case ranked = "ranked"
+
+    var wireValue: String { rawValue }
+
+    var prefsSuffix: String {
+        switch self {
+        case .worldTour: return "worldTour"
+        case .ranked: return "ranked"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .worldTour: return "World Tour"
+        case .ranked: return "Ranked"
+        }
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Networking/APIClient.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/APIClient.swift
@@ -18,11 +18,13 @@ enum APIClient {
         return "Bearer \(jwt)"
     }
 
-    /// `GET /me/records`
+    /// `GET /me/records?mode=...`
     @MainActor
-    static func getRecords() async throws -> [APIRecord] {
+    static func getRecords(mode: GameMode) async throws -> [APIRecord] {
         guard let auth = await authorizationHeader() else { throw APIError.notAuthenticated }
-        var req = URLRequest(url: Config.serverURL.appendingPathComponent("me/records"))
+        var comps = URLComponents(url: Config.serverURL.appendingPathComponent("me/records"), resolvingAgainstBaseURL: false)!
+        comps.queryItems = [URLQueryItem(name: "mode", value: mode.wireValue)]
+        var req = URLRequest(url: comps.url!)
         req.setValue(auth, forHTTPHeaderField: "Authorization")
         let (data, response) = try await URLSession.shared.data(for: req)
         try check(response)
@@ -31,13 +33,13 @@ enum APIClient {
 
     /// `POST /me/records` — upsert a record by date; returns the saved record.
     @MainActor
-    static func upsertRecord(date: String, winPoints: Int) async throws -> APIRecord {
+    static func upsertRecord(date: String, winPoints: Int, mode: GameMode) async throws -> APIRecord {
         guard let auth = await authorizationHeader() else { throw APIError.notAuthenticated }
         var req = URLRequest(url: Config.serverURL.appendingPathComponent("me/records"))
         req.httpMethod = "POST"
         req.setValue(auth, forHTTPHeaderField: "Authorization")
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try JSONEncoder().encode(RecordWrite(date: date, winPoints: winPoints))
+        req.httpBody = try JSONEncoder().encode(RecordWrite(date: date, winPoints: winPoints, mode: mode.wireValue))
         let (data, response) = try await URLSession.shared.data(for: req)
         try check(response)
         return try JSONDecoder().decode(UpsertResponse.self, from: data).record
@@ -70,10 +72,15 @@ enum APIClient {
 
     /// `GET /seasons` — public (no auth); returns the current season window, or nil.
     static func getSeasons() async throws -> Season? {
+        try await getAllSeasons().currentSeason
+    }
+
+    /// `GET /seasons` — public (no auth); the full payload (every season + the current one).
+    static func getAllSeasons() async throws -> SeasonsResponse {
         let req = URLRequest(url: Config.serverURL.appendingPathComponent("seasons"))
         let (data, response) = try await URLSession.shared.data(for: req)
         try check(response)
-        return try seasonsDecoder.decode(SeasonsResponse.self, from: data).currentSeason
+        return try seasonsDecoder.decode(SeasonsResponse.self, from: data)
     }
 
     /// Decoder that parses ISO-8601 timestamps with fractional seconds (e.g. `...000Z`).

--- a/packages/ios/Sources/SeasonSprint/Networking/Models.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/Models.swift
@@ -1,11 +1,13 @@
 import Foundation
 
 /// A record as returned by the server (`GET /me/records`).
-/// Matches the Prisma `Record` model: { id, date (ISO), winPoints, ... }.
+/// Matches the Prisma `Record` model: { id, date (ISO), winPoints, mode, ... }.
 struct APIRecord: Codable, Identifiable, Sendable {
     let id: String
     let date: String
     let winPoints: Int
+    /// Missing/nil means `"world-tour"`, matching the server default.
+    let mode: String?
 }
 
 /// Response from `POST /me/stream/token`.
@@ -21,8 +23,9 @@ struct Season: Codable, Sendable, Equatable {
     let end: Date
 }
 
-/// `GET /seasons` payload (we only need `currentSeason`).
+/// `GET /seasons` payload — the full scraped list, same for every mode.
 struct SeasonsResponse: Codable, Sendable {
+    let seasons: [Season]
     let currentSeason: Season?
 }
 
@@ -30,6 +33,7 @@ struct SeasonsResponse: Codable, Sendable {
 struct RecordWrite: Encodable, Sendable {
     let date: String
     let winPoints: Int
+    var mode: String? = nil
 }
 
 /// Response from `POST /me/records`.

--- a/packages/ios/Sources/SeasonSprint/Networking/SSEClient.swift
+++ b/packages/ios/Sources/SeasonSprint/Networking/SSEClient.swift
@@ -4,9 +4,10 @@ import Foundation
 /// broadcast (UserStream.ts / broadcast.ts).
 enum RecordEvent: Sendable {
     case upsert(APIRecord)
-    case delete(String)
-    case deleteAll
-    case bulkUpsert([APIRecord])
+    /// `mode` is missing/nil for `"world-tour"`, matching the server's broadcast payload.
+    case delete(id: String, mode: String?)
+    case deleteAll(mode: String?)
+    case bulkUpsert([APIRecord], mode: String?)
 }
 
 /// Live-link state for the connection indicator.
@@ -141,18 +142,21 @@ final class SSEClient {
                 onEvent?(.upsert(p.data))
             }
         case "record:delete":
-            struct Inner: Decodable { let id: String }
+            struct Inner: Decodable { let id: String; let mode: String? }
             struct P: Decodable { let data: Inner }
             if let p = try? JSONDecoder().decode(P.self, from: bytes) {
-                onEvent?(.delete(p.data.id))
+                onEvent?(.delete(id: p.data.id, mode: p.data.mode))
             }
         case "record:delete-all":
-            onEvent?(.deleteAll)
+            struct Inner: Decodable { let mode: String? }
+            struct P: Decodable { let data: Inner }
+            let mode = (try? JSONDecoder().decode(P.self, from: bytes))?.data.mode
+            onEvent?(.deleteAll(mode: mode))
         case "record:bulk-upsert":
-            struct Inner: Decodable { let records: [APIRecord] }
+            struct Inner: Decodable { let records: [APIRecord]; let mode: String? }
             struct P: Decodable { let data: Inner }
             if let p = try? JSONDecoder().decode(P.self, from: bytes) {
-                onEvent?(.bulkUpsert(p.data.records))
+                onEvent?(.bulkUpsert(p.data.records, mode: p.data.mode))
             }
         default:
             break

--- a/packages/ios/Sources/SeasonSprint/SeasonSprintApp.swift
+++ b/packages/ios/Sources/SeasonSprint/SeasonSprintApp.swift
@@ -7,7 +7,6 @@ struct SeasonSprintApp: App {
     // *before* anything touches `Clerk.shared`, so we do it here in init and seed
     // the @State from the return value rather than reading `Clerk.shared` directly.
     @State private var clerk: Clerk
-    @State private var settings: AppSettings
 
     init() {
         let options = Clerk.Options(
@@ -25,14 +24,12 @@ struct SeasonSprintApp: App {
             options: options
         )
         _clerk = State(initialValue: configured)
-        _settings = State(initialValue: AppSettings())
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(clerk)
-                .environment(settings)
         }
     }
 }

--- a/packages/ios/Sources/SeasonSprint/State/AppSettings.swift
+++ b/packages/ios/Sources/SeasonSprint/State/AppSettings.swift
@@ -1,16 +1,18 @@
 import Foundation
 import Observation
 
-/// App-wide graph display settings, persisted in UserDefaults. Mirrors the toggles in
+/// App-wide graph display settings, persisted in UserDefaults per mode (matching the web
+/// app's per-mode `storageKey`). Mirrors the toggles in
 /// packages/web/src/components/modals/SettingsModal.vue.
 @MainActor
 @Observable
 final class AppSettings {
-    var showRankOverlay: Bool { didSet { defaults.set(showRankOverlay, forKey: Keys.rankOverlay) } }
-    var showAveragePace: Bool { didSet { defaults.set(showAveragePace, forKey: Keys.averagePace) } }
-    var showDeviationWedge: Bool { didSet { defaults.set(showDeviationWedge, forKey: Keys.deviationWedge) } }
-    var showPaceGraph: Bool { didSet { defaults.set(showPaceGraph, forKey: Keys.paceGraph) } }
+    var showRankOverlay: Bool { didSet { defaults.set(showRankOverlay, forKey: key(Keys.rankOverlay)) } }
+    var showAveragePace: Bool { didSet { defaults.set(showAveragePace, forKey: key(Keys.averagePace)) } }
+    var showDeviationWedge: Bool { didSet { defaults.set(showDeviationWedge, forKey: key(Keys.deviationWedge)) } }
+    var showPaceGraph: Bool { didSet { defaults.set(showPaceGraph, forKey: key(Keys.paceGraph)) } }
 
+    private let mode: GameMode
     private let defaults = UserDefaults.standard
     private enum Keys {
         static let rankOverlay = "settings.showRankOverlay"
@@ -19,11 +21,21 @@ final class AppSettings {
         static let paceGraph = "settings.showPaceGraph"
     }
 
-    init() {
+    // World Tour keeps the original, un-suffixed keys so existing installs don't lose
+    // their toggles; Ranked gets its own suffixed keys.
+    private func key(_ base: String) -> String {
+        mode == .worldTour ? base : "\(base).\(mode.prefsSuffix)"
+    }
+
+    init(mode: GameMode) {
+        self.mode = mode
         let d = UserDefaults.standard
-        showRankOverlay = d.object(forKey: Keys.rankOverlay) as? Bool ?? true
-        showAveragePace = d.object(forKey: Keys.averagePace) as? Bool ?? false
-        showDeviationWedge = d.object(forKey: Keys.deviationWedge) as? Bool ?? false
-        showPaceGraph = d.object(forKey: Keys.paceGraph) as? Bool ?? false
+        func read(_ base: String) -> String {
+            mode == .worldTour ? base : "\(base).\(mode.prefsSuffix)"
+        }
+        showRankOverlay = d.object(forKey: read(Keys.rankOverlay)) as? Bool ?? true
+        showAveragePace = d.object(forKey: read(Keys.averagePace)) as? Bool ?? false
+        showDeviationWedge = d.object(forKey: read(Keys.deviationWedge)) as? Bool ?? false
+        showPaceGraph = d.object(forKey: read(Keys.paceGraph)) as? Bool ?? false
     }
 }

--- a/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
@@ -3,31 +3,42 @@ import Observation
 
 /// Loads the user's records, computes dashboard-derived values, and merges live SSE
 /// updates. Aggregation semantics match packages/web/src/composables/usePointsData.js:
-/// records are *cumulative* season totals, so "current points" is the latest-dated record.
+/// records are *cumulative* season totals, so "current points" is the latest-dated record
+/// for `mode` — independent of which season is being *viewed* (only the chart/pace look back).
 @MainActor
 @Observable
 final class DashboardStore {
+    let mode: GameMode
+
     private(set) var points: [Point] = []
     private(set) var isLoading = false
     /// True once the first load attempt has finished (success or failure).
     private(set) var hasLoaded = false
     private(set) var errorMessage: String?
     private(set) var liveStatus: LiveStatus = .disconnected
+
+    /// The live/current season window (unaffected by `viewedSeasonKey`).
     private(set) var season: Season?
+    /// The full `/seasons` list, same for every mode.
+    private(set) var seasonOptionsAll: [SeasonOption] = []
+    /// Raw season name the server reports as current (matches a `SeasonOption.key`).
+    private(set) var currentSeasonKey: String?
+    /// nil = viewing the live/current season.
+    private(set) var viewedSeasonKey: String?
+    private(set) var overlaySeasonKey: String?
 
     /// Custom goal override; nil means "use the default (next rank target)".
     private var goalOverride: Int?
 
     private let defaults = UserDefaults.standard
-    private enum Keys {
-        static let goal = "goal.worldTour"
-    }
+    private var goalKey: String { "goal.\(mode.prefsSuffix)" }
 
     private let sse = SSEClient()
 
-    init() {
-        if defaults.object(forKey: Keys.goal) != nil {
-            goalOverride = defaults.integer(forKey: Keys.goal)
+    init(mode: GameMode) {
+        self.mode = mode
+        if defaults.object(forKey: goalKey) != nil {
+            goalOverride = defaults.integer(forKey: goalKey)
         }
 
         sse.onEvent = { [weak self] event in
@@ -45,24 +56,28 @@ final class DashboardStore {
         points.sorted { $0.date < $1.date }
     }
 
-    /// Latest-dated record's win points (the season total so far).
+    /// Latest-dated record's win points (the season total so far) — always the live total.
     var currentPoints: Int {
         sortedPoints.last?.winPoints ?? 0
     }
 
-    let thresholds: [Threshold] = worldTourThresholds
+    var thresholds: [Threshold] { SeasonSprint.thresholds(for: mode) }
 
     var rank: RankInfo {
         computeRank(points: currentPoints, thresholds: thresholds)
     }
 
-    /// Points gained today = today's total minus the most recent prior day's total.
+    /// Points gained today = today's total minus the most recent prior day's total. In
+    /// Ranked, a today-entry with no prior point is the placement itself, not earned
+    /// progress, so it reads as 0 gain rather than a jump from 0 (World Tour genuinely
+    /// starts at 0).
     var todayGain: Int? {
         let today = DateKey.today()
         let sorted = sortedPoints
         guard let todayPoint = sorted.first(where: { $0.day == today }) else { return nil }
         let prev = sorted.last(where: { $0.day < today })
-        return todayPoint.winPoints - (prev?.winPoints ?? 0)
+        let prevValue = prev?.winPoints ?? (mode == .ranked ? todayPoint.winPoints : 0)
+        return todayPoint.winPoints - prevValue
     }
 
     /// The goal: a custom override, else the next rank target (or the current floor
@@ -71,7 +86,7 @@ final class DashboardStore {
         get { goalOverride ?? defaultGoal }
         set {
             goalOverride = newValue
-            defaults.set(newValue, forKey: Keys.goal)
+            defaults.set(newValue, forKey: goalKey)
         }
     }
 
@@ -82,15 +97,74 @@ final class DashboardStore {
         rank.nextTarget ?? max(1, rank.currentFloor)
     }
 
-    /// Points that fall within the current season window (all points if no season).
+    private var dataSeasonKeys: Set<String> {
+        seasonsWithDataKeys(points: points, seasons: seasonOptionsAll)
+    }
+
+    /// Season picker entries, newest first: the current season, plus any past season with data.
+    var seasonOptions: [SeasonOption] {
+        seasonOptionsAll
+            .sorted { $0.season.start > $1.season.start }
+            .filter { $0.key == currentSeasonKey || dataSeasonKeys.contains($0.key) }
+    }
+
+    /// Compare-overlay entries, newest first: any season with data, excluding the viewed one.
+    var overlayOptions: [SeasonOption] {
+        let viewed = viewedSeasonKey ?? currentSeasonKey
+        return seasonOptionsAll
+            .sorted { $0.season.start > $1.season.start }
+            .filter { $0.key != viewed && dataSeasonKeys.contains($0.key) }
+    }
+
+    /// True once there's at least one past season with data — otherwise the picker has
+    /// nothing to offer.
+    var seasonModuleDisabled: Bool {
+        !seasonOptionsAll.contains { $0.key != currentSeasonKey && dataSeasonKeys.contains($0.key) }
+    }
+
+    var viewedSeason: Season? {
+        if let viewedSeasonKey, let match = seasonOptionsAll.first(where: { $0.key == viewedSeasonKey }) {
+            return match.season
+        }
+        return season
+    }
+
+    /// Read-only: looking at any season other than the live one.
+    var isViewingPastSeason: Bool {
+        viewedSeasonKey != nil && currentSeasonKey != nil && viewedSeasonKey != currentSeasonKey
+    }
+
+    var overlaySeason: Season? {
+        guard let overlaySeasonKey else { return nil }
+        return seasonOptionsAll.first { $0.key == overlaySeasonKey }?.season
+    }
+
+    /// Points that fall within the *viewed* season window (all points if no season known).
     var seasonPoints: [Point] {
-        guard let season else { return points }
-        return points.filter { $0.date >= season.start && $0.date <= season.end }
+        guard let viewedSeason else { return points }
+        return points.filter { $0.date >= viewedSeason.start && $0.date <= viewedSeason.end }
+    }
+
+    /// The compare season's points, re-mapped onto the viewed season's day-of-season axis.
+    var overlayPoints: [OverlayPoint] {
+        guard let overlaySeason, let viewedSeason else { return [] }
+        let overlayRecords = points.filter { $0.date >= overlaySeason.start && $0.date <= overlaySeason.end }
+        return mapOverlayByDayOfSeason(
+            overlayPoints: overlayRecords,
+            overlaySeasonStart: overlaySeason.start,
+            viewedSeasonStart: viewedSeason.start,
+            viewedSeasonEnd: viewedSeason.end
+        )
+    }
+
+    var paceBaseline: PaceBaseline? {
+        guard let viewedSeason else { return nil }
+        return SeasonSprint.paceBaseline(for: mode, sortedSeasonPoints: seasonPoints.sorted { $0.date < $1.date }, seasonStart: viewedSeason.start)
     }
 
     var pace: PaceStats? {
-        guard let season else { return nil }
-        return computePace(goal: goal, seasonPoints: seasonPoints, start: season.start, end: season.end)
+        guard let viewedSeason else { return nil }
+        return computePace(goal: goal, seasonPoints: seasonPoints, start: viewedSeason.start, end: viewedSeason.end, baseline: paceBaseline)
     }
 
     // MARK: Loading
@@ -100,13 +174,15 @@ final class DashboardStore {
         errorMessage = nil
         defer { isLoading = false; hasLoaded = true }
 
-        // Season is public + best-effort; don't let its failure block records.
-        if let s = try? await APIClient.getSeasons() {
-            season = s
+        // Seasons are public + best-effort; don't let their failure block records.
+        if let payload = try? await APIClient.getAllSeasons() {
+            seasonOptionsAll = SeasonSprint.seasonOptions(from: payload.seasons)
+            season = payload.currentSeason
+            currentSeasonKey = payload.currentSeason?.name
         }
 
         do {
-            let records = try await APIClient.getRecords()
+            let records = try await APIClient.getRecords(mode: mode)
             points = records.map(Point.init(record:))
             startLive()
         } catch APIError.notAuthenticated {
@@ -121,22 +197,55 @@ final class DashboardStore {
         sse.start()
     }
 
+    /// Resume the live-update connection (call when this mode becomes the active tab).
+    func resumeLive() {
+        sse.start()
+    }
+
+    /// Pause the live-update connection (call when this mode is backgrounded, to avoid a
+    /// dangling socket for a mode the user isn't looking at).
+    func pauseLive() {
+        sse.stop()
+    }
+
     func stop() {
         sse.stop()
         liveStatus = .disconnected
     }
 
+    /// View a past season read-only, or pass nil to return to the live season.
+    func viewSeason(_ key: String?) {
+        viewedSeasonKey = key
+        if overlaySeasonKey == key {
+            overlaySeasonKey = nil
+        }
+    }
+
+    func setOverlaySeason(_ key: String?) {
+        overlaySeasonKey = key
+    }
+
     // MARK: Live event merge (mirrors upsertPoint in usePointsData.js)
+
+    /// Whether a live event (missing `mode` means `"world-tour"`) belongs to this store's mode.
+    private func matchesMode(_ raw: String?) -> Bool {
+        let eventMode: GameMode = raw == GameMode.ranked.wireValue ? .ranked : .worldTour
+        return eventMode == mode
+    }
 
     private func apply(_ event: RecordEvent) {
         switch event {
         case .upsert(let r):
+            guard matchesMode(r.mode) else { return }
             upsert(r)
-        case .delete(let id):
+        case .delete(let id, let mode):
+            guard matchesMode(mode) else { return }
             points.removeAll { $0.remoteId == id }
-        case .deleteAll:
+        case .deleteAll(let mode):
+            guard matchesMode(mode) else { return }
             points.removeAll()
-        case .bulkUpsert(let records):
+        case .bulkUpsert(let records, let mode):
+            guard matchesMode(mode) else { return }
             records.forEach(upsert)
         }
     }
@@ -145,12 +254,13 @@ final class DashboardStore {
 
     private(set) var isWriting = false
 
-    /// Add or overwrite the record for a day (`POST /me/records`).
+    /// Add or overwrite the record for a day (`POST /me/records`). No-op while read-only.
     func addOrSet(date: String, winPoints: Int) async {
+        guard !isViewingPastSeason else { return }
         isWriting = true
         defer { isWriting = false }
         do {
-            let record = try await APIClient.upsertRecord(date: date, winPoints: winPoints)
+            let record = try await APIClient.upsertRecord(date: date, winPoints: winPoints, mode: mode)
             upsert(record)
         } catch {
             errorMessage = "Couldn't save that point."
@@ -158,8 +268,9 @@ final class DashboardStore {
     }
 
     /// Edit an existing record in place (`PUT /me/records/:id`). Handles a date change by
-    /// dropping the old day entry once the server confirms.
+    /// dropping the old day entry once the server confirms. No-op while read-only.
     func updatePoint(_ point: Point, date: String, winPoints: Int) async {
+        guard !isViewingPastSeason else { return }
         isWriting = true
         defer { isWriting = false }
         do {
@@ -175,7 +286,9 @@ final class DashboardStore {
     }
 
     /// Delete a record (`DELETE /me/records/:id`), optimistically removing it locally.
+    /// No-op while read-only.
     func deletePoint(_ point: Point) async {
+        guard !isViewingPastSeason else { return }
         points.removeAll { $0.remoteId == point.remoteId }
         do {
             try await APIClient.deleteRecord(id: point.remoteId)

--- a/packages/ios/Sources/SeasonSprint/Views/DetailsTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/DetailsTabView.swift
@@ -10,10 +10,13 @@ struct DetailsTabView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     SeasonBannerView(season: store.season)
+                    SeasonsCardView(store: store)
                     StatsGridView(store: store)
                     GoalControlView(store: store)
                     RankReferenceView(thresholds: store.thresholds, rank: store.rank)
-                    CheatsheetView()
+                    if store.mode == .worldTour {
+                        CheatsheetView()
+                    }
 
                     if let errorMessage = store.errorMessage {
                         Text(errorMessage)

--- a/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/GraphTabView.swift
@@ -13,13 +13,24 @@ struct GraphTabView: View {
                 VStack(spacing: 16) {
                     CompactSummary(rank: store.rank, liveStatus: store.liveStatus)
 
+                    if store.isViewingPastSeason {
+                        Text("Viewing a past season — read-only")
+                            .font(.caption.bold())
+                            .foregroundStyle(.tint)
+                    }
+
+                    let baseline = store.paceBaseline ?? PaceBaseline(date: store.viewedSeason?.start ?? store.season?.start ?? .distantPast, value: 0)
+
                     PointsChartView(
                         points: store.seasonPoints.sorted { $0.date < $1.date },
-                        season: store.season,
+                        season: store.viewedSeason,
                         goal: store.goal,
+                        thresholds: store.thresholds,
+                        baseline: baseline,
                         rank: store.rank,
                         pace: store.pace,
-                        todayGain: store.todayGain,
+                        overlayPoints: store.overlayPoints,
+                        todayGain: store.isViewingPastSeason ? nil : store.todayGain,
                         showRankOverlay: settings.showRankOverlay,
                         showAveragePace: settings.showAveragePace,
                         showDeviationWedge: settings.showDeviationWedge
@@ -29,7 +40,8 @@ struct GraphTabView: View {
                         PaceChartView(
                             points: store.seasonPoints,
                             goal: store.goal,
-                            season: store.season
+                            season: store.viewedSeason,
+                            baseline: baseline
                         )
                     }
                 }

--- a/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
@@ -1,33 +1,58 @@
 import SwiftUI
 import ClerkKit
 
-/// Signed-in root: a Graph tab and a Details tab sharing one DashboardStore (so both
-/// reflect the same data + live SSE), with an app-wide Settings sheet behind a gear.
+private let lastModeKey = "ui.lastMode"
+
+/// Signed-in root: a mode switcher (World Tour / Ranked) above a Graph/Log/Details tab
+/// view. Both modes get their own `DashboardStore`/`AppSettings` instance (mirroring the
+/// web app's separate WorldTour.vue/Ranked.vue view instances), so each mode keeps its own
+/// goal, settings, and loaded records independently. Only the *active* mode's live
+/// connection is kept open.
 struct MainTabView: View {
     @Environment(Clerk.self) private var clerk
-    @Environment(AppSettings.self) private var settings
-    @State private var store = DashboardStore()
+    @State private var mode: GameMode
+    @State private var stores: [GameMode: DashboardStore]
+    @State private var settingsByMode: [GameMode: AppSettings]
     @State private var showSettings = false
+
+    init() {
+        let saved = UserDefaults.standard.string(forKey: lastModeKey).flatMap(GameMode.init(rawValue:)) ?? .worldTour
+        _mode = State(initialValue: saved)
+        _stores = State(initialValue: Dictionary(uniqueKeysWithValues: GameMode.allCases.map { ($0, DashboardStore(mode: $0)) }))
+        _settingsByMode = State(initialValue: Dictionary(uniqueKeysWithValues: GameMode.allCases.map { ($0, AppSettings(mode: $0)) }))
+    }
+
+    private var store: DashboardStore { stores[mode]! }
+    private var settings: AppSettings { settingsByMode[mode]! }
 
     var body: some View {
         Group {
             if store.hasLoaded {
-                TabView {
-                    GraphTabView(store: store, showSettings: $showSettings)
-                        .tabItem { Label("Graph", systemImage: "chart.xyaxis.line") }
-                    LogTabView(store: store, showSettings: $showSettings)
-                        .tabItem { Label("Log", systemImage: "square.and.pencil") }
-                    DetailsTabView(store: store, showSettings: $showSettings)
-                        .tabItem { Label("Details", systemImage: "list.bullet") }
+                VStack(spacing: 0) {
+                    ModeSwitcherView(selected: $mode)
+                    TabView {
+                        GraphTabView(store: store, showSettings: $showSettings)
+                            .environment(settings)
+                            .tabItem { Label("Graph", systemImage: "chart.xyaxis.line") }
+                        LogTabView(store: store, showSettings: $showSettings)
+                            .tabItem { Label("Log", systemImage: "square.and.pencil") }
+                        DetailsTabView(store: store, showSettings: $showSettings)
+                            .tabItem { Label("Details", systemImage: "list.bullet") }
+                    }
                 }
             } else {
                 BrandedLoadingView(message: "Loading your season…")
             }
         }
-        .task { await store.load() }
+        .task(id: mode) {
+            UserDefaults.standard.set(mode.rawValue, forKey: lastModeKey)
+            for (m, s) in stores where m != mode { s.pauseLive() }
+            await store.load()
+            store.resumeLive()
+        }
         .sheet(isPresented: $showSettings) {
             SettingsSheet(settings: settings, liveStatus: store.liveStatus) {
-                store.stop()
+                for s in stores.values { s.stop() }
                 try? await clerk.auth.signOut()
             }
         }

--- a/packages/ios/Sources/SeasonSprint/Views/ModeSwitcherView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/ModeSwitcherView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Segmented World Tour / Ranked pill, mirroring the web's ModeSwitcher.vue.
+struct ModeSwitcherView: View {
+    @Binding var selected: GameMode
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(GameMode.allCases, id: \.self) { mode in
+                segment(for: mode)
+            }
+        }
+        .padding(4)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14))
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 8)
+    }
+
+    private func segment(for mode: GameMode) -> some View {
+        let isSelected = mode == selected
+        return Button {
+            selected = mode
+        } label: {
+            Text(mode.label)
+                .font(.subheadline.weight(.black))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 9)
+                .foregroundStyle(isSelected ? Color.black : Color.secondary)
+                .background {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(LinearGradient(colors: [.yellow, .yellow.opacity(0.85)], startPoint: .top, endPoint: .bottom))
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/Views/PaceChartView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/PaceChartView.swift
@@ -7,6 +7,7 @@ struct PaceChartView: View {
     let points: [Point]
     let goal: Int
     let season: Season?
+    let baseline: PaceBaseline
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -15,7 +16,7 @@ struct PaceChartView: View {
 
             if let season {
                 let required = requiredPaceSeries(seasonPoints: points, goal: goal, end: season.end)
-                let earned = earnedPaceSeries(seasonPoints: points)
+                let earned = earnedPaceSeries(seasonPoints: points, baselineY: baseline.value)
 
                 if required.isEmpty && earned.isEmpty {
                     placeholder("No pace data yet.")

--- a/packages/ios/Sources/SeasonSprint/Views/PointsChartView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/PointsChartView.swift
@@ -31,8 +31,11 @@ struct PointsChartView: View {
     let points: [Point]
     let season: Season?
     let goal: Int
+    let thresholds: [Threshold]
+    let baseline: PaceBaseline
     let rank: RankInfo
     let pace: PaceStats?
+    var overlayPoints: [OverlayPoint] = []
     var todayGain: Int? = nil
     var showRankOverlay = false
     var showAveragePace = false
@@ -92,7 +95,8 @@ struct PointsChartView: View {
                 }
             }
 
-            // Zero -> goal projection.
+            // Baseline -> goal projection (baseline is (seasonStart, 0) for World Tour, the
+            // placement point for Ranked).
             ForEach(zeroProjection) { p in
                 LineMark(x: .value("Date", p.date), y: .value("Points", p.value),
                          series: .value("Series", "zero"))
@@ -106,6 +110,23 @@ struct PointsChartView: View {
                          series: .value("Series", "last"))
                     .foregroundStyle(.green)
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 4]))
+            }
+
+            // Compare-season overlay (faint, dashed, behind the current line).
+            ForEach(overlayPoints) { p in
+                LineMark(x: .value("Date", p.date), y: .value("Points", Double(p.winPoints)),
+                         series: .value("Series", "overlay"))
+                    .foregroundStyle(Color.yellow.opacity(0.55))
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [5, 5]))
+            }
+
+            // Placement baseline segment (Ranked only): a flat span from season start to the
+            // placement point, making it clear the climb begins at placement rather than
+            // zero. No-op for World Tour, whose baseline sits at season start already.
+            ForEach(placementBaselineSegment) { p in
+                LineMark(x: .value("Date", p.date), y: .value("Points", p.value),
+                         series: .value("Series", "placement"))
+                    .foregroundStyle(Color.accentColor.opacity(0.6))
             }
 
             // Actual cumulative points.
@@ -152,6 +173,9 @@ struct PointsChartView: View {
             if showAveragePace {
                 legendItem(color: .purple, label: "Avg pace")
             }
+            if !overlayPoints.isEmpty {
+                legendItem(color: .yellow.opacity(0.55), label: "Compare")
+            }
         }
         .font(.caption2)
         .foregroundStyle(.secondary)
@@ -193,7 +217,7 @@ struct PointsChartView: View {
     /// Adjacent same-tier sub-tiers share a color, so they form a single zone.
     private var tierZones: [(name: String, mid: Double, color: Color)] {
         var zones: [(String, Double, Color)] = []
-        let t = worldTourThresholds
+        let t = thresholds
         var lower = 0
         var i = 0
         while i < t.count {
@@ -217,7 +241,7 @@ struct PointsChartView: View {
     private var rankBands: [RankBand] {
         var bands: [RankBand] = []
         var lower = 0
-        for (i, t) in worldTourThresholds.enumerated() {
+        for (i, t) in thresholds.enumerated() {
             // Only bands below the goal cap; clamp the top band to the goal.
             if Double(lower) < yMax {
                 bands.append(RankBand(id: i, lower: Double(lower), upper: min(Double(t.points), yMax), badge: t.badge))
@@ -230,7 +254,7 @@ struct PointsChartView: View {
     private var zeroProjection: [ProjPoint] {
         guard let season else { return [] }
         return [
-            ProjPoint(id: 0, date: season.start, value: 0),
+            ProjPoint(id: 0, date: baseline.date, value: baseline.value),
             ProjPoint(id: 1, date: season.end, value: Double(goal)),
         ]
     }
@@ -244,12 +268,22 @@ struct PointsChartView: View {
         ]
     }
 
+    /// Ranked only: a flat line from season start across to the placement point, at the
+    /// placement RS. Empty for World Tour, whose baseline already sits at season start.
+    private var placementBaselineSegment: [ProjPoint] {
+        guard let season, baseline.date > season.start else { return [] }
+        return [
+            ProjPoint(id: 0, date: season.start, value: baseline.value),
+            ProjPoint(id: 1, date: baseline.date, value: baseline.value),
+        ]
+    }
+
     private var averagePaceLine: [ProjPoint] {
         guard let season,
-              let end = averagePaceProjectedEnd(seasonPoints: points, start: season.start, end: season.end)
+              let end = averagePaceProjectedEnd(seasonPoints: points, start: season.start, end: season.end, baseline: baseline)
         else { return [] }
         return clampToCap([
-            ProjPoint(id: 0, date: season.start, value: 0),
+            ProjPoint(id: 0, date: baseline.date, value: baseline.value),
             ProjPoint(id: 1, date: season.end, value: end),
         ])
     }
@@ -274,21 +308,24 @@ struct PointsChartView: View {
 
     private var wedgePoints: [WedgePoint] {
         guard let season,
-              let projected = averagePaceProjectedEnd(seasonPoints: points, start: season.start, end: season.end),
-              let dev = deviationAtEnd(seasonPoints: points, start: season.start, end: season.end)
+              let projected = averagePaceProjectedEnd(seasonPoints: points, start: season.start, end: season.end, baseline: baseline),
+              let dev = deviationAtEnd(seasonPoints: points, start: season.start, end: season.end, baseline: baseline)
         else { return [] }
-        // Sample the fan at multiple points so AreaMark renders a band *between* the
-        // lower and upper pace lines, not a fill down to the baseline.
+        // Sample a straight-line fan from the baseline anchor (season start at 0 for World
+        // Tour; the placement point for Ranked) to the projected upper/lower bound at season
+        // end, so AreaMark renders a band *between* the lower and upper pace lines.
+        let yUpperEnd = projected + dev
+        let yLowerEnd = max(0, projected - dev)
         let steps = 24
-        let total = season.end.timeIntervalSince(season.start)
+        let total = season.end.timeIntervalSince(baseline.date)
         return (0...steps).map { i in
             let f = Double(i) / Double(steps)
-            let date = season.start.addingTimeInterval(total * f)
+            let date = baseline.date.addingTimeInterval(total * f)
             return WedgePoint(
                 id: i,
                 date: date,
-                low: min(yMax, max(0, f * (projected - dev))),
-                high: min(yMax, f * (projected + dev))
+                low: min(yMax, max(0, baseline.value + f * (yLowerEnd - baseline.value))),
+                high: min(yMax, baseline.value + f * (yUpperEnd - baseline.value))
             )
         }
     }

--- a/packages/ios/Sources/SeasonSprint/Views/SeasonsCardView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/SeasonsCardView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Season picker + compare overlay. Mirrors SeasonControls.vue: the current season is always
+/// selectable, past seasons appear once they have data, and the whole module explains itself
+/// (rather than showing empty menus) until there's a past season to look at.
+struct SeasonsCardView: View {
+    let store: DashboardStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Seasons").font(.headline)
+
+            if store.seasonModuleDisabled {
+                Text("Log points across more than the current season to unlock historical comparisons.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                seasonRow(
+                    label: "Season",
+                    options: store.seasonOptions,
+                    selectedKey: store.viewedSeasonKey ?? store.currentSeasonKey,
+                    placeholder: nil
+                ) { key in
+                    store.viewSeason(key == store.currentSeasonKey ? nil : key)
+                }
+                seasonRow(
+                    label: "Compare",
+                    options: store.overlayOptions,
+                    selectedKey: store.overlaySeasonKey,
+                    placeholder: "None"
+                ) { key in
+                    store.setOverlaySeason(key)
+                }
+                if store.isViewingPastSeason {
+                    Text("Viewing a past season — read-only. Switch back to the current season to log points.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func seasonRow(
+        label: String,
+        options: [SeasonOption],
+        selectedKey: String?,
+        placeholder: String?,
+        onSelect: @escaping (String?) -> Void
+    ) -> some View {
+        let selectedLabel = options.first(where: { $0.key == selectedKey })?.displayName ?? placeholder ?? "—"
+        return HStack {
+            Text(label)
+            Spacer()
+            Menu {
+                if let placeholder {
+                    Button(placeholder) { onSelect(nil) }
+                }
+                ForEach(options) { option in
+                    Button(option.displayName) { onSelect(option.key) }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(selectedLabel)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2.weight(.semibold))
+                }
+            }
+        }
+    }
+}

--- a/packages/web/tests/rank-parity.spec.js
+++ b/packages/web/tests/rank-parity.spec.js
@@ -18,7 +18,8 @@ import { resolve, dirname } from 'node:path'
  * literal tables, which is enough to catch value/ordering drift.
  *
  * Sources of truth:
- *   - thresholds: packages/web/src/data/worldTourRanks.json
+ *   - World Tour thresholds: packages/web/src/data/worldTourRanks.json
+ *   - Ranked thresholds: packages/web/src/views/Ranked.vue (RANKED_THRESHOLDS)
  *   - cheatsheet: packages/web/src/components/PointsCheatsheet.vue (prop default)
  */
 
@@ -32,16 +33,41 @@ const KOTLIN_RANK =
 
 // --- parsers (literal tables only; deliberately strict so format changes surface) ---
 
+// Both native files now declare two threshold tables (World Tour + Ranked) using the
+// same `Threshold(...)` literal syntax, so the threshold parsers must be scoped to one
+// array declaration at a time rather than matching every `Threshold(...)` in the file.
+// `open` is the exact text marking the start of the array body (e.g. `"= ["` or
+// `"listOf("`), searched for *after* `arrayName` — not just the next bracket, since a
+// Swift `[Threshold]` type annotation contains its own `[`/`]` before the real one.
+function extractBlock(src, arrayName, open, close) {
+  const start = src.indexOf(arrayName)
+  if (start === -1) throw new Error(`could not find \`${arrayName}\` in source`)
+  const openIdx = src.indexOf(open, start)
+  if (openIdx === -1) throw new Error(`could not find \`${open}\` after \`${arrayName}\``)
+  const bodyStart = openIdx + open.length
+  const closeIdx = src.indexOf(`\n${close}`, bodyStart)
+  if (closeIdx === -1) throw new Error(`could not find the \`${arrayName}\` array body`)
+  return src.slice(bodyStart, closeIdx)
+}
+
 // Swift:  Threshold(badge: "Bronze 4", points: 25)
-function parseSwiftThresholds(src) {
-  return [...src.matchAll(/Threshold\(badge:\s*"([^"]+)",\s*points:\s*(\d+)\)/g)].map(
+function parseSwiftThresholds(block) {
+  return [...block.matchAll(/Threshold\(badge:\s*"([^"]+)",\s*points:\s*(\d+)\)/g)].map(
     (m) => ({ badge: m[1], points: Number(m[2]) })
   )
 }
 
 // Kotlin:  Threshold("Bronze 4", 25)   (the `data class` decl has no quote, so it won't match)
-function parseKotlinThresholds(src) {
-  return [...src.matchAll(/Threshold\("([^"]+)",\s*(\d+)\)/g)].map((m) => ({
+function parseKotlinThresholds(block) {
+  return [...block.matchAll(/Threshold\("([^"]+)",\s*(\d+)\)/g)].map((m) => ({
+    badge: m[1],
+    points: Number(m[2]),
+  }))
+}
+
+// Web:  { badge: 'Bronze 4', points: 0 }
+function parseWebThresholds(block) {
+  return [...block.matchAll(/badge:\s*'([^']+)',\s*points:\s*(\d+)/g)].map((m) => ({
     badge: m[1],
     points: Number(m[2]),
   }))
@@ -72,11 +98,21 @@ const jsonThresholds = JSON.parse(read('packages/web/src/data/worldTourRanks.jso
 const swiftSrc = read(SWIFT_RANK)
 const kotlinSrc = read(KOTLIN_RANK)
 const vueSrc = read('packages/web/src/components/PointsCheatsheet.vue')
+const rankedVueSrc = read('packages/web/src/views/Ranked.vue')
 
-const swiftThresholds = parseSwiftThresholds(swiftSrc)
-const kotlinThresholds = parseKotlinThresholds(kotlinSrc)
+const swiftWorldTourBlock = extractBlock(swiftSrc, 'let worldTourThresholds', '= [', ']')
+const kotlinWorldTourBlock = extractBlock(kotlinSrc, 'val worldTourThresholds', 'listOf(', ')')
+const swiftThresholds = parseSwiftThresholds(swiftWorldTourBlock)
+const kotlinThresholds = parseKotlinThresholds(kotlinWorldTourBlock)
 const swiftCheats = parseSwiftCheatsheet(swiftSrc)
 const kotlinCheats = parseKotlinCheatsheet(kotlinSrc)
+
+const swiftRankedBlock = extractBlock(swiftSrc, 'let rankedThresholds', '= [', ']')
+const kotlinRankedBlock = extractBlock(kotlinSrc, 'val rankedThresholds', 'listOf(', ')')
+const webRankedBlock = extractBlock(rankedVueSrc, 'RANKED_THRESHOLDS', '= [', ']')
+const swiftRankedThresholds = parseSwiftThresholds(swiftRankedBlock)
+const kotlinRankedThresholds = parseKotlinThresholds(kotlinRankedBlock)
+const webRankedThresholds = parseWebThresholds(webRankedBlock)
 
 describe('World Tour rank threshold parity (web JSON ↔ iOS ↔ Android)', () => {
   it('the JSON source of truth is non-empty and strictly ascending', () => {
@@ -99,6 +135,30 @@ describe('World Tour rank threshold parity (web JSON ↔ iOS ↔ Android)', () =
 
   it('Android Rank.kt matches the JSON verbatim (badge + points, in order)', () => {
     expect(kotlinThresholds).toEqual(jsonThresholds)
+  })
+})
+
+describe('Ranked rank threshold parity (web Ranked.vue ↔ iOS ↔ Android)', () => {
+  it('the web source of truth is non-empty and strictly ascending', () => {
+    expect(webRankedThresholds.length).toBeGreaterThan(0)
+    for (let i = 1; i < webRankedThresholds.length; i++) {
+      expect(webRankedThresholds[i].points).toBeGreaterThan(webRankedThresholds[i - 1].points)
+    }
+  })
+
+  // Guard: a regex that silently matched nothing must fail here, not pass a
+  // vacuous comparison of two empty arrays elsewhere.
+  it('parsers found the same number of thresholds as the web source', () => {
+    expect(swiftRankedThresholds).toHaveLength(webRankedThresholds.length)
+    expect(kotlinRankedThresholds).toHaveLength(webRankedThresholds.length)
+  })
+
+  it('iOS Rank.swift matches Ranked.vue verbatim (badge + points, in order)', () => {
+    expect(swiftRankedThresholds).toEqual(webRankedThresholds)
+  })
+
+  it('Android Rank.kt matches Ranked.vue verbatim (badge + points, in order)', () => {
+    expect(kotlinRankedThresholds).toEqual(webRankedThresholds)
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds a World Tour / Ranked mode switcher to both the Android and iOS apps, matching the web app. Each mode gets its own goal, display settings, and live-update connection (only the active mode's WebSocket stays open).
- Ports Ranked's RS thresholds and the placement-baseline pace/projection math (Ranked measures progress from the first recorded point in a season, not from zero, since a season starts at a placement rank) to both platforms — including the deviation-wedge fan, which now correctly anchors at the placement baseline instead of always at season start.
- Adds a season picker (Details tab) to both apps, to view any past season read-only, plus a "Compare" overlay that re-maps another season's points onto the viewed season's day-of-season axis — gated so it only appears once there's a past season with data, mirroring the web's `SeasonControls`.

## Test plan
- **Android:**
  - [x] `./gradlew :app:testDebugUnitTest` — new/extended unit tests for Ranked thresholds, the placement baseline, and the season-picker gating/remap logic all pass.
  - [x] `./gradlew :app:assembleDebug` — builds clean.
  - [x] Installed the debug APK on a local emulator, signed in with a real account, and verified against the live server: switching World Tour ⇄ Ranked loads distinct mode-scoped data with the correct rank/thresholds/goal and a visible placement-baseline chart segment for Ranked; the Details season picker correctly shows the "log more seasons" gating message when there's no past-season data yet, and hides the World Tour-only cheatsheet in Ranked mode.
- **iOS:**
  - [x] `xtool dev build` — builds clean.
  - [x] Installed to a physical iPhone via `xtool dev run` and confirmed the app launches and the mode switcher / season picker work as expected.