### PR TITLE
Add shared Zod schema package for the web/server API contract

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,10 +13,13 @@
     "@clerk/backend": "^3.2.4",
     "@clerk/clerk-sdk-node": "^5.1.6",
     "@hono/clerk-auth": "^3.0.3",
+    "@hono/zod-validator": "^0.8.0",
     "@prisma/adapter-d1": "^6.16.1",
     "@prisma/client": "^6.16.1",
+    "@season-sprint/shared": "workspace:*",
     "dotenv": "^17.2.3",
-    "hono": "^4.9.6"
+    "hono": "^4.12.28",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,4 +1,11 @@
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import {
+  CreateFlagInputSchema,
+  ToggleFlagInputSchema,
+  SetUserOverrideInputSchema,
+  SetUserAdminInputSchema,
+} from "@season-sprint/shared";
 import type { Env } from "../index";
 import { requireAdmin, allowlist } from "../middleware/admin";
 import { audit } from "../utils/audit";
@@ -14,25 +21,16 @@ admin.get("/flags", async (c) => {
   return c.json(await c.get("db").listFlags());
 });
 
-admin.post("/flags", async (c) => {
-  const { key, description } = await c.req.json<{
-    key: string;
-    description?: string;
-  }>();
-  if (!key || typeof key !== "string") {
-    return c.text("Missing flag key", 400);
-  }
+admin.post("/flags", zValidator("json", CreateFlagInputSchema), async (c) => {
+  const { key, description } = c.req.valid("json");
   const flag = await c.get("db").createFlag(key, description ?? "");
   audit(c, "flag.create", { key });
   return c.json(flag);
 });
 
-admin.patch("/flags/:key", async (c) => {
+admin.patch("/flags/:key", zValidator("json", ToggleFlagInputSchema), async (c) => {
   const key = c.req.param("key");
-  const { enabledGlobally } = await c.req.json<{ enabledGlobally: boolean }>();
-  if (typeof enabledGlobally !== "boolean") {
-    return c.text("enabledGlobally must be a boolean", 400);
-  }
+  const { enabledGlobally } = c.req.valid("json");
   const flag = await c.get("db").setFlagGlobal(key, enabledGlobally);
   audit(c, "flag.setGlobal", { key, enabledGlobally });
   return c.json(flag);
@@ -55,17 +53,18 @@ admin.get("/users", async (c) => {
   );
 });
 
-admin.put("/users/:userId/flags/:flagKey", async (c) => {
-  const userId = c.req.param("userId");
-  const flagKey = c.req.param("flagKey");
-  const { enabled } = await c.req.json<{ enabled: boolean }>();
-  if (typeof enabled !== "boolean") {
-    return c.text("enabled must be a boolean", 400);
+admin.put(
+  "/users/:userId/flags/:flagKey",
+  zValidator("json", SetUserOverrideInputSchema),
+  async (c) => {
+    const userId = c.req.param("userId");
+    const flagKey = c.req.param("flagKey");
+    const { enabled } = c.req.valid("json");
+    const override = await c.get("db").setUserOverride(userId, flagKey, enabled);
+    audit(c, "user.flag.override.set", { userId, flagKey, enabled });
+    return c.json(override);
   }
-  const override = await c.get("db").setUserOverride(userId, flagKey, enabled);
-  audit(c, "user.flag.override.set", { userId, flagKey, enabled });
-  return c.json(override);
-});
+);
 
 admin.delete("/users/:userId/flags/:flagKey", async (c) => {
   const userId = c.req.param("userId");
@@ -75,12 +74,9 @@ admin.delete("/users/:userId/flags/:flagKey", async (c) => {
   return c.json({ cleared });
 });
 
-admin.patch("/users/:userId", async (c) => {
+admin.patch("/users/:userId", zValidator("json", SetUserAdminInputSchema), async (c) => {
   const userId = c.req.param("userId");
-  const { isAdmin } = await c.req.json<{ isAdmin: boolean }>();
-  if (typeof isAdmin !== "boolean") {
-    return c.text("isAdmin must be a boolean", 400);
-  }
+  const { isAdmin } = c.req.valid("json");
   const user = await c.get("db").setUserAdmin(userId, isAdmin);
   audit(c, "user.setAdmin", { userId, isAdmin });
   return c.json(user);

--- a/packages/server/src/routes/apiKeys.ts
+++ b/packages/server/src/routes/apiKeys.ts
@@ -1,22 +1,18 @@
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { CreateApiKeyInputSchema } from "@season-sprint/shared";
 import type { Env } from "../index";
 import getEmail from "../getEmail";
 import { generateApiKey, hashApiKey, keyPrefix } from "../utils/apiKey";
 
 const apiKeys = new Hono<Env>();
 
-apiKeys.post("/", async (c) => {
+apiKeys.post("/", zValidator("json", CreateApiKeyInputSchema), async (c) => {
   const { userId, email: cachedEmail } = c.get("auth");
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  const { name } = await c.req.json<{ name: string }>();
-  if (!name || typeof name !== "string") {
-    return c.text("name is required", 400);
-  }
-  if (name.length > 64) {
-    return c.text("name must be 64 characters or fewer", 400);
-  }
+  const { name } = c.req.valid("json");
 
   const existing = await db.listApiKeys(userId);
   if (existing.length >= 10) {

--- a/packages/server/src/routes/records.ts
+++ b/packages/server/src/routes/records.ts
@@ -1,6 +1,11 @@
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import {
+  CreateRecordInputSchema,
+  UpdateRecordInputSchema,
+  BulkUpsertInputSchema,
+} from "@season-sprint/shared";
 import type { Env } from "../index";
-import type { GameMode, Record } from "../types";
 import getEmail from "../getEmail";
 import { parseDate } from "../utils/parseDate";
 import { broadcast } from "../utils/broadcast";
@@ -16,21 +21,18 @@ records.get("/", async (c) => {
   return c.json(result);
 });
 
-records.post("/", async (c) => {
+records.post("/", zValidator("json", CreateRecordInputSchema), async (c) => {
   const { userId, email: cachedEmail } = c.get("auth");
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  // `mode` is optional on the wire (older clients omit it) — default it.
-  const { date, winPoints, mode } = await c.req.json<
-    Omit<Record, "id" | "userId" | "mode"> & { mode?: GameMode }
-  >();
+  const { date, winPoints, mode } = c.req.valid("json");
   const resolvedMode = mode ?? "world-tour";
 
   const record = await db.upsertRecord(
     userId,
     email,
-    date,
+    new Date(date),
     winPoints,
     resolvedMode
   );
@@ -52,19 +54,14 @@ records.put("/:id", async (c) => {
 
   let body: unknown;
   try {
-    body = await c.req.json<
-      Partial<{ date: string | Date; winPoints: number }>
-    >();
+    body = await c.req.json();
   } catch {
     body = {};
   }
 
-  const maybeDate = (body as { date?: string | Date }).date;
-  const maybeWinPoints = (body as { winPoints?: unknown }).winPoints;
-
-  const date = parseDate(maybeDate);
-  const winPoints =
-    typeof maybeWinPoints === "number" ? maybeWinPoints : undefined;
+  const parsed = UpdateRecordInputSchema.safeParse(body);
+  const date = parsed.success ? parseDate(parsed.data.date) : undefined;
+  const winPoints = parsed.success ? parsed.data.winPoints : undefined;
 
   if (date === undefined && winPoints === undefined) {
     return c.text("No fields to update", 400);
@@ -107,15 +104,12 @@ records.delete("/", async (c) => {
   return c.json({ deleted: count });
 });
 
-records.post("/bulk", async (c) => {
+records.post("/bulk", zValidator("json", BulkUpsertInputSchema), async (c) => {
   const { userId, email: cachedEmail } = c.get("auth");
   const email = await getEmail(userId, c.env, cachedEmail);
   const db = c.get("db");
 
-  const { records: input, mode } = await c.req.json<{
-    records: { date: string; winPoints: number }[];
-    mode?: string;
-  }>();
+  const { records: input, mode } = c.req.valid("json");
   const resolvedMode = mode ?? "world-tour";
 
   const result = await db.bulkUpsertRecords(

--- a/packages/server/src/routes/records.ts
+++ b/packages/server/src/routes/records.ts
@@ -58,10 +58,16 @@ records.put("/:id", async (c) => {
   } catch {
     body = {};
   }
+  const fields =
+    typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
 
-  const parsed = UpdateRecordInputSchema.safeParse(body);
-  const date = parsed.success ? parseDate(parsed.data.date) : undefined;
-  const winPoints = parsed.success ? parsed.data.winPoints : undefined;
+  // Each field is validated independently (rather than parsing `fields` as a whole)
+  // so a malformed field doesn't wipe out an otherwise-valid one.
+  const dateResult = UpdateRecordInputSchema.shape.date.safeParse(fields.date);
+  const winPointsResult = UpdateRecordInputSchema.shape.winPoints.safeParse(fields.winPoints);
+
+  const date = dateResult.success ? parseDate(dateResult.data) : undefined;
+  const winPoints = winPointsResult.success ? winPointsResult.data : undefined;
 
   if (date === undefined && winPoints === undefined) {
     return c.text("No fields to update", 400);

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,9 +1,0 @@
-export type GameMode = "world-tour" | "ranked";
-
-export type Record = {
-  id: string;
-  userId: string;
-  date: Date;
-  winPoints: number;
-  mode: GameMode;
-};

--- a/packages/server/tests/routes.test.ts
+++ b/packages/server/tests/routes.test.ts
@@ -124,6 +124,68 @@ describe("API Routes", () => {
     });
   });
 
+  describe("PUT /me/records/:id", () => {
+    async function createRecord(d1: D1Database) {
+      const res = await appFetch(d1, "/me/records", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date: "2026-03-01", winPoints: 100 }),
+      });
+      const body = await res.json();
+      return body.record.id;
+    }
+
+    it("updates winPoints", async () => {
+      const id = await createRecord(d1);
+
+      const res = await appFetch(d1, `/me/records/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ winPoints: 250 }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.winPoints).toBe(250);
+    });
+
+    it("applies a valid date even when winPoints is malformed in the same request", async () => {
+      const id = await createRecord(d1);
+
+      const res = await appFetch(d1, `/me/records/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date: "2026-04-15", winPoints: "not-a-number" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(new Date(body.date).toISOString().slice(0, 10)).toBe("2026-04-15");
+    });
+
+    it("returns 400 when no valid fields are provided", async () => {
+      const id = await createRecord(d1);
+
+      const res = await appFetch(d1, `/me/records/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ winPoints: "not-a-number" }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for a non-existent record", async () => {
+      const res = await appFetch(d1, "/me/records/does-not-exist", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ winPoints: 50 }),
+      });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe("DELETE /me/records/:id", () => {
     it("deletes an owned record", async () => {
       const createRes = await appFetch(d1, "/me/records", {

--- a/packages/server/tests/routes.test.ts
+++ b/packages/server/tests/routes.test.ts
@@ -122,6 +122,16 @@ describe("API Routes", () => {
       expect(records).toHaveLength(1);
       expect(records[0].winPoints).toBe(200);
     });
+
+    it("rejects a malformed date instead of erroring", async () => {
+      const res = await appFetch(d1, "/me/records", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date: "not-a-date", winPoints: 100 }),
+      });
+
+      expect(res.status).toBe(400);
+    });
   });
 
   describe("PUT /me/records/:id", () => {
@@ -297,6 +307,18 @@ describe("API Routes", () => {
         (r) => r.date.slice(0, 10) === "2026-03-01"
       );
       expect(march1?.winPoints).toBe(999);
+    });
+
+    it("rejects a malformed date instead of erroring", async () => {
+      const res = await appFetch(d1, "/me/records/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          records: [{ date: "not-a-date", winPoints: 100 }],
+        }),
+      });
+
+      expect(res.status).toBe(400);
     });
   });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@season-sprint/shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "prepare": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
+    "test": "echo \"no tests\" && exit 0"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/shared/src/admin.ts
+++ b/packages/shared/src/admin.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+/** PUT /admin/users/:userId/flags/:flagKey body. */
+export const SetUserOverrideInputSchema = z.object({
+  enabled: z.boolean(),
+});
+export type SetUserOverrideInput = z.infer<typeof SetUserOverrideInputSchema>;
+
+/** PATCH /admin/users/:userId body. */
+export const SetUserAdminInputSchema = z.object({
+  isAdmin: z.boolean(),
+});
+export type SetUserAdminInput = z.infer<typeof SetUserAdminInputSchema>;

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+/** POST /me/api-keys body. */
+export const CreateApiKeyInputSchema = z.object({
+  name: z.string().min(1, "name is required").max(64, "name must be 64 characters or fewer"),
+});
+export type CreateApiKeyInput = z.infer<typeof CreateApiKeyInputSchema>;
+
+/** Wire shape of an API key as returned by GET/POST /me/api-keys (POST also includes the raw `key` once). */
+export const ApiKeySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  keyPrefix: z.string(),
+  createdAt: z.string(),
+});
+export type ApiKeyDto = z.infer<typeof ApiKeySchema>;

--- a/packages/shared/src/apiKeys.ts
+++ b/packages/shared/src/apiKeys.ts
@@ -5,12 +5,3 @@ export const CreateApiKeyInputSchema = z.object({
   name: z.string().min(1, "name is required").max(64, "name must be 64 characters or fewer"),
 });
 export type CreateApiKeyInput = z.infer<typeof CreateApiKeyInputSchema>;
-
-/** Wire shape of an API key as returned by GET/POST /me/api-keys (POST also includes the raw `key` once). */
-export const ApiKeySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  keyPrefix: z.string(),
-  createdAt: z.string(),
-});
-export type ApiKeyDto = z.infer<typeof ApiKeySchema>;

--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/** Wire shape of a feature flag as returned by GET /admin/flags. */
+export const FlagSchema = z.object({
+  key: z.string(),
+  description: z.string(),
+  enabledGlobally: z.boolean(),
+});
+export type FlagDto = z.infer<typeof FlagSchema>;
+
+/** POST /admin/flags body. */
+export const CreateFlagInputSchema = z.object({
+  key: z.string().min(1, "Missing flag key"),
+  description: z.string().optional(),
+});
+export type CreateFlagInput = z.infer<typeof CreateFlagInputSchema>;
+
+/** PATCH /admin/flags/:key body. */
+export const ToggleFlagInputSchema = z.object({
+  enabledGlobally: z.boolean(),
+});
+export type ToggleFlagInput = z.infer<typeof ToggleFlagInputSchema>;
+
+/** GET /me/flags response. */
+export const ResolvedFlagsResponseSchema = z.object({
+  flags: z.record(z.string(), z.boolean()),
+  isAdmin: z.boolean(),
+});
+export type ResolvedFlagsResponse = z.infer<typeof ResolvedFlagsResponseSchema>;

--- a/packages/shared/src/flags.ts
+++ b/packages/shared/src/flags.ts
@@ -1,13 +1,5 @@
 import { z } from "zod";
 
-/** Wire shape of a feature flag as returned by GET /admin/flags. */
-export const FlagSchema = z.object({
-  key: z.string(),
-  description: z.string(),
-  enabledGlobally: z.boolean(),
-});
-export type FlagDto = z.infer<typeof FlagSchema>;
-
 /** POST /admin/flags body. */
 export const CreateFlagInputSchema = z.object({
   key: z.string().min(1, "Missing flag key"),
@@ -20,10 +12,3 @@ export const ToggleFlagInputSchema = z.object({
   enabledGlobally: z.boolean(),
 });
 export type ToggleFlagInput = z.infer<typeof ToggleFlagInputSchema>;
-
-/** GET /me/flags response. */
-export const ResolvedFlagsResponseSchema = z.object({
-  flags: z.record(z.string(), z.boolean()),
-  isAdmin: z.boolean(),
-});
-export type ResolvedFlagsResponse = z.infer<typeof ResolvedFlagsResponseSchema>;

--- a/packages/shared/src/gameMode.ts
+++ b/packages/shared/src/gameMode.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const GameModeSchema = z.enum(["world-tour", "ranked"]);
+export type GameMode = z.infer<typeof GameModeSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./gameMode";
+export * from "./records";
+export * from "./apiKeys";
+export * from "./flags";
+export * from "./admin";

--- a/packages/shared/src/records.ts
+++ b/packages/shared/src/records.ts
@@ -1,19 +1,12 @@
 import { z } from "zod";
 import { GameModeSchema } from "./gameMode";
 
-/** Wire shape of a Record as returned by GET /me/records. Dates are ISO strings — Date objects don't survive JSON. */
-export const RecordSchema = z.object({
-  id: z.string(),
-  userId: z.string(),
-  date: z.string(),
-  winPoints: z.number(),
-  mode: GameModeSchema,
-});
-export type RecordDto = z.infer<typeof RecordSchema>;
+/** Date-only wire format used everywhere records are sent, e.g. "2026-03-01". */
+const DateStringSchema = z.string().date();
 
 /** POST /me/records body. `mode` is optional on the wire — older clients omit it and it defaults to "world-tour". */
 export const CreateRecordInputSchema = z.object({
-  date: z.string(),
+  date: DateStringSchema,
   winPoints: z.number(),
   mode: GameModeSchema.optional(),
 });
@@ -21,7 +14,7 @@ export type CreateRecordInput = z.infer<typeof CreateRecordInputSchema>;
 
 /** PUT /me/records/:id body. Both fields optional — caller must send at least one. */
 export const UpdateRecordInputSchema = z.object({
-  date: z.string().optional(),
+  date: DateStringSchema.optional(),
   winPoints: z.number().optional(),
 });
 export type UpdateRecordInput = z.infer<typeof UpdateRecordInputSchema>;
@@ -30,7 +23,7 @@ export type UpdateRecordInput = z.infer<typeof UpdateRecordInputSchema>;
 export const BulkUpsertInputSchema = z.object({
   records: z.array(
     z.object({
-      date: z.string(),
+      date: DateStringSchema,
       winPoints: z.number(),
     })
   ),

--- a/packages/shared/src/records.ts
+++ b/packages/shared/src/records.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { GameModeSchema } from "./gameMode";
+
+/** Wire shape of a Record as returned by GET /me/records. Dates are ISO strings — Date objects don't survive JSON. */
+export const RecordSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  date: z.string(),
+  winPoints: z.number(),
+  mode: GameModeSchema,
+});
+export type RecordDto = z.infer<typeof RecordSchema>;
+
+/** POST /me/records body. `mode` is optional on the wire — older clients omit it and it defaults to "world-tour". */
+export const CreateRecordInputSchema = z.object({
+  date: z.string(),
+  winPoints: z.number(),
+  mode: GameModeSchema.optional(),
+});
+export type CreateRecordInput = z.infer<typeof CreateRecordInputSchema>;
+
+/** PUT /me/records/:id body. Both fields optional — caller must send at least one. */
+export const UpdateRecordInputSchema = z.object({
+  date: z.string().optional(),
+  winPoints: z.number().optional(),
+});
+export type UpdateRecordInput = z.infer<typeof UpdateRecordInputSchema>;
+
+/** POST /me/records/bulk body. */
+export const BulkUpsertInputSchema = z.object({
+  records: z.array(
+    z.object({
+      date: z.string(),
+      winPoints: z.number(),
+    })
+  ),
+  mode: GameModeSchema.optional(),
+});
+export type BulkUpsertInput = z.infer<typeof BulkUpsertInputSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@clerk/themes": "^2.4.18",
     "@clerk/vue": "^1.13.0",
+    "@season-sprint/shared": "workspace:*",
     "axios": "1.11.0",
     "cheerio": "^1.1.2",
     "core-js": "^3.8.3",

--- a/packages/web/src/services/api.js
+++ b/packages/web/src/services/api.js
@@ -1,3 +1,13 @@
+import {
+  CreateRecordInputSchema,
+  BulkUpsertInputSchema,
+  CreateApiKeyInputSchema,
+  CreateFlagInputSchema,
+  ToggleFlagInputSchema,
+  SetUserOverrideInputSchema,
+  SetUserAdminInputSchema,
+} from "@season-sprint/shared";
+
 const isLocalDevHost =
   typeof window !== "undefined" &&
   (window.location.hostname === "localhost" ||
@@ -12,6 +22,17 @@ function requireApiBaseUrl() {
     );
   }
   return BASE;
+}
+
+// Validates a request payload against the shared API contract before it's sent,
+// so a shape drift between web and server surfaces at the call site instead of
+// as an opaque 400 from the worker.
+function validateBody(schema, data) {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new Error(result.error.issues.map((issue) => issue.message).join(", "));
+  }
+  return result.data;
 }
 
 export async function getRecords(authorizationHeader, mode = "world-tour") {
@@ -49,7 +70,7 @@ export async function upsertRecord(
       "Content-Type": "application/json",
       Authorization: authorizationHeader,
     },
-    body: JSON.stringify({ date, winPoints, mode }),
+    body: JSON.stringify(validateBody(CreateRecordInputSchema, { date, winPoints, mode })),
   });
 
   if (!response.ok) {
@@ -114,7 +135,7 @@ export async function bulkUpsertRecords(
       "Content-Type": "application/json",
       Authorization: authorizationHeader,
     },
-    body: JSON.stringify({ records, mode }),
+    body: JSON.stringify(validateBody(BulkUpsertInputSchema, { records, mode })),
   });
 
   if (!response.ok) {
@@ -151,7 +172,7 @@ export async function createApiKey(name, authorizationHeader) {
       "Content-Type": "application/json",
       Authorization: authorizationHeader,
     },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify(validateBody(CreateApiKeyInputSchema, { name })),
   });
 
   if (!response.ok) {
@@ -224,14 +245,14 @@ export function adminListFlags(authorizationHeader) {
 export function adminCreateFlag(key, description, authorizationHeader) {
   return adminFetch("/admin/flags", authorizationHeader, {
     method: "POST",
-    body: JSON.stringify({ key, description }),
+    body: JSON.stringify(validateBody(CreateFlagInputSchema, { key, description })),
   });
 }
 
 export function adminToggleFlag(key, enabledGlobally, authorizationHeader) {
   return adminFetch(`/admin/flags/${encodeURIComponent(key)}`, authorizationHeader, {
     method: "PATCH",
-    body: JSON.stringify({ enabledGlobally }),
+    body: JSON.stringify(validateBody(ToggleFlagInputSchema, { enabledGlobally })),
   });
 }
 
@@ -246,7 +267,7 @@ export function adminSetUserOverride(userId, flagKey, enabled, authorizationHead
   return adminFetch(
     `/admin/users/${encodeURIComponent(userId)}/flags/${encodeURIComponent(flagKey)}`,
     authorizationHeader,
-    { method: "PUT", body: JSON.stringify({ enabled }) }
+    { method: "PUT", body: JSON.stringify(validateBody(SetUserOverrideInputSchema, { enabled })) }
   );
 }
 
@@ -261,7 +282,7 @@ export function adminClearUserOverride(userId, flagKey, authorizationHeader) {
 export function adminSetUserAdmin(userId, isAdmin, authorizationHeader) {
   return adminFetch(`/admin/users/${encodeURIComponent(userId)}`, authorizationHeader, {
     method: "PATCH",
-    body: JSON.stringify({ isAdmin }),
+    body: JSON.stringify(validateBody(SetUserAdminInputSchema, { isAdmin })),
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,19 +24,28 @@ importers:
         version: 5.1.6(react@19.1.1)
       '@hono/clerk-auth':
         specifier: ^3.0.3
-        version: 3.0.3(hono@4.9.6)(react@19.1.1)
+        version: 3.0.3(hono@4.12.28)(react@19.1.1)
+      '@hono/zod-validator':
+        specifier: ^0.8.0
+        version: 0.8.0(hono@4.12.28)(zod@3.25.76)
       '@prisma/adapter-d1':
         specifier: ^6.16.1
         version: 6.16.1
       '@prisma/client':
         specifier: ^6.16.1
         version: 6.16.1(prisma@6.16.1(typescript@5.9.3))(typescript@5.9.3)
+      '@season-sprint/shared':
+        specifier: workspace:*
+        version: link:../shared
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
       hono:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.12.28
+        version: 4.12.28
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: ^9.36.0
@@ -66,6 +75,16 @@ importers:
         specifier: ^4.4.0
         version: 4.35.0(@cloudflare/workers-types@4.20250912.0)
 
+  packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/web:
     dependencies:
       '@clerk/themes':
@@ -74,6 +93,9 @@ importers:
       '@clerk/vue':
         specifier: ^1.13.0
         version: 1.13.0(vue@3.5.18(typescript@5.9.3))
+      '@season-sprint/shared':
+        specifier: workspace:*
+        version: link:../shared
       axios:
         specifier: 1.11.0
         version: 1.11.0
@@ -1242,6 +1264,12 @@ packages:
     engines: {node: '>=16.x.x'}
     peerDependencies:
       hono: '>=3.0.0'
+
+  '@hono/zod-validator@0.8.0':
+    resolution: {integrity: sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w==}
+    peerDependencies:
+      hono: '>=4.10.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3501,8 +3529,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.9.6:
-    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@2.8.9:
@@ -5552,6 +5580,9 @@ packages:
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@achrinza/node-ipc@9.2.9':
@@ -6690,14 +6721,19 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/clerk-auth@3.0.3(hono@4.9.6)(react@19.1.1)':
+  '@hono/clerk-auth@3.0.3(hono@4.12.28)(react@19.1.1)':
     dependencies:
       '@clerk/backend': 2.14.0(react@19.1.1)
       '@clerk/types': 4.85.0
-      hono: 4.9.6
+      hono: 4.12.28
     transitivePeerDependencies:
       - react
       - react-dom
+
+  '@hono/zod-validator@0.8.0(hono@4.12.28)(zod@3.25.76)':
+    dependencies:
+      hono: 4.12.28
+      zod: 3.25.76
 
   '@humanfs/core@0.19.1': {}
 
@@ -9301,7 +9337,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.9.6: {}
+  hono@4.12.28: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -11460,3 +11496,5 @@ snapshots:
       youch-core: 0.3.3
 
   zod@3.22.3: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary
- Add `packages/shared` (`@season-sprint/shared`) with Zod schemas + inferred types for every mutating API endpoint (records, API keys, flags, admin) — the single source of truth for the web↔server request contract.
- Wire these schemas into server routes via `@hono/zod-validator`, replacing hand-rolled `c.req.json<T>()` type assertions (which type-checked but validated nothing at runtime) with real runtime validation.
- Wire the same schemas into web's `api.js` to validate outgoing payloads before they're sent, so a shape drift between a composable and the API surfaces immediately as a clear client-side error.
- Bump `hono` 4.9.6 → 4.12.28 (required by `@hono/zod-validator`'s peer dependency; the old pin broke its generic type inference).
- Remove `server/src/types.ts`, now dead code since its only importer switched to the shared schemas.

`packages/shared` builds to `dist/` automatically via a `prepare` script that runs on every `pnpm install`, so no separate build step is needed locally or in CI.

## Test plan
- [x] `pnpm --filter server run codegen && pnpm --filter server run lint` — clean
- [x] `pnpm --filter server run test` — 47/47 passing
- [x] `pnpm --filter web run lint` — clean
- [x] `pnpm --filter web run test` — 116/116 passing
- [x] `pnpm --filter web run build` (actual webpack production build, not just the Vite test runner) — succeeds
- [x] `pnpm install --frozen-lockfile` from a clean `packages/shared/dist` — rebuilds correctly, matching CI's install flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared validation for records, API keys, and admin actions, improving consistency across the app.
  * Introduced support for reusable shared request/response shapes across web and server packages.

* **Bug Fixes**
  * Improved request handling for create, update, and bulk actions so invalid inputs are caught earlier with clearer validation feedback.
  * Updated admin and API key flows to use stricter checks, reducing unexpected errors from malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->