### PR TITLE
fix(local-win): installer {app} crash on token page; smooth eviction in diagnostics panel

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,17 +1,24 @@
 name: Build Windows installer
 
-# Builds the Inno Setup .exe whenever files under packages/local-win/ change,
-# on manual dispatch, or on a v* tag push. Every run uploads
+# Builds the Inno Setup .exe on PRs touching packages/local-win/ (compile
+# check), on manual dispatch, and on a v* tag push. Every run uploads
 # SeasonSprintTracker.exe as a workflow artifact; tag pushes additionally
 # publish a GitHub Release with the installer attached.
+#
+# Note the trigger shape: an `on.push` with `tags:` and no `branches:` never
+# fires for branch pushes (the old `paths:` filter here was dead), and adding
+# `paths:` alongside `tags:` would filter tag pushes by changed files — a tag
+# on an already-pushed commit has none, silently skipping release builds. So
+# PR-time checks use `pull_request` and tag pushes stay unfiltered.
 
 on:
   push:
+    tags:
+      - "v*"
+  pull_request:
     paths:
       - "packages/local-win/**"
       - ".github/workflows/build-windows-installer.yml"
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/packages/local-win/debug_panel.py
+++ b/packages/local-win/debug_panel.py
@@ -86,11 +86,11 @@ class _Row:
 
     def __init__(self, panel: "_Panel", rec) -> None:
         self.rec = rec
-        self.dying = False
 
         f = tk.Frame(panel.canvas, bg=ROW_BG, padx=6, pady=6, cursor="hand2")
-        img = Image.open(io.BytesIO(rec.png_bytes))
+        img = Image.open(io.BytesIO(rec.png_bytes)).convert("RGB")
         img.thumbnail((THUMB_W, ROW_H - 16))
+        self.pil_thumb = img  # kept for the fade-out ghost on eviction
         self.thumb = ImageTk.PhotoImage(img)  # ref held or Tk drops the image
         thumb_lbl = tk.Label(f, image=self.thumb, bg=ROW_BG)
         thumb_lbl.pack(side="left")
@@ -126,12 +126,53 @@ class _Row:
         self.frame = f
 
 
+class _Ghost:
+    """Fade-out stand-in for an evicted row. Canvas *window* items (real
+    widgets) always render above every other canvas item, so a row widget
+    can never slide visually under the deletion line — and widgets can't
+    fade. The ghost swaps the row for a plain canvas image item (which
+    respects z-order and can be alpha-blended), then tweens down past the
+    line while fading into the background."""
+
+    def __init__(self, panel: "_Panel", row: _Row) -> None:
+        self.base = row.pil_thumb
+        self._bg = Image.new("RGB", self.base.size, (30, 30, 30))  # BG color
+        self.y = row.y
+        self.start_y = row.y
+        # Evictions only happen with a full buffer, but at this moment the
+        # row list is momentarily one short (the "added" event lands next),
+        # so _line_target() would aim one slot high. Use the full-buffer
+        # line position: fade out just past where the line settles.
+        self.target_y = panel._slot_y(panel.buf.maxlen) + 42
+        self.photo = ImageTk.PhotoImage(self.base)
+        self.item = panel.canvas.create_image(
+            LEFT_PAD + 6, self.y, image=self.photo, anchor="nw",
+        )
+        # Keep the deletion line + label rendering above the ghost.
+        panel.canvas.tag_raise(panel.line)
+        panel.canvas.tag_raise(panel.line_label)
+
+    def step(self, canvas: tk.Canvas) -> bool:
+        """Advance one tick; returns False once fully faded (caller deletes)."""
+        dy = self.target_y - self.y
+        if abs(dy) < 1.0:
+            canvas.delete(self.item)
+            return False
+        self.y += dy * EASE
+        travelled = (self.y - self.start_y) / (self.target_y - self.start_y)
+        alpha = max(0.0, 1.0 - travelled)
+        self.photo = ImageTk.PhotoImage(Image.blend(self._bg, self.base, alpha))
+        canvas.itemconfigure(self.item, image=self.photo)
+        canvas.coords(self.item, LEFT_PAD + 6, self.y)
+        return True
+
+
 class _Panel:
     def __init__(self, root: tk.Tk, buf) -> None:
         self.root = root
         self.buf = buf
         self.rows: list[_Row] = []      # newest first; index = slot on canvas
