### PR TITLE
fix(local): tolerate misread separator in points readout; installer update UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ packages/local-win/.venv/
 packages/local-win/.last-wtp
 packages/local-win/.tracker-pid
 packages/local-win/tracker.log
+packages/local-win/debug_captures/
 packages/local-win/__pycache__/
 packages/local-win/**/__pycache__/
 packages/local-win/dist/

--- a/packages/local-linux/ocr_preprocess.py
+++ b/packages/local-linux/ocr_preprocess.py
@@ -14,6 +14,7 @@ The C binary (season-tracker) handles screen capture and Tesseract gate
 checks directly. This daemon is only called for EasyOCR points reading.
 """
 
+import re
 import sys
 import easyocr
 
@@ -83,10 +84,16 @@ def process_image(reader, path):
         # Check if it's a number or a "N / N" pattern
         if cleaned.isdigit():
             numbers.append((text_center_x, int(cleaned), text))
-        elif '/' in cleaned:
-            # Already in "N / N" format
-            print(text)
-            return
+        else:
+            # "current / max", e.g. "4 / 25" — EasyOCR frequently misreads
+            # the thin slash glyph as "|", "l", "I", or drops it, so pull
+            # digit runs out directly instead of requiring a literal "/".
+            # Re-emit a clean "N / N" so parse_metric()'s sscanf on the C
+            # side (which does expect a literal slash) still matches.
+            nums = re.findall(r'\d+', cleaned)
+            if len(nums) >= 2:
+                print(f"{nums[0]} / {nums[1]}")
+                return
 
     # Sort by horizontal position (left to right) — "current / max" reads left-to-right
     numbers.sort(key=lambda x: x[0])

--- a/packages/local-win/debug_panel.py
+++ b/packages/local-win/debug_panel.py
@@ -1,0 +1,397 @@
+"""
+debug_panel.py — forward-facing OCR diagnostics window for the tray app.
+
+Opened from the tray icon (right-click > OCR diagnostics). Lets the user
+temporarily switch the tracker from its standard delete-immediately capture
+handling (restored when this window closes) to a rolling buffer of the last
+30 screenshots, shown as a vertical list: newest on top, older shots
+animating downward until they fall past the "deleted forever" line at the
+bottom. Clicking a shot shows the full screenshot, the raw OCR output, and
+the verdict the tracker derived from it ("not on the World Tour page",
+"read current points = 12", ...). "Keep" pulls a shot out of the rolling
+buffer and saves it to debug_captures\\ so it can be shared.
+
+Threading: pystray menu handlers and the tracker loop each run on their own
+threads, but ALL Tk calls happen on the single panel thread spawned here —
+Tkinter objects must only ever be touched from the thread that created
+them. The tracker communicates one-way through season_tracker.DEBUG_BUFFER's
+thread-safe event queue, which the panel drains from a root.after() tick.
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+from PIL import Image, ImageTk
+
+import season_tracker as st
+
+_lock = threading.Lock()
+_thread: threading.Thread | None = None
+_focus_requested = threading.Event()
+
+
+def open_panel() -> None:
+    """Open the diagnostics window, or focus it if it's already open.
+    Safe to call from any thread (i.e. the pystray menu handler)."""
+    global _thread
+    with _lock:
+        if _thread is not None and _thread.is_alive():
+            _focus_requested.set()
+            return
+        _thread = threading.Thread(target=_run, name="ocr-diagnostics", daemon=True)
+        _thread.start()
+
+
+# Layout constants. ROW_H is the vertical slot each screenshot row occupies
+# on the canvas; rows tween between slot positions rather than jumping.
+ROW_H = 100
+THUMB_W = 240
+TOP_PAD = 10
+LEFT_PAD = 10
+TICK_MS = 25          # ~40fps animation/queue-drain tick
+EASE = 0.22           # fraction of remaining distance covered per tick
+
+BG = "#1e1e1e"
+FG = "#e0e0e0"
+FG_DIM = "#9a9a9a"
+ROW_BG = "#2a2a2a"
+ACCENT = "#d9534f"    # deletion-zone red
+
+
+def _run() -> None:
+    buf = st.DEBUG_BUFFER
+    # Drain any events left over from a previous open — they describe
+    # records that were cleared when that window closed.
+    while not buf.events.empty():
+        try:
+            buf.events.get_nowait()
+        except Exception:
+            break
+
+    root = tk.Tk()
+    root.title("Season Sprint — OCR diagnostics")
+    root.geometry("640x700")
+    root.configure(bg=BG)
+    _Panel(root, buf)
+    root.mainloop()
+
+
+class _Row:
+    """One screenshot entry in the rolling list: a frame embedded in the
+    canvas as a window item, tweening toward target_y each tick."""
+
+    def __init__(self, panel: "_Panel", rec) -> None:
+        self.rec = rec
+        self.dying = False
+
+        f = tk.Frame(panel.canvas, bg=ROW_BG, padx=6, pady=6, cursor="hand2")
+        img = Image.open(io.BytesIO(rec.png_bytes))
+        img.thumbnail((THUMB_W, ROW_H - 16))
+        self.thumb = ImageTk.PhotoImage(img)  # ref held or Tk drops the image
+        thumb_lbl = tk.Label(f, image=self.thumb, bg=ROW_BG)
+        thumb_lbl.pack(side="left")
+
+        info = tk.Frame(f, bg=ROW_BG)
+        info.pack(side="left", fill="both", expand=True, padx=(8, 0))
+        head = tk.Frame(info, bg=ROW_BG)
+        head.pack(fill="x")
+        tk.Label(
+            head, text=f"#{rec.seq}  {rec.timestamp:%H:%M:%S}",
+            bg=ROW_BG, fg=FG, font=("Segoe UI", 9, "bold"),
+        ).pack(side="left")
+        tk.Button(
+            head, text="Keep", command=lambda: panel.keep(self),
+            bg="#3a3a3a", fg=FG, activebackground="#4a4a4a",
+            activeforeground=FG, relief="flat", padx=8,
+        ).pack(side="right")
+        tk.Label(
+            info, text=rec.verdict, bg=ROW_BG, fg=FG_DIM,
+            font=("Segoe UI", 9), wraplength=300, justify="left", anchor="nw",
+        ).pack(fill="both", expand=True)
+
+        for w in (f, thumb_lbl, info, head, *info.winfo_children(), *head.winfo_children()):
+            if not isinstance(w, tk.Button):
+                w.bind("<Button-1>", lambda _e: panel.show_detail(self.rec))
+
+        self.y = float(TOP_PAD - ROW_H)  # slide in from above the list
+        self.target_y = float(TOP_PAD)
+        self.win = panel.canvas.create_window(
+            LEFT_PAD, self.y, window=f, anchor="nw",
+            width=panel.row_width(), height=ROW_H - 8,
+        )
+        self.frame = f
+
+
+class _Panel:
+    def __init__(self, root: tk.Tk, buf) -> None:
+        self.root = root
+        self.buf = buf
+        self.rows: list[_Row] = []      # newest first; index = slot on canvas
+        self.dying: list[_Row] = []     # evicted rows still animating out
+        self.kept_thumbs: list = []     # PhotoImage refs for the kept strip
+
+        # ── Header: buffering toggle + status line ──
+        header = tk.Frame(root, bg=BG, padx=10, pady=8)
+        header.pack(fill="x")
+        self.buffering = tk.BooleanVar(value=False)
+        tk.Checkbutton(
+            header,
+            text=f"Buffer the last {buf.maxlen} screenshots for diagnosis",
+            variable=self.buffering, command=self._toggle,
+            bg=BG, fg=FG, activebackground=BG, activeforeground=FG,
+            selectcolor="#333333", font=("Segoe UI", 10),
+        ).pack(anchor="w")
+        tk.Label(
+            header,
+            text="Standard behavior (screenshots deleted immediately) resumes "
+                 "when this window closes.",
+            bg=BG, fg=FG_DIM, font=("Segoe UI", 8),
+        ).pack(anchor="w")
+        self.status = tk.Label(
+            header, text="buffering off — screenshots are deleted immediately",
+            bg=BG, fg=FG_DIM, font=("Segoe UI", 9, "italic"),
+            wraplength=600, justify="left",
+        )
+        self.status.pack(anchor="w", pady=(6, 0))
+
+        # ── Kept screenshots strip (hidden until first Keep) ──
+        self.kept_frame = tk.LabelFrame(
+            root, text=" Kept screenshots (saved to debug_captures) ",
+            bg=BG, fg=FG, font=("Segoe UI", 9),
+        )
+
+        # ── Rolling list canvas ──
+        body = tk.Frame(root, bg=BG)
+        body.pack(fill="both", expand=True, padx=10, pady=(4, 10))
+        self.canvas = tk.Canvas(body, bg=BG, highlightthickness=0)
+        sb = ttk.Scrollbar(body, orient="vertical", command=self.canvas.yview)
+        self.canvas.configure(yscrollcommand=sb.set)
+        sb.pack(side="right", fill="y")
+        self.canvas.pack(side="left", fill="both", expand=True)
+        self.canvas.bind_all(
+            "<MouseWheel>",
+            lambda e: self.canvas.yview_scroll(-1 * (e.delta // 120), "units"),
+        )
+
+        # Deletion zone: a dashed line + label that sit just below the last
+        # row (capped at the 30th slot). Rows animating past it are being
+        # destroyed — that's the "deleted forever" cue.
+        self.line_y = float(self._line_target())
+        self.line = self.canvas.create_line(
+            LEFT_PAD, self.line_y, 600, self.line_y,
+            fill=ACCENT, dash=(6, 4), width=2,
+        )
+        self.line_label = self.canvas.create_text(
+            LEFT_PAD, self.line_y + 10, anchor="nw", fill=ACCENT,
+            font=("Segoe UI", 9, "bold"),
+            text="\U0001f5d1 screenshots pushed past this line are deleted forever",
+        )
+        self._update_scrollregion()
+
+        self.canvas.bind("<Configure>", self._on_resize)
+        root.protocol("WM_DELETE_WINDOW", self._on_close)
+        root.after(TICK_MS, self._tick)
+
+    def row_width(self) -> int:
+        # Before the first layout pass winfo_width() reports 1; fall back to
+        # a width matching the initial 640px window.
+        w = self.canvas.winfo_width()
+        return w - LEFT_PAD * 2 if w > 100 else 580
+
+    def _on_resize(self, _event) -> None:
+        for row in self.rows + self.dying:
+            self.canvas.itemconfigure(row.win, width=self.row_width())
+
+    # ── Buffer toggle / close ──
+
+    def _toggle(self) -> None:
+        on = self.buffering.get()
+        self.buf.set_enabled(on)
+        if on:
+            self.status.config(text="buffering on — waiting for the next capture ...")
+        # The off path gets its status text from the ("cleared",) event.
+
+    def _on_close(self) -> None:
+        self.buf.set_enabled(False)  # restore standard delete-immediately behavior
+        self.root.destroy()
+
+    # ── Event pump + animation tick ──
+
+    def _tick(self) -> None:
+        if _focus_requested.is_set():
+            _focus_requested.clear()
+            self.root.deiconify()
+            self.root.lift()
+            self.root.focus_force()
+
+        while not self.buf.events.empty():
+            try:
+                ev = self.buf.events.get_nowait()
+            except Exception:
+                break
+            kind = ev[0]
+            if kind == "added":
+                self._on_added(ev[1])
+            elif kind == "evicted":
+                self._on_evicted(ev[1])
+            elif kind == "cleared":
+                self._on_cleared()
+            elif kind == "status":
+                self.status.config(text=ev[1])
+
+        self._animate()
+        self.root.after(TICK_MS, self._tick)
+
+    def _animate(self) -> None:
+        for row in self.rows + self.dying:
+            dy = row.target_y - row.y
+            if abs(dy) < 1.0:
+                row.y = row.target_y
+            else:
+                row.y += dy * EASE
+            self.canvas.coords(row.win, LEFT_PAD, row.y)
+        for row in [r for r in self.dying if r.y == r.target_y]:
+            self.dying.remove(row)
+            self.canvas.delete(row.win)
+            row.frame.destroy()
+
+        dy = self._line_target() - self.line_y
+        if abs(dy) < 1.0:
+            self.line_y = float(self._line_target())
+        else:
+            self.line_y += dy * EASE
+        w = max(self.canvas.winfo_width() - LEFT_PAD, 600)
+        self.canvas.coords(self.line, LEFT_PAD, self.line_y, w, self.line_y)
+        self.canvas.coords(self.line_label, LEFT_PAD, self.line_y + 10)
+
+    # ── Event handlers ──
+
+    def _slot_y(self, index: int) -> float:
+        return float(TOP_PAD + index * ROW_H)
+
+    def _line_target(self) -> float:
+        return self._slot_y(min(len(self.rows), self.buf.maxlen)) + 6
+
+    def _retarget(self) -> None:
+        for i, row in enumerate(self.rows):
+            row.target_y = self._slot_y(i)
+        self._update_scrollregion()
+
+    def _update_scrollregion(self) -> None:
+        bottom = self._line_target() + ROW_H
+        self.canvas.configure(scrollregion=(0, 0, 620, bottom))
+
+    def _on_added(self, rec) -> None:
+        self.rows.insert(0, _Row(self, rec))
+        self._retarget()
+        self.status.config(text=f"last capture {rec.timestamp:%H:%M:%S}: {rec.verdict}")
+
+    def _on_evicted(self, seq: int) -> None:
+        row = next((r for r in self.rows if r.rec.seq == seq), None)
+        if row is None:
+            return
+        self.rows.remove(row)
+        row.dying = True
+        row.target_y = self._line_target() + ROW_H  # push it past the line
+        self.dying.append(row)
+        self._retarget()
+
+    def _on_cleared(self) -> None:
+        for row in self.rows + self.dying:
+            self.canvas.delete(row.win)
+            row.frame.destroy()
+        self.rows.clear()
+        self.dying.clear()
+        self.line_y = float(self._line_target())
+        self._update_scrollregion()
+        self.status.config(text="buffering off — screenshots are deleted immediately")
+
+    # ── Keep (protect from deletion) ──
+
+    def keep(self, row: _Row) -> None:
+        path = self.buf.protect(row.rec.seq)
+        if path is None:  # already rolled off between click and handling
+            return
+        self.rows.remove(row)
+        self.canvas.delete(row.win)
+        row.frame.destroy()
+        self._retarget()
+        self._add_kept(row.rec, path)
+
+    def _add_kept(self, rec, path) -> None:
+        if not self.kept_frame.winfo_ismapped():
+            self.kept_frame.pack(fill="x", padx=10, pady=(0, 4), before=self.canvas.master)
+        entry = tk.Frame(self.kept_frame, bg=BG, cursor="hand2")
+        entry.pack(fill="x", padx=6, pady=3)
+        img = Image.open(io.BytesIO(rec.png_bytes))
+        img.thumbnail((120, 44))
+        thumb = ImageTk.PhotoImage(img)
+        self.kept_thumbs.append(thumb)
+        tk.Label(entry, image=thumb, bg=BG).pack(side="left")
+        tk.Label(
+            entry,
+            text=f"\U0001f4cc #{rec.seq}  {rec.timestamp:%H:%M:%S} — saved to {path.name}",
+            bg=BG, fg=FG, font=("Segoe UI", 9), anchor="w",
+        ).pack(side="left", padx=(8, 0))
+        for w in (entry, *entry.winfo_children()):
+            w.bind("<Button-1>", lambda _e: self.show_detail(rec))
+
+    # ── Detail view ──
+
+    def show_detail(self, rec) -> None:
+        win = tk.Toplevel(self.root)
+        win.title(f"Capture #{rec.seq} — {rec.timestamp:%H:%M:%S}")
+        win.configure(bg=BG)
+
+        img = Image.open(io.BytesIO(rec.png_bytes))
+        # Cap to a sane window size; the region is already a monitor crop.
+        img.thumbnail((1000, 500))
+        photo = ImageTk.PhotoImage(img)
+        win._photo = photo  # keep a ref alive for the window's lifetime
+        tk.Label(win, image=photo, bg=BG).pack(padx=12, pady=(12, 8))
+
+        tk.Label(
+            win, text=f"Verdict: {rec.verdict}",
+            bg=BG, fg=FG, font=("Segoe UI", 10, "bold"),
+            wraplength=960, justify="left",
+        ).pack(anchor="w", padx=12)
+        tk.Label(
+            win, text=f"OCR took {rec.ocr_ms:.0f}ms — raw output:",
+            bg=BG, fg=FG_DIM, font=("Segoe UI", 9),
+        ).pack(anchor="w", padx=12, pady=(8, 2))
+
+        text = tk.Text(
+            win, height=max(3, min(10, len(rec.ocr_lines) + 1)), width=80,
+            bg="#141414", fg=FG, relief="flat", font=("Consolas", 9),
+        )
+        if rec.ocr_lines:
+            for line, conf in rec.ocr_lines:
+                text.insert("end", f"conf={conf:.2f}  {line!r}\n")
+        else:
+            text.insert("end", "<no text boxes detected>\n")
+        text.config(state="disabled")
+        text.pack(fill="x", padx=12)
+
+        footer = tk.Frame(win, bg=BG)
+        footer.pack(fill="x", padx=12, pady=10)
+        if rec.saved_path is not None:
+            tk.Label(
+                footer, text=f"\U0001f4cc kept — saved to {rec.saved_path}",
+                bg=BG, fg=FG_DIM, font=("Segoe UI", 9),
+            ).pack(side="left")
+        else:
+            def _keep_from_detail():
+                row = next((r for r in self.rows if r.rec.seq == rec.seq), None)
+                if row is not None:
+                    self.keep(row)
+                win.destroy()
+
+            tk.Button(
+                footer, text="Keep this screenshot", command=_keep_from_detail,
+                bg="#3a3a3a", fg=FG, activebackground="#4a4a4a",
+                activeforeground=FG, relief="flat", padx=10,
+            ).pack(side="left")

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.14"
+#define AppVersion    "0.1.15"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -62,6 +62,7 @@ UninstallDisplayName={#AppName}
 ; Source paths are relative to this .iss file.
 Source: "..\season_tracker.py"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\tray.py";           DestDir: "{app}"; Flags: ignoreversion
+Source: "..\debug_panel.py";    DestDir: "{app}"; Flags: ignoreversion
 Source: "..\requirements.txt";  DestDir: "{app}"; Flags: ignoreversion
 Source: "..\test_ocr.py";       DestDir: "{app}"; Flags: ignoreversion
 Source: "..\setup.bat";         DestDir: "{app}"; Flags: ignoreversion

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.12"
+#define AppVersion    "0.1.13"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -105,6 +105,7 @@ var
   DepsAttempted: Boolean;            // guard so Back/Next doesn't re-run deps
   LaunchEdit: TNewEdit;              // selectable Steam launch line on finish page
   Method2Label: TNewStaticText;     // non-Steam (Start-menu) instructions on finish page
+  PrevMonitorIndex: Integer;        // MONITOR_INDEX from an existing {app}\.env, if any (0 = none)
 
 // True once install-deps.bat has produced the venv python. Drives the monitor
 // page skip and the finish-page success/failure branch.
@@ -129,17 +130,46 @@ begin
   Result := True;
 end;
 
+// Re-running the installer over an existing install (an update) should not
+// force the user to blind-retype their API key — that's exactly the kind of
+// transcription slip that produces a hard-to-diagnose 401 later. If {app}\.env
+// already exists, pre-fill the token page from it and remember the previously
+// chosen monitor so RunDepsAndEnumerate can preselect it once repopulated.
+procedure LoadPreviousConfig;
+var
+  EnvLines: TArrayOfString;
+  i, eq: Integer;
+  key, val: String;
+begin
+  PrevMonitorIndex := 0;
+  if not LoadStringsFromFile(ExpandConstant('{app}\.env'), EnvLines) then
+    exit;
+  for i := 0 to GetArrayLength(EnvLines) - 1 do begin
+    eq := Pos('=', EnvLines[i]);
+    if eq > 0 then begin
+      key := Copy(EnvLines[i], 1, eq - 1);
+      val := Copy(EnvLines[i], eq + 1, Length(EnvLines[i]));
+      if key = 'AUTH_TOKEN' then
+        TokenPage.Values[0] := val
+      else if key = 'MONITOR_INDEX' then
+        PrevMonitorIndex := StrToIntDef(val, 0);
+    end;
+  end;
+end;
+
 procedure InitializeWizard;
 begin
   DepsOK := False;
   DepsAttempted := False;
   SetArrayLength(MonitorIndices, 0);
+  PrevMonitorIndex := 0;
 
   TokenPage := CreateInputQueryPage(wpWelcome,
     'Season Sprint account',
     'Enter your personal API key',
     'Paste the key from the web app''s "API Keys" banner (the full key in the green banner, not the truncated prefix). It starts with "sk_" and is 67 characters long. Clicking Next sets up Python and dependencies, which takes 1-2 minutes on the first install.');
   TokenPage.Add('API key:', True);
+  LoadPreviousConfig;
 
   MonitorPage := CreateInputOptionPage(TokenPage.ID,
     'Game monitor',
@@ -230,8 +260,16 @@ begin
           end;
         end;
       end;
-      if GetArrayLength(MonitorIndices) > 0 then
+      if GetArrayLength(MonitorIndices) > 0 then begin
+        // Default to the first monitor, unless this is an update and the
+        // previous MONITOR_INDEX is still present in the freshly-enumerated
+        // list — then keep the user's existing choice.
         MonitorPage.SelectedValueIndex := 0;
+        if PrevMonitorIndex > 0 then
+          for i := 0 to GetArrayLength(MonitorIndices) - 1 do
+            if MonitorIndices[i] = PrevMonitorIndex then
+              MonitorPage.SelectedValueIndex := i;
+      end;
     end;
   finally
     Progress.Hide;

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.13"
+#define AppVersion    "0.1.14"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -106,6 +106,7 @@ var
   LaunchEdit: TNewEdit;              // selectable Steam launch line on finish page
   Method2Label: TNewStaticText;     // non-Steam (Start-menu) instructions on finish page
   PrevMonitorIndex: Integer;        // MONITOR_INDEX from an existing {app}\.env, if any (0 = none)
+  PrevConfigLoaded: Boolean;        // guard so LoadPreviousConfig only runs once
 
 // True once install-deps.bat has produced the venv python. Drives the monitor
 // page skip and the finish-page success/failure branch.
@@ -163,13 +164,17 @@ begin
   DepsAttempted := False;
   SetArrayLength(MonitorIndices, 0);
   PrevMonitorIndex := 0;
+  PrevConfigLoaded := False;
 
   TokenPage := CreateInputQueryPage(wpWelcome,
     'Season Sprint account',
     'Enter your personal API key',
     'Paste the key from the web app''s "API Keys" banner (the full key in the green banner, not the truncated prefix). It starts with "sk_" and is 67 characters long. Clicking Next sets up Python and dependencies, which takes 1-2 minutes on the first install.');
   TokenPage.Add('API key:', True);
-  LoadPreviousConfig;
+  // NOTE: LoadPreviousConfig is NOT called here — {app} is not yet resolved
+  // during InitializeWizard (Inno Setup raises "attempt to expand the app
+  // constant before it was initialized" if you try). It's deferred to
+  // CurPageChanged, once the token page is actually about to be shown.
 
   MonitorPage := CreateInputOptionPage(TokenPage.ID,
     'Game monitor',
@@ -329,6 +334,13 @@ procedure CurPageChanged(CurPageID: Integer);
 var
   L: TNewStaticText;
 begin
+  // {app} only resolves once Setup has passed the (hidden) directory page,
+  // which has happened by the time any wizard page is actually displayed —
+  // safe here, unlike in InitializeWizard.
+  if (CurPageID = TokenPage.ID) and (not PrevConfigLoaded) then begin
+    LoadPreviousConfig;
+    PrevConfigLoaded := True;
+  end;
   if CurPageID = wpFinished then begin
     L := WizardForm.FinishedLabel;
     L.AutoSize := False;

--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -20,11 +20,15 @@ from __future__ import annotations
 
 import datetime as dt
 import getpass
+import io
 import os
+import queue
 import re
 import signal
 import sys
+import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -320,10 +324,15 @@ def _grab_points_region(sct: mss.base.MSSBase, monitor_index: int) -> np.ndarray
     return frame
 
 
-def parse_wtp_from_ocr(results) -> Optional[int]:
+def analyze_ocr(results) -> tuple[Optional[int], str]:
     """Given EasyOCR readtext() results, return the first 'current points'
-    number located spatially below a 'WORLD TOUR POINTS' header. Mirrors
-    the logic in packages/local-linux/ocr_preprocess.py."""
+    number located spatially below a 'WORLD TOUR POINTS' header, plus a
+    human-readable verdict explaining how that conclusion was reached (shown
+    in the diagnostics panel and test_ocr.py). Mirrors the parsing logic in
+    packages/local-linux/ocr_preprocess.py."""
+    if not results:
+        return None, "No text detected in the capture region"
+
     header_bbox = None
     for bbox, text, _conf in results:
         up = text.upper()
@@ -332,7 +341,10 @@ def parse_wtp_from_ocr(results) -> Optional[int]:
             break
 
     if header_bbox is None:
-        return None
+        return None, (
+            f"Found {len(results)} text box(es), but no 'WORLD TOUR POINTS' "
+            f"header — probably not on the World Tour page"
+        )
 
     header_top = min(pt[1] for pt in header_bbox)
     header_bottom = max(pt[1] for pt in header_bbox)
@@ -363,10 +375,152 @@ def parse_wtp_from_ocr(results) -> Optional[int]:
             # a literal "/" (which silently dropped real reads like "4 | 25").
             nums = re.findall(r"\d+", cleaned)
             if len(nums) >= 2:
-                return int(nums[0])
+                return int(nums[0]), (
+                    f"Read current points = {nums[0]} "
+                    f"(from a 'current / max' readout {cleaned!r})"
+                )
 
     candidates.sort(key=lambda c: c[0])
-    return candidates[0][1] if candidates else None
+    if candidates:
+        return candidates[0][1], f"Read current points = {candidates[0][1]}"
+    return None, "Found the 'WORLD TOUR POINTS' header, but no readable number near it"
+
+
+def parse_wtp_from_ocr(results) -> Optional[int]:
+    """Back-compat wrapper around analyze_ocr for callers that only want
+    the number (test_ocr.py's original interface)."""
+    return analyze_ocr(results)[0]
+
+
+# ── Diagnostics buffer ────────────────────────────────────────────────────────
+#
+# Backing store for the tray app's "OCR diagnostics" window (debug_panel.py).
+# Disabled by default: the tracker's standard behavior is to discard each
+# captured frame as soon as OCR has run. While the panel has buffering
+# switched on, the last DEBUG_BUFFER_SIZE captures are kept in memory (as
+# PNG bytes) together with their OCR output and verdict, so the user can see
+# exactly what the tracker saw. "Protecting" a capture pulls it out of the
+# rolling buffer and writes it to debug_captures\ so it can be shared.
+
+DEBUG_BUFFER_SIZE = 30
+DEBUG_CAPTURE_DIR = SCRIPT_DIR / "debug_captures"
+
+
+@dataclass
+class CaptureRecord:
+    seq: int
+    timestamp: dt.datetime
+    png_bytes: bytes
+    ocr_lines: list  # (text, confidence) per EasyOCR box, reading order
+    wtp: Optional[int]
+    verdict: str
+    ocr_ms: float
+    protected: bool = False
+    saved_path: Optional[Path] = None
+
+
+class DebugBuffer:
+    """Thread-safe rolling buffer of recent captures.
+
+    Written to by the tracker loop (its thread), toggled and read by the
+    diagnostics panel (its own Tk thread). UI updates flow one way through
+    `events`, a queue of tuples the panel polls:
+
+        ("added",   CaptureRecord)  — new capture appended
+        ("evicted", seq)            — oldest capture rolled off the end
+        ("cleared",)                — buffering switched off, records dropped
+        ("status",  text)           — tracker state note (e.g. cooldown)
+    """
+
+    def __init__(self, maxlen: int = DEBUG_BUFFER_SIZE):
+        self.maxlen = maxlen
+        self._lock = threading.Lock()
+        self._records: deque = deque(maxlen=maxlen)
+        self._seq = 0
+        self._enabled = False
+        self.events: "queue.Queue[tuple]" = queue.Queue()
+
+    @property
+    def enabled(self) -> bool:
+        with self._lock:
+            return self._enabled
+
+    def set_enabled(self, enabled: bool) -> None:
+        with self._lock:
+            if enabled == self._enabled:
+                return
+            self._enabled = enabled
+            if not enabled:
+                self._records.clear()
+        if not enabled:
+            self.events.put(("cleared",))
+
+    def add(self, frame, ocr_results, wtp: Optional[int], verdict: str, ocr_ms: float) -> None:
+        """Record one capture. No-op (including the PNG encode) when
+        buffering is off, so the tracker's default hot path is unchanged."""
+        with self._lock:
+            if not self._enabled:
+                return
+            self._seq += 1
+            seq = self._seq
+
+        from PIL import Image  # deferred like easyocr: only paid when buffering
+
+        buf = io.BytesIO()
+        Image.fromarray(frame).save(buf, format="PNG")
+        rec = CaptureRecord(
+            seq=seq,
+            timestamp=dt.datetime.now(),
+            png_bytes=buf.getvalue(),
+            ocr_lines=[(text, float(conf)) for _bbox, text, conf in (ocr_results or [])],
+            wtp=wtp,
+            verdict=verdict,
+            ocr_ms=ocr_ms,
+        )
+
+        with self._lock:
+            if not self._enabled:  # switched off while we were encoding
+                return
+            evicted = self._records[0].seq if len(self._records) == self.maxlen else None
+            self._records.append(rec)
+        if evicted is not None:
+            self.events.put(("evicted", evicted))
+        self.events.put(("added", rec))
+
+    def post_status(self, text: str) -> None:
+        if self.enabled:
+            self.events.put(("status", text))
+
+    def protect(self, seq: int) -> Optional[Path]:
+        """Pull a capture out of the rolling buffer so it can't be evicted,
+        and save it to debug_captures\\ (PNG + .txt sidecar with the OCR
+        output and verdict). Returns the PNG path, or None if the capture
+        already rolled off."""
+        with self._lock:
+            rec = next((r for r in self._records if r.seq == seq), None)
+            if rec is None:
+                return None
+            self._records.remove(rec)
+            rec.protected = True
+
+        DEBUG_CAPTURE_DIR.mkdir(exist_ok=True)
+        stem = f"capture-{rec.timestamp.strftime('%Y%m%d-%H%M%S')}-{rec.seq}"
+        png_path = DEBUG_CAPTURE_DIR / f"{stem}.png"
+        png_path.write_bytes(rec.png_bytes)
+        sidecar = [
+            f"captured: {rec.timestamp.isoformat(timespec='seconds')}",
+            f"ocr time: {rec.ocr_ms:.0f}ms",
+            f"verdict:  {rec.verdict}",
+            f"wtp:      {rec.wtp}",
+            "",
+            "raw OCR output:",
+        ] + [f"  conf={conf:.2f}  {text!r}" for text, conf in rec.ocr_lines]
+        (DEBUG_CAPTURE_DIR / f"{stem}.txt").write_text("\n".join(sidecar) + "\n", encoding="utf-8")
+        rec.saved_path = png_path
+        return png_path
+
+
+DEBUG_BUFFER = DebugBuffer()
 
 
 # ── State + HTTP push ─────────────────────────────────────────────────────────
@@ -469,12 +623,20 @@ def main_loop(cfg: Config) -> None:
             try:
                 frame = _grab_points_region(sct, cfg.monitor_index)
                 results = reader.readtext(frame)
-                wtp = parse_wtp_from_ocr(results)
+                wtp, verdict = analyze_ocr(results)
             except Exception as e:
                 print(f"[err] capture/OCR: {e}")
-                wtp = None
+                frame = results = None
+                wtp, verdict = None, f"capture/OCR error: {e}"
 
             dt_ms = (time.monotonic() - t0) * 1000
+
+            if frame is not None:
+                try:
+                    DEBUG_BUFFER.add(frame, results, wtp, verdict, dt_ms)
+                except Exception as e:
+                    # Diagnostics must never take down the tracker itself.
+                    print(f"[warn] debug buffer: {e}")
 
             if wtp is None:
                 consecutive_reads = 0
@@ -498,6 +660,10 @@ def main_loop(cfg: Config) -> None:
                     else:
                         print(f"[steady] wtp={wtp} unchanged from last push")
                     print(f"[cooldown] sleeping {COOLDOWN_SECS}s")
+                    resume = dt.datetime.now() + dt.timedelta(seconds=COOLDOWN_SECS)
+                    DEBUG_BUFFER.post_status(
+                        f"cooldown after a confirmed read — capturing resumes at {resume:%H:%M:%S}"
+                    )
                     _sleep_interruptible(COOLDOWN_SECS)
                     consecutive_reads = 0
                     last_val = None

--- a/packages/local-win/season_tracker.py
+++ b/packages/local-win/season_tracker.py
@@ -356,12 +356,14 @@ def parse_wtp_from_ocr(results) -> Optional[int]:
         cleaned = text.replace(",", "").replace("_", "").strip()
         if cleaned.isdigit():
             candidates.append((t_cx, int(cleaned)))
-        elif "/" in cleaned:
-            # e.g. "1234 / 2400" — left side is current
-            left, _, _ = cleaned.partition("/")
-            left = left.strip()
-            if left.isdigit():
-                return int(left)
+        else:
+            # "current / max", e.g. "4 / 25" — left side is current. EasyOCR
+            # frequently misreads the thin slash glyph as "|", "l", "I", or
+            # drops it, so pull digit runs out directly instead of requiring
+            # a literal "/" (which silently dropped real reads like "4 | 25").
+            nums = re.findall(r"\d+", cleaned)
+            if len(nums) >= 2:
+                return int(nums[0])
 
     candidates.sort(key=lambda c: c[0])
     return candidates[0][1] if candidates else None

--- a/packages/local-win/test_ocr.py
+++ b/packages/local-win/test_ocr.py
@@ -49,8 +49,9 @@ def main() -> int:
         y2 = max(p[1] for p in bbox)
         print(f"  [{x1:4.0f},{y1:4.0f}]-[{x2:4.0f},{y2:4.0f}] conf={conf:.2f}  {text!r}")
 
-    wtp = season_tracker.parse_wtp_from_ocr(results)
-    print(f"\n--- parse_wtp_from_ocr -> {wtp} ---")
+    wtp, verdict = season_tracker.analyze_ocr(results)
+    print(f"\n--- analyze_ocr -> {wtp} ---")
+    print(f"    verdict: {verdict}")
 
     if wtp is None:
         print(

--- a/packages/local-win/tray.py
+++ b/packages/local-win/tray.py
@@ -98,6 +98,18 @@ def main() -> int:
 
     tracker_thread = threading.Thread(target=st.main_loop, args=(cfg,), daemon=True)
 
+    def on_open_diagnostics(icon, item):
+        try:
+            # Imported lazily so a broken/missing tkinter can't stop the
+            # tray (and tracker) from starting at all.
+            import debug_panel
+            debug_panel.open_panel()
+        except Exception as e:
+            _message_box(
+                f"Could not open the diagnostics panel:\n{e}",
+                flags=MB_OK | MB_ICONERROR,
+            )
+
     def on_open_log(icon, item):
         try:
             os.startfile(str(st.LOG_FILE))  # noqa: S606 (Windows-only, trusted path)
@@ -113,6 +125,7 @@ def main() -> int:
         _load_icon_image(),
         "Season Sprint Tracker",
         menu=pystray.Menu(
+            pystray.MenuItem("OCR diagnostics", on_open_diagnostics),
             pystray.MenuItem("Open log", on_open_log),
             pystray.MenuItem("Quit", on_quit),
         ),


### PR DESCRIPTION
## Summary
- Both trackers (Windows Python, Linux C+Python) required a literal `/` to
  parse the "current / max" points readout. EasyOCR frequently misreads the
  thin slash as `|`, `l`, or `I`, or drops it — silently producing no reading
  at all, indistinguishable in logs from the header genuinely not being on
  screen. Now extracts digit groups directly regardless of separator.
- Windows installer: re-running it over an existing install (an update) always
  re-prompted for a blind-retyped API key and reset the monitor choice, even
  though install always overwrites `.env` from the token page. A mistyped key
  here is exactly what produces a hard-to-diagnose 401 later. Now pre-fills
  both from the existing `{app}\.env` when present.
- Bumps installer `AppVersion` to 0.1.13 (tag `v0.1.13` already pushed).

## Test plan
- [x] Verified against a real user-reported screenshot: EasyOCR output
      `'4 | 25'` (conf 0.59) previously made `parse_wtp_from_ocr` return
      `None`; now correctly returns `4`.
- [x] `python3 -m py_compile` clean on both changed `.py` files.
- [ ] CI: Inno Setup build via `build-windows-installer.yml` (triggered by the
      `v0.1.13` tag push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR handling for “current / maximum” values, including cases where the separator is misread or missing.
  * Normalized OCR results into a consistent “current / maximum” format for more reliable point detection.
* **New Features**
  * Added an “OCR diagnostics” panel accessible from the system tray, with screenshot history, verdict details, and a way to keep selected captures.
* **Installer Improvements**
  * Updated the Windows installer to version **0.1.15** and included the diagnostics panel.
  * Updates now retain the existing API token and preselect the previously used monitor when available.
* **Chores**
  * Ignored the Windows debug captures directory in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->