### PR TITLE
feat(android): email+password sign-up, sign-in, and password reset

### DIFF
--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/MainActivity.kt
@@ -12,6 +12,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -20,6 +23,7 @@ import com.lcarthur.seasonsprint.auth.AuthState
 import com.lcarthur.seasonsprint.auth.AuthViewModel
 import com.lcarthur.seasonsprint.ui.MainScreen
 import com.lcarthur.seasonsprint.ui.SignInScreen
+import com.lcarthur.seasonsprint.ui.SignUpScreen
 import com.lcarthur.seasonsprint.ui.theme.SeasonSprintTheme
 
 class MainActivity : ComponentActivity() {
@@ -46,8 +50,19 @@ fun App(authViewModel: AuthViewModel = viewModel()) {
     val authState by authViewModel.state.collectAsStateWithLifecycle()
     when (authState) {
         AuthState.Loading -> LoadingScreen()
-        AuthState.SignedOut -> SignInScreen()
+        AuthState.SignedOut -> SignedOutGate()
         AuthState.SignedIn -> MainScreen(onSignOut = authViewModel::signOut)
+    }
+}
+
+/** Signed-out flow: sign-in by default, with a local toggle over to sign-up and back. */
+@Composable
+private fun SignedOutGate() {
+    var showSignUp by rememberSaveable { mutableStateOf(false) }
+    if (showSignUp) {
+        SignUpScreen(onSwitchToSignIn = { showSignUp = false })
+    } else {
+        SignInScreen(onSwitchToSignUp = { showSignUp = true })
     }
 }
 

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/auth/SignInViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/auth/SignInViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.clerk.api.Clerk
 import com.clerk.api.network.serialization.onFailure
 import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.network.serialization.shortErrorMessageOrNull
+import com.clerk.api.signin.resetPassword
+import com.clerk.api.signin.sendResetPasswordCode
 import com.clerk.api.signin.verifyCode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,15 +15,16 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
- * Two-step email-code sign-in, mirroring the iOS SignInView:
- *   1. [sendCode] → Clerk.auth.signInWithOtp { email = … }
- *   2. [verify]   → Clerk.auth.currentSignIn.verifyCode(code)
+ * Email + password sign-in with an email-code password-reset flow:
+ *   - [signIn]        → Clerk.auth.signInWithPassword { identifier / password }
+ *   - [sendResetCode] → Clerk.auth.signIn { email } then sendResetPasswordCode
+ *   - [resetPassword] → currentSignIn.verifyCode(code) then resetPassword(newPassword)
  * On success Clerk's userFlow updates and [AuthViewModel] swaps the gate to the dashboard.
  */
 class SignInViewModel : ViewModel() {
 
     data class UiState(
-        val codeSent: Boolean = false,
+        val resetCodeSent: Boolean = false,
         val isWorking: Boolean = false,
         val error: String? = null,
     )
@@ -28,27 +32,70 @@ class SignInViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(UiState())
     val uiState = _uiState.asStateFlow()
 
-    fun sendCode(email: String) {
-        if (email.isBlank()) return
+    fun signIn(email: String, password: String) {
+        if (email.isBlank() || password.isBlank()) return
         _uiState.update { it.copy(isWorking = true, error = null) }
         viewModelScope.launch {
-            Clerk.auth.signInWithOtp { this.email = email.trim() }
-                .onSuccess { _uiState.update { it.copy(isWorking = false, codeSent = true) } }
-                .onFailure {
+            Clerk.auth.signInWithPassword {
+                this.identifier = email.trim()
+                this.password = password
+            }
+                // Clear state on success: the VM is activity-scoped and survives sign-out,
+                // so a stale isWorking would leave the spinner running on the next visit.
+                .onSuccess { _uiState.value = UiState() }
+                .onFailure { failure ->
                     _uiState.update {
-                        it.copy(isWorking = false, error = "Couldn't send a code. Check the email and try again.")
+                        it.copy(
+                            isWorking = false,
+                            error = failure.shortErrorMessageOrNull()
+                                ?: "Couldn't sign in. Check your email and password.",
+                        )
                     }
                 }
         }
     }
 
-    fun verify(code: String) {
+    fun sendResetCode(email: String) {
+        if (email.isBlank()) return
+        _uiState.update { it.copy(isWorking = true, error = null) }
+        viewModelScope.launch {
+            Clerk.auth.signIn { this.email = email.trim() }
+                .onSuccess { signIn ->
+                    signIn.sendResetPasswordCode { this.email = email.trim() }
+                        .onSuccess { _uiState.update { it.copy(isWorking = false, resetCodeSent = true) } }
+                        .onFailure {
+                            _uiState.update {
+                                it.copy(isWorking = false, error = "Couldn't send a reset code. Try again.")
+                            }
+                        }
+                }
+                .onFailure {
+                    _uiState.update {
+                        it.copy(isWorking = false, error = "Couldn't find an account with that email.")
+                    }
+                }
+        }
+    }
+
+    fun resetPassword(code: String, newPassword: String) {
         val signIn = Clerk.auth.currentSignIn
-        if (code.isBlank() || signIn == null) return
+        if (code.isBlank() || newPassword.isBlank() || signIn == null) return
         _uiState.update { it.copy(isWorking = true, error = null) }
         viewModelScope.launch {
             signIn.verifyCode(code.trim())
-                .onSuccess { /* gate switches automatically via userFlow */ }
+                .onSuccess { verified ->
+                    verified.resetPassword(newPassword)
+                        .onSuccess { _uiState.value = UiState() }
+                        .onFailure { failure ->
+                            _uiState.update {
+                                it.copy(
+                                    isWorking = false,
+                                    error = failure.shortErrorMessageOrNull()
+                                        ?: "Couldn't set that password. Try a stronger one.",
+                                )
+                            }
+                        }
+                }
                 .onFailure {
                     _uiState.update {
                         it.copy(isWorking = false, error = "That code didn't work. Try again.")

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/auth/SignUpViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/auth/SignUpViewModel.kt
@@ -1,0 +1,92 @@
+package com.lcarthur.seasonsprint.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
+import com.clerk.api.auth.types.VerificationType
+import com.clerk.api.network.serialization.onFailure
+import com.clerk.api.network.serialization.onSuccess
+import com.clerk.api.network.serialization.shortErrorMessageOrNull
+import com.clerk.api.signup.SignUp
+import com.clerk.api.signup.sendEmailCode
+import com.clerk.api.signup.verifyCode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Two-step email + password sign-up, the registration counterpart of [SignInViewModel]:
+ *   1. [sendCode] → Clerk.auth.signUp { email / password } then signUp.sendEmailCode()
+ *   2. [verify]   → Clerk.auth.currentSignUp.verifyCode(code, EMAIL)
+ * On success Clerk's userFlow updates and [AuthViewModel] swaps the gate to the dashboard.
+ */
+class SignUpViewModel : ViewModel() {
+
+    data class UiState(
+        val codeSent: Boolean = false,
+        val isWorking: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _uiState = MutableStateFlow(UiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun sendCode(email: String, password: String) {
+        if (email.isBlank() || password.isBlank()) return
+        _uiState.update { it.copy(isWorking = true, error = null) }
+        viewModelScope.launch {
+            Clerk.auth.signUp {
+                this.email = email.trim()
+                this.password = password
+            }
+                .onSuccess { signUp ->
+                    signUp.sendEmailCode()
+                        .onSuccess { _uiState.update { it.copy(isWorking = false, codeSent = true) } }
+                        .onFailure {
+                            _uiState.update {
+                                it.copy(isWorking = false, error = "Couldn't send a code. Check the email and try again.")
+                            }
+                        }
+                }
+                .onFailure { failure ->
+                    _uiState.update {
+                        it.copy(
+                            isWorking = false,
+                            error = failure.shortErrorMessageOrNull()
+                                ?: "Couldn't create an account with that email. It may already be in use.",
+                        )
+                    }
+                }
+        }
+    }
+
+    fun verify(code: String) {
+        val signUp = Clerk.auth.currentSignUp
+        if (code.isBlank() || signUp == null) return
+        _uiState.update { it.copy(isWorking = true, error = null) }
+        viewModelScope.launch {
+            signUp.verifyCode(code.trim(), VerificationType.EMAIL)
+                .onSuccess { result ->
+                    if (result.status != SignUp.Status.COMPLETE) {
+                        _uiState.update {
+                            it.copy(isWorking = false, error = "Something's missing from the sign-up. Try again.")
+                        }
+                    } else {
+                        // Clear state: the VM is activity-scoped and survives sign-out, so stale
+                        // codeSent/isWorking would otherwise resurface on the next visit.
+                        _uiState.value = UiState()
+                    }
+                }
+                .onFailure {
+                    _uiState.update {
+                        it.copy(isWorking = false, error = "That code didn't work. Try again.")
+                    }
+                }
+        }
+    }
+
+    fun reset() {
+        _uiState.value = UiState()
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SignInScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SignInScreen.kt
@@ -94,12 +94,6 @@ fun SignInScreen(
                 if (state.isWorking) CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
                 else Text("Sign in")
             }
-            TextButton(
-                onClick = { viewModel.sendResetCode(email) },
-                enabled = email.isNotBlank() && !state.isWorking,
-            ) {
-                Text("Forgot password?")
-            }
         } else {
             Text(
                 "Enter the code sent to $email and choose a new password",
@@ -149,8 +143,17 @@ fun SignInScreen(
         }
 
         if (!state.resetCodeSent) {
-            TextButton(onClick = onSwitchToSignUp) {
-                Text("Don't have an account? Sign up")
+            // Grouped without the outer 16.dp spacing so the two links sit close together.
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                TextButton(
+                    onClick = { viewModel.sendResetCode(email) },
+                    enabled = email.isNotBlank() && !state.isWorking,
+                ) {
+                    Text("Forgot password?")
+                }
+                TextButton(onClick = onSwitchToSignUp) {
+                    Text("Don't have an account? Sign up")
+                }
             }
         }
     }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SignUpScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/SignUpScreen.kt
@@ -30,22 +30,23 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.lcarthur.seasonsprint.auth.SignInViewModel
+import com.lcarthur.seasonsprint.auth.SignUpViewModel
 
 /**
- * Email + password sign-in with a "Forgot password?" email-code reset flow. On success the
- * auth gate swaps to the dashboard automatically.
+ * Minimal email-code sign-up, the registration counterpart of [SignInScreen]: enter email →
+ * send code → enter code → verify. On success the auth gate swaps to the dashboard automatically.
  */
 @Composable
-fun SignInScreen(
-    onSwitchToSignUp: () -> Unit,
-    viewModel: SignInViewModel = viewModel(),
+fun SignUpScreen(
+    onSwitchToSignIn: () -> Unit,
+    viewModel: SignUpViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
     var code by remember { mutableStateOf("") }
-    var newPassword by remember { mutableStateOf("") }
+    val passwordsMismatch = confirmPassword.isNotEmpty() && password != confirmPassword
 
     Column(
         modifier = Modifier
@@ -63,12 +64,12 @@ fun SignInScreen(
         )
         Text("Season Sprint", style = MaterialTheme.typography.headlineMedium)
         Text(
-            "Sign in to view your season progress",
+            "Create an account to track your season progress",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        if (!state.resetCodeSent) {
+        if (!state.codeSent) {
             OutlinedTextField(
                 value = email,
                 onValueChange = { email = it },
@@ -86,23 +87,31 @@ fun SignInScreen(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                 modifier = Modifier.fillMaxWidth(),
             )
+            OutlinedTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = { Text("Confirm password") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                isError = passwordsMismatch,
+                supportingText = if (passwordsMismatch) {
+                    { Text("Passwords don't match") }
+                } else null,
+                modifier = Modifier.fillMaxWidth(),
+            )
             Button(
-                onClick = { viewModel.signIn(email, password) },
-                enabled = email.isNotBlank() && password.isNotBlank() && !state.isWorking,
+                onClick = { viewModel.sendCode(email, password) },
+                enabled = email.isNotBlank() && password.isNotBlank() &&
+                    password == confirmPassword && !state.isWorking,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (state.isWorking) CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                else Text("Sign in")
-            }
-            TextButton(
-                onClick = { viewModel.sendResetCode(email) },
-                enabled = email.isNotBlank() && !state.isWorking,
-            ) {
-                Text("Forgot password?")
+                else Text("Create account")
             }
         } else {
             Text(
-                "Enter the code sent to $email and choose a new password",
+                "Enter the code sent to $email",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -114,29 +123,19 @@ fun SignInScreen(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                 modifier = Modifier.fillMaxWidth(),
             )
-            OutlinedTextField(
-                value = newPassword,
-                onValueChange = { newPassword = it },
-                label = { Text("New password") },
-                singleLine = true,
-                visualTransformation = PasswordVisualTransformation(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                modifier = Modifier.fillMaxWidth(),
-            )
             Button(
-                onClick = { viewModel.resetPassword(code, newPassword) },
-                enabled = code.isNotBlank() && newPassword.isNotBlank() && !state.isWorking,
+                onClick = { viewModel.verify(code) },
+                enabled = code.isNotBlank() && !state.isWorking,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (state.isWorking) CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
-                else Text("Reset password")
+                else Text("Verify")
             }
             TextButton(onClick = {
                 code = ""
-                newPassword = ""
                 viewModel.reset()
             }) {
-                Text("Back to sign in")
+                Text("Use a different email")
             }
         }
 
@@ -148,10 +147,8 @@ fun SignInScreen(
             )
         }
 
-        if (!state.resetCodeSent) {
-            TextButton(onClick = onSwitchToSignUp) {
-                Text("Don't have an account? Sign up")
-            }
+        TextButton(onClick = onSwitchToSignIn) {
+            Text("Already have an account? Sign in")
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a full password-based auth experience to the Android app, replacing the email-OTP sign-in:

- **Sign-up flow** (new): email + password + confirm-password → email-code verification → signed in. Client-side confirm field blocks submission until the passwords match; Clerk's own error messages (weak password, email in use) surface inline.
- **Sign-in**: now email + password via `signInWithPassword` instead of email OTP.
- **Forgot password?**: email-code reset flow — enter email → receive code → enter code + new password → signed in immediately.
- The signed-out gate toggles between sign-in and sign-up screens (`rememberSaveable`, survives rotation).

## Bug fixes

- Button spinners wobbled: `Modifier.height(20.dp)` constrained only height so the indicator drew in a 40×20 box with an off-center orbit. Now `size(20.dp)` + 2dp stroke.
- Eternal spinner after sign-out: the activity-scoped auth ViewModels kept stale `isWorking`/`codeSent` after a successful flow, so returning to the sign-in screen showed a stuck spinner. State now resets on success.
- Tightened spacing between the sign-in footer links.

## Config dependency

Requires **"Sign-in with password"** enabled on the Clerk instance (already done in the dashboard). Email-code sign-in remains enabled, so the iOS OTP flow is unaffected; the web prebuilt component adapts automatically.

## Testing

Manually tested end-to-end on the `season_sprint` emulator: sign-up with email verification, sign-in, wrong-password error, password reset via emailed code, sign-out/sign-in round trip, rotation during flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account creation with email, password, confirmation, and email verification.
  * Replaced code-based sign-in with email-and-password authentication.
  * Added password reset flow with verification code and new password entry.
  * Added navigation between sign-in and sign-up screens.
  * Added loading indicators and error messages during authentication actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->