-        self.dying: list[_Row] = []     # evicted rows still animating out
+        self.ghosts: list[_Ghost] = []  # evicted rows still fading out
         self.kept_thumbs: list = []     # PhotoImage refs for the kept strip
 
         # ── Header: buffering toggle + status line ──
@@ -203,7 +244,7 @@ class _Panel:
         return w - LEFT_PAD * 2 if w > 100 else 580
 
     def _on_resize(self, _event) -> None:
-        for row in self.rows + self.dying:
+        for row in self.rows:
             self.canvas.itemconfigure(row.win, width=self.row_width())
 
     # ── Buffer toggle / close ──
@@ -247,17 +288,14 @@ class _Panel:
         self.root.after(TICK_MS, self._tick)
 
     def _animate(self) -> None:
-        for row in self.rows + self.dying:
+        for row in self.rows:
             dy = row.target_y - row.y
             if abs(dy) < 1.0:
                 row.y = row.target_y
             else:
                 row.y += dy * EASE
             self.canvas.coords(row.win, LEFT_PAD, row.y)
-        for row in [r for r in self.dying if r.y == r.target_y]:
-            self.dying.remove(row)
-            self.canvas.delete(row.win)
-            row.frame.destroy()
+        self.ghosts = [g for g in self.ghosts if g.step(self.canvas)]
 
         dy = self._line_target() - self.line_y
         if abs(dy) < 1.0:
@@ -282,8 +320,16 @@ class _Panel:
         self._update_scrollregion()
 
     def _update_scrollregion(self) -> None:
+        # An eviction momentarily shrinks the list (30 -> 29 rows) before the
+        # incoming capture grows it back, and Tk clamps a bottom-scrolled view
+        # upward whenever the scrollregion shrinks — which read as the whole
+        # page jumping. If the user is scrolled to the bottom (watching the
+        # deletion line), keep them pinned there across the change.
+        at_bottom = self.canvas.yview()[1] >= 0.999
         bottom = self._line_target() + ROW_H
         self.canvas.configure(scrollregion=(0, 0, 620, bottom))
+        if at_bottom:
+            self.canvas.yview_moveto(1.0)
 
     def _on_added(self, rec) -> None:
         self.rows.insert(0, _Row(self, rec))
@@ -295,17 +341,19 @@ class _Panel:
         if row is None:
             return
         self.rows.remove(row)
-        row.dying = True
-        row.target_y = self._line_target() + ROW_H  # push it past the line
-        self.dying.append(row)
+        self.ghosts.append(_Ghost(self, row))
+        self.canvas.delete(row.win)
+        row.frame.destroy()
         self._retarget()
 
     def _on_cleared(self) -> None:
-        for row in self.rows + self.dying:
+        for row in self.rows:
             self.canvas.delete(row.win)
             row.frame.destroy()
+        for ghost in self.ghosts:
+            self.canvas.delete(ghost.item)
         self.rows.clear()
-        self.dying.clear()
+        self.ghosts.clear()
         self.line_y = float(self._line_target())
         self._update_scrollregion()
         self.status.config(text="buffering off — screenshots are deleted immediately")

--- a/packages/local-win/installer/installer.iss
+++ b/packages/local-win/installer/installer.iss
@@ -27,7 +27,7 @@
 ; Output: dist\SeasonSprintTracker.exe (relative to this file).
 
 #define AppName       "Season Sprint Tracker"
-#define AppVersion    "0.1.15"
+#define AppVersion    "0.1.16"
 #define AppPublisher  "lcflight"
 #define AppURL        "https://github.com/lcflight/season-sprint"
 
@@ -134,9 +134,19 @@ end;
 
 // Re-running the installer over an existing install (an update) should not
 // force the user to blind-retype their API key — that's exactly the kind of
-// transcription slip that produces a hard-to-diagnose 401 later. If {app}\.env
-// already exists, pre-fill the token page from it and remember the previously
-// chosen monitor so RunDepsAndEnumerate can preselect it once repopulated.
+// transcription slip that produces a hard-to-diagnose 401 later. If the
+// install dir's .env already exists, pre-fill the token page from it and
+// remember the previously chosen monitor so RunDepsAndEnumerate can
+// preselect it once repopulated.
+//
+// IMPORTANT: this must not reference {app}. The token page sits right after
+// wpWelcome — BEFORE the (hidden) directory page — and {app} only becomes
+// expandable after that page is passed, so ExpandConstant('{app}\...') here
+// raises "attempt to expand the app constant before it was initialized",
+// and the exception unwinding out of the event handler then corrupts the
+// script VM ("Out of Global Vars range" on later events). WizardDirValue is
+// the documented safe accessor: it's valid from InitializeWizard onward and
+// already holds the previous install's directory on an update (via AppId).
 procedure LoadPreviousConfig;
 var
   EnvLines: TArrayOfString;
