### PR TITLE
chore: bump version to 0.1.12

### DIFF
--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.11"
+#define AppVersion    "0.1.12"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 


### PR DESCRIPTION
First release with Ranked mode and previous-seasons viewing on Android and iOS (#135).