### PR TITLE
Fix ranked season-overlay comparison line not rendering

### DIFF
--- a/packages/web/src/composables/useChartGeometry.js
+++ b/packages/web/src/composables/useChartGeometry.js
@@ -163,13 +163,21 @@ export function useChartGeometry({
 
   const overlayPathPoints = computed(() => {
     const sp = overlayScaledPoints.value;
-    if (!sp.length || mode === "ranked") return sp;
+    if (!sp.length) return sp;
     const overlayStartMs = dateToMs(overlayStart?.value);
     const firstMs = dateToMs(overlayPointsRaw.value[0]?.date);
-    if (isFinite(overlayStartMs) && isFinite(firstMs) && firstMs > overlayStartMs) {
-      return [{ x: scaleX(seasonStart.value), y: scaleY(0) }, ...sp];
+    if (!isFinite(overlayStartMs) || !isFinite(firstMs) || firstMs <= overlayStartMs) {
+      return sp;
     }
-    return sp;
+    // Ranked doesn't start at 0 -- stitch a flat lead-in at the overlay
+    // season's own first recorded value (its placement), matching the live
+    // line's placementBaselinePath semantics. Without this, a ranked overlay
+    // season with only one logged point (common in Ranked, which tends to
+    // get logged less often than World Tour) never draws a line at all --
+    // buildPathD needs >=2 points, so the "compare to a previous season"
+    // line silently failed to render for Ranked.
+    const baselineY = mode === "ranked" ? overlayPointsRaw.value[0].y : 0;
+    return [{ x: scaleX(seasonStart.value), y: scaleY(baselineY) }, ...sp];
   });
 
   const overlayPathD = computed(() => buildPathD(overlayPathPoints.value));

--- a/packages/web/tests/overlay-line.spec.js
+++ b/packages/web/tests/overlay-line.spec.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { ref, computed } from 'vue'
+import { useChartGeometry } from '@/composables/useChartGeometry'
+import { dateToMs } from '@/utils/date'
+
+// "Compare to a previous season" overlay: worked for World Tour but silently
+// drew nothing for Ranked whenever the overlay season had only one logged
+// point (buildPathD needs >=2 points, and ranked never stitched a lead-in).
+function makeGeometry({ mode, points, seasonStart, seasonEnd, overlayStart, overlayEnd }) {
+  const sortedPoints = computed(() =>
+    [...points].sort((a, b) => dateToMs(a.date) - dateToMs(b.date))
+  )
+  return useChartGeometry({
+    width: 600,
+    height: 400,
+    padding: 20,
+    paceTop: 420,
+    paceHeight: 70,
+    pacePadY: 6,
+    today: new Date('2026-08-01'),
+    mode,
+    goalOptions: () => [],
+    seasonStart: ref(seasonStart),
+    seasonEnd: ref(seasonEnd),
+    goalWinPoints: ref(1000),
+    isSeasonValid: ref(true),
+    points,
+    sortedPoints,
+    overlayStart: ref(overlayStart),
+    overlayEnd: ref(overlayEnd),
+  })
+}
+
+// buildPathD emits "M{x},{y} L{x},{y}...". Pull out the leading M's y value.
+function firstPathY(pathD) {
+  const match = pathD.match(/^M[\d.-]+,([\d.-]+)/)
+  return match ? Number(match[1]) : null
+}
+
+describe('overlay line rendering', () => {
+  it('draws a ranked overlay line from a single logged point in the overlay season', () => {
+    const points = [
+      // Live season (world-tour dates reused as a generic season window)
+      { date: '2026-07-05', y: 8000 },
+      { date: '2026-07-10', y: 12000 },
+      // Overlay season -- exactly one point, several days after its season start
+      { date: '2026-04-06', y: 5000 },
+    ]
+    const geometry = makeGeometry({
+      mode: 'ranked',
+      points,
+      seasonStart: '2026-07-01',
+      seasonEnd: '2026-09-01',
+      overlayStart: '2026-04-01',
+      overlayEnd: '2026-06-01',
+    })
+
+    // Before the fix this was '' -- a single overlay point with no stitched
+    // lead-in never met buildPathD's 2-point minimum.
+    expect(geometry.overlayPathD.value).not.toBe('')
+  })
+
+  it('still draws a world-tour overlay line the same way (zero baseline)', () => {
+    const points = [
+      { date: '2026-07-05', y: 500 },
+      { date: '2026-04-06', y: 300 },
+    ]
+    const geometry = makeGeometry({
+      mode: 'world-tour',
+      points,
+      seasonStart: '2026-07-01',
+      seasonEnd: '2026-09-01',
+      overlayStart: '2026-04-01',
+      overlayEnd: '2026-06-01',
+    })
+
+    expect(geometry.overlayPathD.value).not.toBe('')
+    // World Tour's stitched lead-in is a zero baseline, not the point's own value.
+    expect(firstPathY(geometry.overlayPathD.value)).toBe(geometry.scaleY(0))
+  })
+
+  it('ranked overlay lead-in uses the overlay point value, not zero', () => {
+    const points = [
+      { date: '2026-07-05', y: 8000 },
+      { date: '2026-04-06', y: 5000 },
+    ]
+    const geometry = makeGeometry({
+      mode: 'ranked',
+      points,
+      seasonStart: '2026-07-01',
+      seasonEnd: '2026-09-01',
+      overlayStart: '2026-04-01',
+      overlayEnd: '2026-06-01',
+    })
+
+    expect(firstPathY(geometry.overlayPathD.value)).toBe(geometry.scaleY(5000))
+  })
+})


### PR DESCRIPTION
## Summary
"Compare to a previous season" worked for World Tour but silently drew nothing for Ranked whenever the overlay season had only one logged point.

World Tour always stitches a synthetic `(seasonStart, y=0)` lead-in point when the first in-season point isn't on day 0. Ranked's `overlayPathPoints` (`useChartGeometry.js`) unconditionally skipped that stitch (`mode === "ranked"` early return), with no equivalent lead-in of its own -- `buildPathD` needs >=2 points to draw anything, so a single-point ranked overlay season (common, since Ranked tends to get logged less often than World Tour) rendered only the lone scatter dot, never a line.

## Fix
Always stitch a lead-in point now. For Ranked, the lead-in uses the overlay season's own first recorded value as the baseline instead of 0 -- matching `placementBaselinePath`'s existing "ranked starts at placement, not zero" semantics for the live line.

Scope note: this only affects web. Android's overlay renderer never stitches a lead-in for *either* mode (a separate, smaller parity gap, not the reported bug), so it wasn't touched here.

## Test plan
- [x] New regression tests in `overlay-line.spec.js` -- confirmed they fail without the fix (`git stash` sanity check) and pass with it
- [x] Full suite: `pnpm test` -- 124 tests pass
- [x] `pnpm run lint` / `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart overlay rendering when an overlay contains only one logged point.
  * Ranked overlays now begin at the overlay point’s baseline, while other overlays continue to use a zero baseline.
  * Improved handling of overlays whose starting timestamps are missing or invalid.

* **Tests**
  * Added coverage for ranked and world-tour overlay line rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->