### PR TITLE
Add real account deletion request form

### DIFF
--- a/packages/server/migrations/0008_create_deletion_requests.sql
+++ b/packages/server/migrations/0008_create_deletion_requests.sql
@@ -1,0 +1,7 @@
+-- CreateTable
+CREATE TABLE "DeletionRequest" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -73,3 +73,14 @@ model UserFlagOverride {
 
   @@unique([userId, flagKey])
 }
+
+// Submitted via the public /delete-account page (no auth required — the
+// requester may not be signed in, or may have lost access to their
+// account). Not linked to a User row for the same reason. An admin
+// actions the request manually (see routes/admin.ts) then dismisses it.
+model DeletionRequest {
+  id        String   @id @default(uuid())
+  email     String
+  reason    String?
+  createdAt DateTime @default(now())
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { CreateDeletionRequestInputSchema } from "@season-sprint/shared";
 import { DbService } from "./services/db";
 import { cors } from "hono/cors";
 import { getAuth } from "@hono/clerk-auth";
@@ -79,6 +81,20 @@ app.get("/seasons", async (c) => {
     return c.json({ error: "Season data unavailable" }, 503);
   }
 });
+
+// Public endpoint — no auth required. Deliberately unauthenticated: the
+// requester may not be signed in, or may have lost access to their account.
+// An admin actions the request manually via /admin/deletion-requests.
+app.post(
+  "/deletion-requests",
+  zValidator("json", CreateDeletionRequestInputSchema),
+  async (c) => {
+    const { email, reason } = c.req.valid("json");
+    const db = c.get("db");
+    const request = await db.createDeletionRequest(email, reason);
+    return c.json({ message: "Deletion request received", request });
+  }
+);
 
 // SSE stream — has its own auth via query param (must be before global auth)
 app.route("/me/stream", stream);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,6 +6,7 @@ import { cors } from "hono/cors";
 import { getAuth } from "@hono/clerk-auth";
 import { getCachedSeasons, scrapeAndStore } from "./services/seasonScraper";
 import { clerkOrDevToken, resolveAuth } from "./middleware/auth";
+import getEmail from "./getEmail";
 import records from "./routes/records";
 import apiKeys from "./routes/apiKeys";
 import stream from "./routes/stream";
@@ -82,20 +83,6 @@ app.get("/seasons", async (c) => {
   }
 });
 
-// Public endpoint — no auth required. Deliberately unauthenticated: the
-// requester may not be signed in, or may have lost access to their account.
-// An admin actions the request manually via /admin/deletion-requests.
-app.post(
-  "/deletion-requests",
-  zValidator("json", CreateDeletionRequestInputSchema),
-  async (c) => {
-    const { email, reason } = c.req.valid("json");
-    const db = c.get("db");
-    const request = await db.createDeletionRequest(email, reason);
-    return c.json({ message: "Deletion request received", request });
-  }
-);
-
 // SSE stream — has its own auth via query param (must be before global auth)
 app.route("/me/stream", stream);
 
@@ -108,6 +95,26 @@ app.route("/me/records", records);
 app.route("/me/api-keys", apiKeys);
 app.route("/me/flags", flags);
 app.route("/admin", admin);
