### PR TITLE
Fix points-gain calc reaching across season boundary

### DIFF
--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/DashboardViewModel.kt
@@ -66,16 +66,20 @@ data class DashboardState(
     val rank: RankInfo get() = computeRank(currentPoints, thresholds)
 
     /**
-     * Points gained today = today's total minus the most recent prior day's total. In Ranked,
-     * a today-entry with no prior point is the placement itself, not earned progress, so it
-     * reads as 0 gain rather than a jump from 0 (World Tour genuinely starts at 0).
+     * Points gained today = today's total minus the most recent prior day's total, restricted to
+     * the live season -- points reset to (near) zero at season start, so a point from a previous
+     * season isn't a real "yesterday" to diff against (it would otherwise read as a huge drop,
+     * e.g. -2400, on the first log of a new season). In Ranked, a today-entry with no in-season
+     * prior point is the placement itself, not earned progress, so it reads as 0 gain rather than
+     * a jump from 0 (World Tour genuinely starts at 0).
      */
     val todayGain: Int?
         get() {
             val today = DateKey.today()
             val sorted = sortedPoints
             val todayPoint = sorted.firstOrNull { it.day == today } ?: return null
-            val prev = sorted.lastOrNull { it.day < today }
+            val seasonStart = season?.start
+            val prev = sorted.lastOrNull { it.day < today && (seasonStart == null || !it.instant.isBefore(seasonStart)) }
             val prevValue = prev?.winPoints ?: (if (mode == GameMode.Ranked) todayPoint.winPoints else 0)
             return todayPoint.winPoints - prevValue
         }

--- a/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/DashboardStore.swift
@@ -67,15 +67,21 @@ final class DashboardStore {
         computeRank(points: currentPoints, thresholds: thresholds)
     }
 
-    /// Points gained today = today's total minus the most recent prior day's total. In
-    /// Ranked, a today-entry with no prior point is the placement itself, not earned
-    /// progress, so it reads as 0 gain rather than a jump from 0 (World Tour genuinely
-    /// starts at 0).
+    /// Points gained today = today's total minus the most recent prior day's total,
+    /// restricted to the live season — points reset to (near) zero at season start, so a
+    /// point from a previous season isn't a real "yesterday" to diff against (it would
+    /// otherwise read as a huge drop, e.g. -2400, on the first log of a new season). In
+    /// Ranked, a today-entry with no in-season prior point is the placement itself, not
+    /// earned progress, so it reads as 0 gain rather than a jump from 0 (World Tour
+    /// genuinely starts at 0).
     var todayGain: Int? {
         let today = DateKey.today()
         let sorted = sortedPoints
         guard let todayPoint = sorted.first(where: { $0.day == today }) else { return nil }
-        let prev = sorted.last(where: { $0.day < today })
+        let seasonStart = season?.start
+        let prev = sorted.last(where: { point in
+            point.day < today && (seasonStart == nil || point.date >= seasonStart!)
+        })
         let prevValue = prev?.winPoints ?? (mode == .ranked ? todayPoint.winPoints : 0)
         return todayPoint.winPoints - prevValue
     }

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -52,8 +52,14 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
   })
   const todayGain = computed(() => {
     if (!todayPoint.value) return 0
+    const seasonStartMs = dateToMs(seasonStart?.value)
     const prev = [...sortedPoints.value]
       .filter((p) => p.date < todayStr)
+      // Points reset to (near) zero at the start of a new season, so a prior
+      // point from a previous season isn't a real "previous day" to diff
+      // against — without this, the first log of a new season reads as a
+      // huge drop (e.g. -2400) instead of a fresh start.
+      .filter((p) => !isFinite(seasonStartMs) || dateToMs(p.date) >= seasonStartMs)
       .pop()
     // In ranked the first point is the placement rank, not earned progress, so
     // when there's no prior point treat the placement as the baseline (0 gain)
@@ -277,10 +283,16 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     if (idxToday !== -1) {
       base = Number(points[idxToday].y) || 0
     } else {
+      // Only base off a point within the current season — otherwise the
+      // first "+points" of a new season adds on top of last season's final
+      // total instead of starting fresh from zero.
+      const seasonStartMs = dateToMs(seasonStart?.value)
       let last = null
       for (const p of sortedPoints.value) {
         const ms = dateToMs(p.date)
-        if (isFinite(ms) && ms <= todayMs) last = p
+        if (isFinite(ms) && ms <= todayMs && (!isFinite(seasonStartMs) || ms >= seasonStartMs)) {
+          last = p
+        }
       }
       base = last ? Number(last.y) || 0 : 0
     }

--- a/packages/web/tests/usePointsData.spec.js
+++ b/packages/web/tests/usePointsData.spec.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { usePointsData } from '@/composables/usePointsData'
+import { formatDate } from '@/utils/date'
+
+// incrementWinPoints persists via getAuthorizationHeader() -> upsertRecord(),
+// which otherwise falls through to an 8s wait for window.Clerk (never present
+// in this test environment) before resolving unauthenticated. Short-circuit
+// it so the test exercises the local optimistic-update logic under test, not
+// unrelated auth-resolution timing.
+vi.mock('@/services/api', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, getAuthorizationHeader: async () => null }
+})
+
+// A point from a prior season shouldn't be treated as "yesterday's total" once
+// a new season starts — points reset to (near) zero at season start, so
+// diffing against last season's final total reads as a huge, wrong drop.
+describe('usePointsData — season boundary', () => {
+  const today = new Date()
+  const todayStr = formatDate(today)
+  const seasonStartDate = new Date(today)
+  seasonStartDate.setDate(seasonStartDate.getDate() - 2)
+  const seasonStartStr = formatDate(seasonStartDate)
+  const lastSeasonDate = new Date(today)
+  lastSeasonDate.setDate(lastSeasonDate.getDate() - 30)
+  const lastSeasonStr = formatDate(lastSeasonDate)
+
+  function setup(mode = 'world-tour') {
+    const isSeasonValid = ref(true)
+    const seasonStart = ref(seasonStartStr)
+    const seasonEnd = ref('2099-01-01')
+    const autoSetSeasonFromImport = ref(false)
+    return usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSeasonFromImport, mode })
+  }
+
+  it('todayGain ignores a prior-season point instead of diffing against it', () => {
+    const { points, todayGain } = setup('world-tour')
+    points.push({ date: lastSeasonStr, y: 2400 }) // last season's final total
+    points.push({ date: todayStr, y: 50 }) // fresh start this season
+
+    // Without the fix this would be 50 - 2400 = -2350.
+    expect(todayGain.value).toBe(50)
+  })
+
+  it('todayGain still diffs correctly against an in-season prior point', () => {
+    const { points, todayGain } = setup('world-tour')
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+    points.push({ date: lastSeasonStr, y: 2400 })
+    points.push({ date: formatDate(yesterday), y: 120 })
+    points.push({ date: todayStr, y: 180 })
+
+    expect(todayGain.value).toBe(60)
+  })
+
+  it('todayGain treats a ranked placement with no in-season history as zero gain', () => {
+    const { points, todayGain } = setup('ranked')
+    points.push({ date: lastSeasonStr, y: 40000 }) // last season's rank score
+    points.push({ date: todayStr, y: 500 }) // this season's placement match
+
+    expect(todayGain.value).toBe(0)
+  })
+
+  it('incrementWinPoints bases off zero, not a prior-season total', async () => {
+    const { points, incrementWinPoints } = setup('world-tour')
+    points.push({ date: lastSeasonStr, y: 2400 })
+
+    await incrementWinPoints(25)
+
+    const todayEntry = points.find((p) => p.date === todayStr)
+    // Without the fix this would be 2400 + 25 = 2425.
+    expect(todayEntry.y).toBe(25)
+  })
+
+  it('incrementWinPoints still bases off an in-season prior point', async () => {
+    const { points, incrementWinPoints } = setup('world-tour')
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+    points.push({ date: lastSeasonStr, y: 2400 })
+    points.push({ date: formatDate(yesterday), y: 100 })
+
+    await incrementWinPoints(25)
+
+    const todayEntry = points.find((p) => p.date === todayStr)
+    expect(todayEntry.y).toBe(125)
+  })
+})


