### PR TITLE
Add anchored data deletion section for Play Console Data Safety

### DIFF
--- a/packages/web/src/router/index.js
+++ b/packages/web/src/router/index.js
@@ -40,7 +40,12 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(),
   routes,
-  scrollBehavior() {
+  scrollBehavior(to) {
+    // Respect an in-page anchor (e.g. /privacy#data-deletion) instead of
+    // always snapping to the top — applies on initial load too.
+    if (to.hash) {
+      return { el: to.hash }
+    }
     return { top: 0 }
   },
 })

--- a/packages/web/src/views/Privacy.vue
+++ b/packages/web/src/views/Privacy.vue
@@ -72,11 +72,33 @@ export default { name: "PrivacyView" };
         We do not sell or share your data with any other third party.
       </p>
 
-      <h2 class="card-title">Data deletion</h2>
+      <h2 id="data-deletion" class="card-title">Data deletion</h2>
       <p>
         You can delete individual season records at any time from within the
-        app. To delete your account and all associated data entirely,
-        contact us using the email below and we'll remove it.
+        Season Sprint app (Android, iOS, or web) — open a record and choose
+        delete.
+      </p>
+      <p>
+        To delete your Season Sprint account and all associated data
+        entirely:
+      </p>
+      <ol>
+        <li>
+          Email <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>
+          from the address your account uses, with the subject "Delete my
+          account."
+        </li>
+        <li>
+          We'll confirm the request and permanently delete your account,
+          email, season records, and API keys within 30 days.
+        </li>
+      </ol>
+      <p>
+        Standard infrastructure request logs kept by our hosting provider,
+        Cloudflare (e.g. IP address and timestamp of requests — see "Where
+        your data is stored" above), are not covered by this process and age
+        out per Cloudflare's own retention policy, independent of your
+        account.
       </p>
 
       <h2 class="card-title">Children's privacy</h2>
@@ -144,6 +166,9 @@ export default { name: "PrivacyView" };
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--text-strong);
+  /* So a direct link to #data-deletion doesn't land the heading underneath
+     the sticky header bar. */
+  scroll-margin-top: 80px;
 }
 .privacy-card .card-title:first-child {
   margin-top: 0;
@@ -158,7 +183,8 @@ export default { name: "PrivacyView" };
   margin-bottom: 0;
 }
 
-.privacy-card ul {
+.privacy-card ul,
+.privacy-card ol {
   margin: 0 0 8px;
   padding-left: 20px;
   color: var(--text);


### PR DESCRIPTION
## Summary
- Play Console's Data Safety form wants a dedicated deletion-request URL that prominently shows the steps and states retention -- the existing privacy policy paragraph wasn't specific enough. Expands the "Data deletion" section into numbered steps, an explicit 30-day deletion commitment, and a note about Cloudflare's independent log retention. Adds `id="data-deletion"` so `https://app.seasonsprint.com/privacy#data-deletion` links directly to it.
- Fixes `router/index.js`'s `scrollBehavior`, which unconditionally returned `{ top: 0 }` and ignored any URL hash, including on initial page load -- the new anchor wouldn't have actually scrolled into view without this.

## Test plan
- [x] Built production bundle, served it, and screenshotted `/privacy#data-deletion` -- confirms the section scrolls into view correctly below the sticky header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved in-page navigation so links to section anchors now scroll to the correct spot instead of the top of the page.
  * Added a direct link target for the Privacy Policy’s **Data deletion** section.
  * Expanded the Privacy Policy with clearer deletion instructions, timelines, and account deletion steps.

* **Bug Fixes**
  * Fixed anchor-linked headings from being hidden behind the sticky header.
  * Improved list spacing consistency across the Privacy Policy page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->