+
+// Deletion requests — authenticated so the email is derived from the
+// caller's own session, never taken from client input. Otherwise anyone
+// could request deletion of someone else's account just by typing their
+// email address. An admin actions the request manually via
+// /admin/deletion-requests. (Users who can no longer sign in at all use the
+// email fallback in the privacy policy instead — those still require manual
+// identity verification by whoever processes them.)
+app.post(
+  "/me/deletion-requests",
+  zValidator("json", CreateDeletionRequestInputSchema),
+  async (c) => {
+    const { userId, email: cachedEmail } = c.get("auth");
+    const email = await getEmail(userId, c.env, cachedEmail);
+    const { reason } = c.req.valid("json");
+    const db = c.get("db");
+    const request = await db.createDeletionRequest(email, reason);
+    return c.json({ message: "Deletion request received", request });
+  }
+);
 
 // Stream token exchange — uses normal Clerk auth to issue a stream token
 app.post("/me/stream/token", async (c) => {

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -82,4 +82,17 @@ admin.patch("/users/:userId", zValidator("json", SetUserAdminInputSchema), async
   return c.json(user);
 });
 
+// ── Deletion requests ────────────────────────────────────────────────────
+
+admin.get("/deletion-requests", async (c) => {
+  return c.json(await c.get("db").listDeletionRequests());
+});
+
+admin.delete("/deletion-requests/:id", async (c) => {
+  const id = c.req.param("id");
+  const dismissed = await c.get("db").dismissDeletionRequest(id);
+  audit(c, "deletionRequest.dismiss", { id });
+  return c.json({ dismissed });
+});
+
 export default admin;

--- a/packages/server/src/services/db.ts
+++ b/packages/server/src/services/db.ts
@@ -378,4 +378,26 @@ export class DbService {
       select: { id: true, email: true, isAdmin: true },
     });
   }
+
+  // ── Deletion requests ────────────────────────────────────────────────────
+
+  async createDeletionRequest(email: string, reason?: string) {
+    return await this.prisma.deletionRequest.create({
+      data: { email, reason },
+      select: { id: true, email: true, reason: true, createdAt: true },
+    });
+  }
+
+  async listDeletionRequests() {
+    return await this.prisma.deletionRequest.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async dismissDeletionRequest(id: string): Promise<boolean> {
+    const result = await this.prisma.deletionRequest.deleteMany({
+      where: { id },
+    });
+    return result.count > 0;
+  }
 }

--- a/packages/shared/src/deletionRequests.ts
+++ b/packages/shared/src/deletionRequests.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+/** POST /deletion-requests body. Public endpoint — no auth required. */
+export const CreateDeletionRequestInputSchema = z.object({
+  email: z.string().email("Enter a valid email address"),
+  reason: z.string().max(1000).optional(),
+});
+export type CreateDeletionRequestInput = z.infer<
+  typeof CreateDeletionRequestInputSchema
+>;

--- a/packages/shared/src/deletionRequests.ts
+++ b/packages/shared/src/deletionRequests.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 
-/** POST /deletion-requests body. Public endpoint — no auth required. */
+/**
+ * POST /me/deletion-requests body. Authenticated — the account email is
+ * derived server-side from the caller's session, never taken from the
+ * request body. Otherwise anyone could request deletion of someone else's
+ * account just by typing their email address.
+ */
 export const CreateDeletionRequestInputSchema = z.object({
-  email: z.string().email("Enter a valid email address"),
   reason: z.string().max(1000).optional(),
 });
 export type CreateDeletionRequestInput = z.infer<

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,4 @@ export * from "./records";
 export * from "./apiKeys";
 export * from "./flags";
 export * from "./admin";
+export * from "./deletionRequests";

--- a/packages/web/src/router/index.js
+++ b/packages/web/src/router/index.js
@@ -35,6 +35,12 @@ const routes = [
     component: () => import('@/views/Privacy.vue'),
     meta: { public: true },
   },