### PR DESCRIPTION
## Summary
At the start of a new season, points reset to (near) zero, but the "today gain" stat and the "+points" quick-add both picked the most recent prior record regardless of which season it belonged to. So the first log of a new season diffed against last season's final total (e.g. `0 - 2400 = -2400`) instead of a fresh baseline.

`incrementWinPoints` is the more serious half of this: it doesn't just display the wrong number, it **persists** it -- "+points" would add on top of last season's stale total (e.g. `2400 + 25 = 2425`) instead of starting from zero.

## Fix
Restricted the "prior point" search in both functions to the live season window, using `seasonStart` -- already threaded through each client, just never used for this calculation. Fixed in all three ports:

- **web**: `usePointsData.js` (`todayGain` + `incrementWinPoints`), with new regression tests in `usePointsData.spec.js`
- **Android**: `DashboardViewModel.kt` (`todayGain`)
- **iOS**: `DashboardStore.swift` (`todayGain`)

The main chart/pace projection math was already correctly scoped to the season window (web's `useChartGeometry.js` `pointsInSeason`, Android's `Pace.kt`) -- only these two "today" stats reached across the boundary.

## Test plan
- [x] `pnpm test` -- 121 tests pass (5 new, covering: cross-season point ignored, in-season point still diffs correctly, ranked placement treated as zero gain, `incrementWinPoints` bases off zero not a stale total, `incrementWinPoints` still bases off an in-season prior point)
- [x] `pnpm run lint` / `pnpm build` pass
- [x] Android: `./gradlew :app:compileDebugKotlin` succeeds
- [ ] iOS: verified by manual review only -- a full build isn't possible in this environment (`ClerkKit`'s `AuthenticationServices` dependency doesn't compile under plain SPM on Linux, and `xtool dev` requires a paired device). Worth a build/smoke-test on your end before this ships to the App Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daily gain calculations at the start of a new season to prevent misleading negative drops.
  * Ensured point increments use the current season’s baseline rather than totals from previous seasons.
  * Ranked results now show zero gain when no in-season history is available.

* **Tests**
  * Added coverage for season-boundary gain and point-increment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->