### PR TITLE
feat(web): enable sign-up in the Clerk sign-in widget

### DIFF
--- a/packages/web/src/components/SignInView.vue
+++ b/packages/web/src/components/SignInView.vue
@@ -20,15 +20,17 @@ const appearance = {
   <main class="signin-view">
     <div class="signin-brand">
       <img src="/logo-transparent.svg" alt="" class="signin-logo" />
-      <h1 class="signin-title">Sign in to Season Sprint</h1>
+      <h1 class="signin-title">Welcome to Season Sprint</h1>
       <p class="signin-tagline">
         Track your World Tour points and sync across all your devices.
       </p>
     </div>
     <div class="signin-widget">
       <!-- routing="hash" keeps the whole flow on app.seasonsprint.com without a
-           dedicated route, so the user never leaves the site to sign in. -->
-      <SignIn routing="hash" :appearance="appearance" />
+           dedicated route, so the user never leaves the site to sign in.
+           with-sign-up enables Clerk's combined flow: sign-up (email + password
+           + email-code verification) happens in this same widget. -->
+      <SignIn routing="hash" with-sign-up :appearance="appearance" />
     </div>
   </main>
 </template>


### PR DESCRIPTION
## Summary

Brings the web app to parity with the Android password-auth work: enables account creation directly in the sign-in view by passing `with-sign-up` to Clerk's prebuilt `<SignIn>` component.

Because web uses Clerk's hosted widget (not a hand-built form like Android), this one flag is the whole change — Clerk generates password + email + confirm-password fields, email-code verification, and a "Forgot password?" link automatically, driven by the same instance settings we configured for Android (password required, password sign-in enabled).

- `with-sign-up` on `<SignIn>` → combined sign-in / sign-up flow in a single widget, no extra route.
- Heading updated "Sign in to Season Sprint" → "Welcome to Season Sprint" since it now covers both directions.

## Testing

Lint passes. Confirmed `with-sign-up` is a supported prop in the installed `@clerk/vue@1.13.0`. Not visually verifiable locally: the app intentionally disables Clerk on `localhost` with a `pk_live_` key, and Clerk's production instance only initializes on allow-listed origins (`app.seasonsprint.com`), so the widget must be checked on the deployed site after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sign-up access directly within the sign-in flow.
  * Updated the sign-in page branding to “Welcome to Season Sprint.”


<!-- end of auto-generated comment: release notes by coderabbit.ai -->