+  {
+    path: '/delete-account',
+    name: 'DeleteAccount',
+    component: () => import('@/views/DeleteAccount.vue'),
+    meta: { public: true },
+  },
 ]
 
 const router = createRouter({

--- a/packages/web/src/services/api.js
+++ b/packages/web/src/services/api.js
@@ -6,6 +6,7 @@ import {
   ToggleFlagInputSchema,
   SetUserOverrideInputSchema,
   SetUserAdminInputSchema,
+  CreateDeletionRequestInputSchema,
 } from "@season-sprint/shared";
 
 const isLocalDevHost =
@@ -197,6 +198,36 @@ export async function revokeApiKey(keyId, authorizationHeader) {
   }
 
   return response.json();
+}
+
+// ── Deletion requests ────────────────────────────────────────────────────────
+
+// Public — no auth required. The requester may not be signed in.
+export async function requestAccountDeletion(email, reason) {
+  const apiBase = requireApiBaseUrl();
+  const response = await fetch(`${apiBase}/deletion-requests`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      validateBody(CreateDeletionRequestInputSchema, { email, reason: reason || undefined })
+    ),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to submit deletion request: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function adminListDeletionRequests(authorizationHeader) {
+  return adminFetch("/admin/deletion-requests", authorizationHeader);
+}
+
+export function adminDismissDeletionRequest(id, authorizationHeader) {
+  return adminFetch(`/admin/deletion-requests/${encodeURIComponent(id)}`, authorizationHeader, {
+    method: "DELETE",
+  });
 }
 
 // ── Feature flags ───────────────────────────────────────────────────────────

--- a/packages/web/src/services/api.js
+++ b/packages/web/src/services/api.js
@@ -202,14 +202,22 @@ export async function revokeApiKey(keyId, authorizationHeader) {
 
 // ── Deletion requests ────────────────────────────────────────────────────────
 
-// Public — no auth required. The requester may not be signed in.
-export async function requestAccountDeletion(email, reason) {
+// Authenticated — the account email is derived server-side from the
+// caller's session, never sent from the client. Otherwise anyone could
+// request deletion of someone else's account just by typing their email.
+export async function requestAccountDeletion(reason, authorizationHeader) {
+  if (!authorizationHeader) {
+    throw new Error("Missing authorization header");
+  }
   const apiBase = requireApiBaseUrl();
-  const response = await fetch(`${apiBase}/deletion-requests`, {
+  const response = await fetch(`${apiBase}/me/deletion-requests`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authorizationHeader,
+    },
     body: JSON.stringify(
-      validateBody(CreateDeletionRequestInputSchema, { email, reason: reason || undefined })
+      validateBody(CreateDeletionRequestInputSchema, { reason: reason || undefined })
     ),
   });
 

--- a/packages/web/src/views/Admin.vue
+++ b/packages/web/src/views/Admin.vue
@@ -87,6 +87,22 @@
       </div>
       <p v-if="searched && !users.length" class="muted">No users found.</p>
     </div>
+
+    <!-- Deletion requests -->
+    <div class="card">
+      <h2 class="card-title">Deletion requests</h2>
+      <div v-for="r in deletionRequests" :key="r.id" class="deletion-row">
+        <div class="deletion-head">
+          <span class="user-email">{{ r.email }}</span>
+          <span class="deletion-date">{{ new Date(r.createdAt).toLocaleDateString() }}</span>
+          <button class="btn-ghost" type="button" @click="dismissRequest(r)">
+            Mark handled
+          </button>
+        </div>
+        <p v-if="r.reason" class="deletion-reason">{{ r.reason }}</p>
+      </div>
+      <p v-if="!deletionRequests.length" class="muted">No pending requests.</p>
+    </div>
   </section>
 </template>
 
@@ -107,6 +123,8 @@ import {
   adminSetUserOverride,
   adminClearUserOverride,
   adminSetUserAdmin,
+  adminListDeletionRequests,
+  adminDismissDeletionRequest,
 } from "@/services/api";
 
 const flags = ref([]);
@@ -116,6 +134,7 @@ const newDescription = ref("");
 const searchEmail = ref("");
 const searched = ref(false);
 const error = ref("");
+const deletionRequests = ref([]);
 
 // Defense-in-depth: the router guard already blocks non-admins, but if this
 // view is ever reached without admin rights, render nothing and bounce out.
@@ -212,8 +231,24 @@ async function setAdmin(user, isAdmin) {
   });
 }
 
+async function loadDeletionRequests() {
+  await run(async () => {
+    deletionRequests.value = await adminListDeletionRequests(await auth());
+  });
+}
+
+async function dismissRequest(request) {
+  await run(async () => {
+    await adminDismissDeletionRequest(request.id, await auth());
+    deletionRequests.value = deletionRequests.value.filter((r) => r.id !== request.id);
+  });
+}
+
 onMounted(() => {
-  if (isAdmin.value) loadFlags();
+  if (isAdmin.value) {
+    loadFlags();
+    loadDeletionRequests();
+  }
 });
 </script>
 
@@ -326,6 +361,25 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  font-size: 13px;
+}
+.deletion-row {
+  padding: 10px 0;
+  border-bottom: 1px solid color-mix(in oklab, var(--primary) 12%, var(--surface));
+}
+.deletion-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.deletion-date {
+  font-size: 12px;
+  color: var(--muted);
+}
+.deletion-reason {
+  margin: 6px 0 0;
+  color: var(--text);
   font-size: 13px;
 }
 </style>

--- a/packages/web/src/views/DeleteAccount.vue
+++ b/packages/web/src/views/DeleteAccount.vue
@@ -1,0 +1,182 @@
+<script>
+export default { name: "DeleteAccountView" };
+</script>
+
+<script setup>
+import { ref } from "vue";
+import { requestAccountDeletion } from "@/services/api";
+
+const email = ref("");
+const reason = ref("");
+const submitting = ref(false);
+const submitted = ref(false);
+const error = ref("");
+
+async function submit() {
+  error.value = "";
+  submitting.value = true;
+  try {
+    await requestAccountDeletion(email.value.trim(), reason.value.trim());
+    submitted.value = true;
+  } catch (e) {
+    error.value = e?.message || "Something went wrong — try again.";
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="delete-page">
+    <header class="delete-page-head">
+      <h1>Delete Account</h1>
+      <router-link class="btn-ghost back-link" to="/">Back</router-link>
+    </header>
+
+    <section class="delete-card">
+      <template v-if="submitted">
+        <p class="confirm">
+          Request received. We'll confirm by email and permanently delete
+          your account, season records, and API keys within 30 days.
+        </p>
+      </template>
+      <template v-else>
+        <p>
+          Requesting deletion of your Season Sprint account and all
+          associated data — season records and API keys. This can't be
+          undone. Individual records can be deleted anytime from within the
+          app without deleting your whole account.
+        </p>
+
+        <form class="delete-form" @submit.prevent="submit">
+          <label class="field">
+            <span>Account email</span>
+            <input
+              v-model="email"
+              type="email"
+              required
+              placeholder="you@example.com"
+              autocomplete="email"
+            />
+          </label>
+
+          <label class="field">
+            <span>Reason (optional)</span>
+            <textarea
+              v-model="reason"
+              rows="3"
+              placeholder="Optional — helps us improve"
+            ></textarea>
+          </label>
+
+          <p v-if="error" class="error">{{ error }}</p>
+
+          <button class="btn-primary" type="submit" :disabled="submitting || !email">
+            {{ submitting ? "Submitting…" : "Request deletion" }}
+          </button>
+        </form>
+      </template>
+    </section>
+
+    <p class="fallback">
+      Prefer email? Reach out directly at
+      <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>.
+      See the <router-link to="/privacy#data-deletion">privacy policy</router-link>
+      for details on what's deleted and what's retained.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.delete-page {
+  width: min(560px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 20px;
+  text-align: left;
+}
+
+.delete-page-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.delete-page-head h1 {
+  margin: 0;
+  font-size: clamp(20px, 5vw, 28px);
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-strong);
+}
+
+.back-link {
+  text-decoration: none;
+}
+
+.delete-card {
+  background: var(--surface);
+  border: 1px solid color-mix(in oklab, var(--primary) 20%, var(--surface));
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+  padding: 20px 24px;
+}
+
+.delete-card p {
+  margin: 0 0 8px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.confirm {
+  color: var(--text-strong);
+  font-weight: 700;
+}
+
+.delete-form {
+  display: grid;
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.field input,
+.field textarea {
+  font: inherit;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklab, var(--primary) 24%, var(--surface));
+  background: color-mix(in oklab, var(--surface) 92%, #000);
+  color: var(--text-strong);
+  resize: vertical;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+.error {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.fallback {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.fallback a {
+  color: var(--primary);
+}
+</style>

--- a/packages/web/src/views/DeleteAccount.vue
+++ b/packages/web/src/views/DeleteAccount.vue
@@ -3,20 +3,36 @@ export default { name: "DeleteAccountView" };
 </script>
 
 <script setup>
-import { ref } from "vue";
-import { requestAccountDeletion } from "@/services/api";
+import { onMounted, ref } from "vue";
+import { requestAccountDeletion, getAuthorizationHeader } from "@/services/api";
+import { getClerkUser } from "@/services/clerk";
 
-const email = ref("");
+const checking = ref(true);
+const authHeader = ref("");
+const accountEmail = ref("");
 const reason = ref("");
 const submitting = ref(false);
 const submitted = ref(false);
 const error = ref("");
 
+onMounted(async () => {
+  authHeader.value = (await getAuthorizationHeader()) || "";
+  if (authHeader.value) {
+    // Best-effort — only resolves for a real Clerk session, not the local
+    // dev-token bypass. Purely cosmetic (confirms which account you're
+    // about to delete); the server derives the real email from the session
+    // regardless of what's shown here.
+    const user = await getClerkUser({ waitForLoad: false });
+    accountEmail.value = user?.email || "";
+  }
+  checking.value = false;
+});
+
 async function submit() {
   error.value = "";
   submitting.value = true;
   try {
-    await requestAccountDeletion(email.value.trim(), reason.value.trim());
+    await requestAccountDeletion(reason.value.trim(), authHeader.value);
     submitted.value = true;
   } catch (e) {
     error.value = e?.message || "Something went wrong — try again.";
@@ -34,12 +50,25 @@ async function submit() {
     </header>
 
     <section class="delete-card">
-      <template v-if="submitted">
+      <template v-if="checking">
+        <p>Checking sign-in status…</p>
+      </template>
+
+      <template v-else-if="submitted">
         <p class="confirm">
           Request received. We'll confirm by email and permanently delete
           your account, season records, and API keys within 30 days.
         </p>
       </template>
+
+      <template v-else-if="!authHeader">
+        <p>
+          Sign in to request deletion of your own account — this confirms
+          it's really you asking, not someone typing in your email address.
+        </p>
+        <router-link class="btn-primary sign-in-link" to="/">Sign in</router-link>
+      </template>
+
       <template v-else>
         <p>
           Requesting deletion of your Season Sprint account and all
@@ -49,16 +78,10 @@ async function submit() {
         </p>
 
         <form class="delete-form" @submit.prevent="submit">
-          <label class="field">
-            <span>Account email</span>
-            <input
-              v-model="email"
-              type="email"
-              required
-              placeholder="you@example.com"
-              autocomplete="email"
-            />
-          </label>
+          <div v-if="accountEmail" class="field">
+            <span>Account</span>
+            <div class="account-email">{{ accountEmail }}</div>
+          </div>
 
           <label class="field">
             <span>Reason (optional)</span>
@@ -71,7 +94,7 @@ async function submit() {
 
           <p v-if="error" class="error">{{ error }}</p>
 
-          <button class="btn-primary" type="submit" :disabled="submitting || !email">
+          <button class="btn-primary" type="submit" :disabled="submitting">
             {{ submitting ? "Submitting…" : "Request deletion" }}
           </button>
         </form>
@@ -79,8 +102,9 @@ async function submit() {
     </section>
 
     <p class="fallback">
-      Prefer email? Reach out directly at
-      <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>.
+      Can't sign in anymore? Email
+      <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>
+      directly and we'll verify it's your account before deleting anything.
       See the <router-link to="/privacy#data-deletion">privacy policy</router-link>
       for details on what's deleted and what's retained.
     </p>
@@ -135,6 +159,12 @@ async function submit() {
   font-weight: 700;
 }
 
+.sign-in-link {
+  display: inline-flex;
+  text-decoration: none;
+  margin-top: 4px;
+}
+
 .delete-form {
   display: grid;
   gap: 14px;
@@ -163,6 +193,15 @@ async function submit() {
 .field textarea:focus {
   outline: none;
   box-shadow: 0 0 0 3px var(--ring);
+}
+
+.account-email {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in oklab, var(--primary) 14%, var(--surface));
+  background: color-mix(in oklab, var(--surface) 96%, #000);
+  color: var(--text-strong);
+  font-weight: 700;
 }
 
 .error {

--- a/packages/web/src/views/Privacy.vue
+++ b/packages/web/src/views/Privacy.vue
@@ -84,10 +84,12 @@ export default { name: "PrivacyView" };
       </p>
       <ol>
         <li>
-          Submit the <router-link to="/delete-account">account deletion form</router-link>
-          with the email your account uses (or email
+          Sign in and submit the
+          <router-link to="/delete-account">account deletion form</router-link>
+          — this confirms the request is really coming from you. Can't sign
+          in anymore? Email
           <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>
-          directly).
+          directly and we'll verify it's your account first.
         </li>
         <li>
           We'll confirm the request and permanently delete your account,

--- a/packages/web/src/views/Privacy.vue
+++ b/packages/web/src/views/Privacy.vue
@@ -84,9 +84,10 @@ export default { name: "PrivacyView" };
       </p>
       <ol>
         <li>
-          Email <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>
-          from the address your account uses, with the subject "Delete my
-          account."
+          Submit the <router-link to="/delete-account">account deletion form</router-link>
+          with the email your account uses (or email
+          <a href="mailto:larthur.creations@gmail.com">larthur.creations@gmail.com</a>
+          directly).
         </li>
         <li>
           We'll confirm the request and permanently delete your account,


### PR DESCRIPTION
## Summary
- Adds an account deletion request form at `/delete-account` (viewable without an account, but submitting requires sign-in — see security note below).
- Submissions POST to `/me/deletion-requests` and land in a new `DeletionRequest` table.
- Requests show up in a new "Deletion requests" card in the Admin panel, actioned manually and dismissed — same manual-processing workflow as before, just no email client.
- No new external services — reuses the existing D1 database and admin panel rather than adding a transactional email provider.
- Privacy policy's "Data deletion" section links to the form as the primary method; the email fallback is kept for anyone who's lost account access, with a note that path requires manual identity verification before anything gets deleted.

## Security: authenticated, not client-supplied email
The endpoint originally took a client-supplied `email` with zero verification — anyone could submit someone else's address and have it show up in the Admin panel looking legitimate. Fixed before merge: the endpoint now requires the same auth as `/me/records`, and the email is always derived server-side from the caller's session (`getEmail()`), never trusted from the request body. Confirmed via curl that a spoofed `email` field in the body is silently ignored in favor of the real session's email. The web form reflects this — signed in shows the form with no email field (nothing left to supply), signed out shows a sign-in prompt.

## Migration note
`prisma migrate diff` against the local dev DB produced an **unsafe** diff — it wanted to `DROP TABLE ScrapeCache` (exists via a hand-written migration, isn't tracked in `schema.prisma`) plus unrelated rewrites of `FeatureFlag`/`User`/`UserFlagOverride` from type drift. Migration `0008_create_deletion_requests.sql` is hand-written instead, scoped to just the new table. Worth being careful with `prisma migrate diff` on this DB going forward — always inspect the output before applying.

## Test plan
- [x] Migration applies cleanly to local D1; Prisma client regenerated
- [x] `pnpm run lint` / `pnpm run test` pass in `packages/server` (53 tests)
- [x] `pnpm run lint` / `pnpm run build` pass in `packages/web`
- [x] Verified end-to-end via curl against the local server: unauthenticated request rejected (401), authenticated request with a spoofed `email` field ignores it and uses the real session email, `GET /admin/deletion-requests` lists it correctly
- [x] Screenshotted `/delete-account` in both signed-in (form) and signed-out (sign-in prompt) states
- [ ] Live UI check: sign into `/admin` locally with a real account and confirm the "Deletion requests" card shows a test submission, then dismiss it — headless Chromium testing hit a pre-existing quirk (an up-to-8s wait for `window.Clerk` that never resolves when Clerk isn't mounted) that affected getting a clean screenshot of the admin card's live data; this is unrelated to the new code and reproduces on the pre-existing Flags section too

🤖 Generated with [Claude Code](https://claude.com/claude-code)
