### PR TITLE
fix(ci): make refresh-landing fire automatically after real releases

### DIFF
--- a/.github/workflows/refresh-landing.yml
+++ b/.github/workflows/refresh-landing.yml
@@ -4,6 +4,16 @@ name: Refresh landing downloads
 # static site rebuilds and re-bakes packages/landing/releases.json (via
 # `pnpm -F landing build` → generate-releases.mjs) with the new assets.
 #
+# The `release` trigger below is mostly aspirational: GitHub does not dispatch
+# `release` (or `push`) events for actions taken with a workflow's own
+# GITHUB_TOKEN, and every release here is created that way (softprops/action-gh-release
+# in build-android.yml / build-linux.yml / build-windows-installer.yml). So this
+# also listens for those three build-and-release workflows completing — that's
+# what actually fires after every real release. The job only acts on a
+# successful run of a `v*` tag build (those workflows also run on PRs/pushes
+# unrelated to a release), so it may ping the hook up to 3 times per release;
+# that's harmless, just a few redundant rebuilds.
+#
 # Setup: in the Render dashboard for the landing static site, create a Deploy
 # Hook (Settings → Deploy Hook), then add its URL as the repo secret
 # RENDER_LANDING_DEPLOY_HOOK. Without the secret this job is a no-op, so the
@@ -13,6 +23,9 @@ name: Refresh landing downloads
 on:
   release:
     types: [published, edited, released, deleted, unpublished]
+  workflow_run:
+    workflows: ["Build Android APK", "Build Linux tarball", "Build Windows installer"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -21,6 +34,12 @@ permissions:
 jobs:
   trigger-render:
     runs-on: ubuntu-latest
+    # For workflow_run: only act on a successful v*-tag build, not the PR/push
+    # runs those workflows also do. release/workflow_dispatch always proceed.
+    if: >
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
       - name: Trigger Render deploy
         env:


### PR DESCRIPTION
## Summary
- `refresh-landing.yml`'s `release` trigger has never actually fired: GitHub doesn't dispatch `release`/`push` events for actions taken with a workflow's own `GITHUB_TOKEN`, and that's how every release is created here (`softprops/action-gh-release` in `build-android.yml`/`build-linux.yml`/`build-windows-installer.yml`). Every release since has silently relied on Render happening to redeploy from an unrelated `main` push — which is why the downloads page was still showing `v0.1.11` minutes after `v0.1.12` was tagged.
- Adds a `workflow_run` trigger keyed to those three build workflows completing, gated to only act on a successful `v*`-tag run (they also run on unrelated PRs/pushes). May ping the Render deploy hook up to 3 times per release — harmless, just a couple of redundant rebuilds.

## Test plan
- [x] Confirmed the root cause: `gh run list --workflow=refresh-landing.yml` showed only manual `workflow_dispatch` runs, never a `release`-triggered one, across every past release.
- [x] Manually triggered `workflow_dispatch` to refresh the current stale snapshot (now shows v0.1.12 live).
- [ ] Verify on the next tagged release that `refresh-landing.yml` now fires automatically via `workflow_run` without manual intervention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release automation so the landing page deploy hook runs after successful real release builds.
  * Improved the conditions that determine when the deployment step runs, reducing accidental or premature triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->