### PR TITLE
chore(android): versionName 1.1.0 + tracks input fix

### DIFF
--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -81,5 +81,5 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.lcarthur.seasonsprint
           releaseFiles: packages/android/app/build/outputs/bundle/release/app-release.aab
-          track: alpha
+          tracks: alpha
           status: completed

--- a/packages/android/app/build.gradle.kts
+++ b/packages/android/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
         // CI (deploy-android.yml) overrides versionCode with the main-branch commit
         // count so every Play upload has a strictly increasing code.
         versionCode = System.getenv("ANDROID_VERSION_CODE")?.toIntOrNull() ?: 1
-        versionName = "0.1.0"
+        versionName = "1.1.0"
     }
 
     signingConfigs {


### PR DESCRIPTION
- Bump `versionName` 0.1.0 → **1.1.0** (continues from the manually-uploaded 1.0.1; covers the password-auth release). Version code is CI-derived and unaffected.
- Migrate the deploy workflow's deprecated `track:` input to `tracks:`.

Merging this triggers a fresh closed-testing deploy, doubling as the pipeline's second end-to-end run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)