@@ -144,7 +154,7 @@ var
   key, val: String;
 begin
   PrevMonitorIndex := 0;
-  if not LoadStringsFromFile(ExpandConstant('{app}\.env'), EnvLines) then
+  if not LoadStringsFromFile(WizardDirValue + '\.env', EnvLines) then
     exit;
   for i := 0 to GetArrayLength(EnvLines) - 1 do begin
     eq := Pos('=', EnvLines[i]);
@@ -172,10 +182,9 @@ begin
     'Enter your personal API key',
     'Paste the key from the web app''s "API Keys" banner (the full key in the green banner, not the truncated prefix). It starts with "sk_" and is 67 characters long. Clicking Next sets up Python and dependencies, which takes 1-2 minutes on the first install.');
   TokenPage.Add('API key:', True);
-  // NOTE: LoadPreviousConfig is NOT called here — {app} is not yet resolved
-  // during InitializeWizard (Inno Setup raises "attempt to expand the app
-  // constant before it was initialized" if you try). It's deferred to
-  // CurPageChanged, once the token page is actually about to be shown.
+  // LoadPreviousConfig is deferred to CurPageChanged (first display of the
+  // token page) so it runs once, lazily; see its comment for why it must use
+  // WizardDirValue rather than {app}.
 
   MonitorPage := CreateInputOptionPage(TokenPage.ID,
     'Game monitor',
@@ -335,9 +344,6 @@ procedure CurPageChanged(CurPageID: Integer);
 var
   L: TNewStaticText;
 begin
-  // {app} only resolves once Setup has passed the (hidden) directory page,
-  // which has happened by the time any wizard page is actually displayed —
-  // safe here, unlike in InitializeWizard.
   if (CurPageID = TokenPage.ID) and (not PrevConfigLoaded) then begin
     LoadPreviousConfig;
     PrevConfigLoaded := True;


### PR DESCRIPTION
## Installer runtime errors (0.1.14/0.1.15)

Running the installer produced two errors on the API-key page:

- `Runtime error: Internal error: An attempt was made to expand the "app" constant before it was initialized.`
- `Runtime error: Out of Global Vars range.`

**Root cause:** custom wizard pages created after `wpWelcome` are shown *before* Inno's (hidden) directory page, and `{app}` only becomes expandable once that page is passed. `LoadPreviousConfig` ran on first display of the token page and called `ExpandConstant('{app}\.env')`, raising the first error — and the exception unwinding out of the event handler corrupted the PascalScript VM, producing the follow-on "Out of Global Vars range" on later events. The 0.1.14 fix (deferring from `InitializeWizard` to `CurPageChanged`) didn't move the call far enough.

**Fix:** use `WizardDirValue` instead of `{app}` — documented as valid from wizard creation onward, and it already holds the previous install's directory on an update (via `AppId`), so the API-key/monitor carry-over behavior is preserved. Bump to 0.1.16.

## Diagnostics panel: scroll jump on eviction

When scrolled to the bottom watching the deletion line, each eviction made the whole view jump up, and the deleted screenshot was gone by the time you scrolled back down.

- An eviction momentarily shrinks the canvas scrollregion by one slot before the incoming capture grows it back, and Tk clamps a bottom-scrolled view upward on shrink. The view is now **pinned to the bottom** across scrollregion changes when already there.
- Tk canvas *window* items (real widgets) always render above canvas items and can't fade, so the evicted row is now swapped for a canvas **image ghost** that slides under the red line while alpha-blending into the background — you see the last screenshot fade as it's pushed past the "deleted forever" line.

## Testing

- Tk smoke test drives 3 evict+add cycles with the view scrolled to the bottom: asserts the view stays pinned (`yview >= 0.999` throughout), ghosts fade and are cleaned up, Keep/detail/clear still work, zero Tk callback errors
- Installer script can't be compiled locally (Linux); the `build-windows-installer.yml` run on this push is the compile check, and the real verification is running the built installer over an existing install in the Windows VM — the exact path that crashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)