### PR TITLE
feat: prompt new users for their current win points on first launch

### DIFF
--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
@@ -1,0 +1,96 @@
+package com.lcarthur.seasonsprint.state
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.lcarthur.seasonsprint.GameMode
+import com.lcarthur.seasonsprint.data.ApiClient
+import com.lcarthur.seasonsprint.domain.DateKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class OnboardingState(
+    /** null until the check completes, so the caller can hold the dashboard back. */
+    val isNeeded: Boolean? = null,
+    val isSaving: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * Decides whether to show the first-launch "enter your current totals" prompt, and saves what
+ * the user enters as today's record in each mode. Mirrors iOS OnboardingStore.
+ *
+ * A user is considered new when they have no records at all, in either mode — detection is
+ * server-side so it holds across devices and platforms, rather than re-prompting after every
+ * reinstall. The dismissed flag exists only to stop nagging someone who genuinely has zero
+ * points and chose to skip; they'd otherwise see the prompt on every launch.
+ */
+class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
+    private val prefs = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    private val _state = MutableStateFlow(OnboardingState())
+    val state = _state.asStateFlow()
+
+    init {
+        check()
+    }
+
+    private fun check() {
+        if (prefs.getBoolean(KEY_DISMISSED, false)) {
+            _state.update { it.copy(isNeeded = false) }
+            return
+        }
+        viewModelScope.launch {
+            val needed = try {
+                GameMode.entries.all { ApiClient.getRecords(it).isEmpty() }
+            } catch (e: Exception) {
+                // Never let a failed probe block the app — fall through to the dashboard,
+                // which surfaces its own load error if the API is genuinely down.
+                false
+            }
+            _state.update { it.copy(isNeeded = needed) }
+        }
+    }
+
+    /**
+     * Persist the totals the user filled in as today's record, one per mode. [values] only
+     * carries the modes they actually entered — a player who only plays one mode shouldn't get
+     * a phantom 0 in the other, which would anchor that mode's graph and pace at zero.
+     */
+    fun save(values: Map<GameMode, Int>) {
+        _state.update { it.copy(isSaving = true, error = null) }
+        viewModelScope.launch {
+            try {
+                val today = DateKey.today()
+                values.forEach { (mode, winPoints) ->
+                    ApiClient.upsertRecord(today, winPoints, mode)
+                }
+                dismiss()
+            } catch (e: Exception) {
+                _state.update { it.copy(isSaving = false, error = "Could not save. Please try again.") }
+            }
+        }
+    }
+
+    fun skip() = dismiss()
+
+    private fun dismiss() {
+        prefs.edit().putBoolean(KEY_DISMISSED, true).apply()
+        _state.update { it.copy(isNeeded = false, isSaving = false, error = null) }
+    }
+
+    class Factory(private val app: Application) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T =
+            OnboardingViewModel(app) as T
+    }
+
+    private companion object {
+        const val PREFS = "onboarding"
+        const val KEY_DISMISSED = "onboarding.dismissed"
+    }
+}

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
@@ -26,8 +26,9 @@ data class OnboardingState(
  *
  * A user is considered new when they have no records at all, in either mode — detection is
  * server-side so it holds across devices and platforms, rather than re-prompting after every
- * reinstall. The dismissed flag exists only to stop nagging someone who genuinely has zero
- * points and chose to skip; they'd otherwise see the prompt on every launch.
+ * reinstall. The resolved flag marks onboarding as settled by any route — saved, skipped, or
+ * found to already have records — so later launches skip the probe entirely instead of
+ * refetching every mode just to rediscover the user isn't new.
  */
 class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     private val prefs = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
@@ -40,7 +41,7 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private fun check() {
-        if (prefs.getBoolean(KEY_DISMISSED, false)) {
+        if (prefs.getBoolean(KEY_RESOLVED, false)) {
             _state.update { it.copy(isNeeded = false) }
             return
         }
@@ -51,6 +52,11 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
                 // Never let a failed probe block the app — fall through to the dashboard,
                 // which surfaces its own load error if the API is genuinely down.
                 false
+            }
+            if (!needed) {
+                // Already has data, so they're settled — record that so later launches skip
+                // this probe instead of re-asking the server every time.
+                markResolved()
             }
             _state.update { it.copy(isNeeded = needed) }
         }
@@ -79,8 +85,12 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     fun skip() = dismiss()
 
     private fun dismiss() {
-        prefs.edit().putBoolean(KEY_DISMISSED, true).apply()
+        markResolved()
         _state.update { it.copy(isNeeded = false, isSaving = false, error = null) }
+    }
+
+    private fun markResolved() {
+        prefs.edit().putBoolean(KEY_RESOLVED, true).apply()
     }
 
     class Factory(private val app: Application) : ViewModelProvider.Factory {
@@ -91,6 +101,6 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
 
     private companion object {
         const val PREFS = "onboarding"
-        const val KEY_DISMISSED = "onboarding.dismissed"
+        const val KEY_RESOLVED = "onboarding.resolved"
     }
 }

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/state/OnboardingViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.clerk.api.Clerk
 import com.lcarthur.seasonsprint.GameMode
 import com.lcarthur.seasonsprint.data.ApiClient
 import com.lcarthur.seasonsprint.domain.DateKey
@@ -29,9 +30,20 @@ data class OnboardingState(
  * reinstall. The resolved flag marks onboarding as settled by any route — saved, skipped, or
  * found to already have records — so later launches skip the probe entirely instead of
  * refetching every mode just to rediscover the user isn't new.
+ *
+ * That flag is scoped per user id: signing out leaves it behind, so a single global key would
+ * let the first account to resolve onboarding silently suppress it for anyone who signs in on
+ * the device afterwards — dropping a genuinely new user onto a zero graph.
  */
 class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     private val prefs = app.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    /**
+     * Per-user key, or null if the signed-in user can't be identified — in which case we fail
+     * safe by probing rather than trusting a flag that may belong to another account.
+     */
+    private val resolvedKey: String?
+        get() = Clerk.userFlow.value?.id?.let { "$KEY_RESOLVED.$it" }
 
     private val _state = MutableStateFlow(OnboardingState())
     val state = _state.asStateFlow()
@@ -41,7 +53,7 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private fun check() {
-        if (prefs.getBoolean(KEY_RESOLVED, false)) {
+        if (resolvedKey?.let { prefs.getBoolean(it, false) } == true) {
             _state.update { it.copy(isNeeded = false) }
             return
         }
@@ -90,7 +102,7 @@ class OnboardingViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private fun markResolved() {
-        prefs.edit().putBoolean(KEY_RESOLVED, true).apply()
+        resolvedKey?.let { prefs.edit().putBoolean(it, true).apply() }
     }
 
     class Factory(private val app: Application) : ViewModelProvider.Factory {

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/FormFields.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/FormFields.kt
@@ -36,12 +36,12 @@ fun DateField(label: String, dateMillis: Long, onClick: () -> Unit) {
 
 /** Numeric win-points input (digits only). */
 @Composable
-fun WinPointsField(value: String, onValueChange: (String) -> Unit) {
+fun WinPointsField(value: String, onValueChange: (String) -> Unit, label: String = "Win points") {
     val scheme = MaterialTheme.colorScheme
     OutlinedTextField(
         value = value,
         onValueChange = { input -> onValueChange(input.filter { it.isDigit() }) },
-        label = { Text("Win points") },
+        label = { Text(label) },
         singleLine = true,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         modifier = Modifier.fillMaxWidth(),

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/MainScreen.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lcarthur.seasonsprint.GameMode
 import com.lcarthur.seasonsprint.state.DashboardViewModel
+import com.lcarthur.seasonsprint.state.OnboardingViewModel
 import com.lcarthur.seasonsprint.state.SettingsViewModel
 
 private enum class Tab(val label: String, val icon: ImageVector) {
@@ -73,9 +74,16 @@ fun MainScreen(onSignOut: () -> Unit) {
     val dashboardViewModel = dashboardViewModels.getValue(mode)
     val settingsViewModel = settingsViewModels.getValue(mode)
 
+    val onboardingViewModel = viewModel<OnboardingViewModel>(factory = OnboardingViewModel.Factory(app))
+    val onboarding by onboardingViewModel.state.collectAsStateWithLifecycle()
+
     // Only the active mode's VM keeps its records fresh and its WebSocket open; the inactive
     // one is paused (it still holds its last-loaded state, so switching back is instant).
-    LaunchedEffect(mode) {
+    // Keyed on the onboarding state as well as the mode so that finishing onboarding re-runs
+    // the load — otherwise the dashboard would show the empty result fetched before the
+    // starting totals were saved.
+    LaunchedEffect(mode, onboarding.isNeeded) {
+        if (onboarding.isNeeded != false) return@LaunchedEffect
         dashboardViewModels.forEach { (m, vm) -> if (m != mode) vm.pauseLive() }
         dashboardViewModel.load()
         dashboardViewModel.resumeLive()
@@ -85,6 +93,20 @@ fun MainScreen(onSignOut: () -> Unit) {
     val settings by settingsViewModel.state.collectAsStateWithLifecycle()
     var selected by remember { mutableStateOf(Tab.Graph) }
     var showSettings by remember { mutableStateOf(false) }
+
+    // Hold the dashboard back until we know whether this is a new user, so the graph doesn't
+    // flash into view and then get replaced by the prompt.
+    when (onboarding.isNeeded) {
+        null -> {
+            BrandedLoadingScreen(message = "Loading your season…")
+            return
+        }
+        true -> {
+            OnboardingScreen(onboardingViewModel)
+            return
+        }
+        else -> Unit
+    }
 
     if (!state.hasLoaded) {
         BrandedLoadingScreen(message = "Loading your season…")

--- a/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/OnboardingScreen.kt
+++ b/packages/android/app/src/main/java/com/lcarthur/seasonsprint/ui/OnboardingScreen.kt
@@ -1,0 +1,110 @@
+package com.lcarthur.seasonsprint.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lcarthur.seasonsprint.GameMode
+import com.lcarthur.seasonsprint.state.OnboardingViewModel
+
+/**
+ * First-launch prompt asking a new user for their current season totals, so their graph starts
+ * from where they actually are instead of zero. Either mode may be left blank.
+ * Mirrors iOS OnboardingView.swift and the web's OnboardingPrompt.vue.
+ */
+@Composable
+fun OnboardingScreen(viewModel: OnboardingViewModel, modifier: Modifier = Modifier) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    // Kept as strings so a blank field stays blank ("don't record this mode") rather than
+    // coercing to 0, which would anchor that mode's graph and pace at zero.
+    val entries = remember { mutableStateMapOf<GameMode, String>() }
+
+    val values = GameMode.entries.mapNotNull { mode ->
+        entries[mode]?.trim()?.toIntOrNull()?.let { mode to it }
+    }.toMap()
+
+    // At least one total is needed — otherwise "Get started" would do nothing that
+    // "Skip for now" doesn't already do.
+    val canSave = values.isNotEmpty() && !state.isSaving
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("Welcome to Season Sprint", style = MaterialTheme.typography.headlineSmall)
+        Text(
+            "Enter your current total win points so your graph starts from where you actually " +
+                "are. You can leave a mode blank if you don't play it.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        GameMode.entries.forEach { mode ->
+            WinPointsField(
+                value = entries[mode] ?: "",
+                onValueChange = { entries[mode] = it },
+                label = mode.label,
+            )
+        }
+
+        state.error?.let { error ->
+            Text(error, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+
+        Text(
+            "Saved as today's entry — you can edit it any time.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Button(
+            onClick = { viewModel.save(values) },
+            enabled = canSave,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (state.isSaving) {
+                CircularProgressIndicator(
+                    modifier = Modifier.height(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            } else {
+                Text("Get started")
+            }
+        }
+
+        TextButton(
+            onClick = { viewModel.skip() },
+            enabled = !state.isSaving,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text("Skip for now")
+        }
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Observation
+
+/// Decides whether to show the first-launch "enter your current totals" prompt, and saves
+/// what the user enters as today's record in each mode.
+///
+/// A user is considered new when they have no records at all, in either mode — detection is
+/// server-side so it holds across devices and platforms, rather than re-prompting after every
+/// reinstall. `dismissedKey` exists only to stop nagging someone who genuinely has zero points
+/// and chose to skip; they'd otherwise see the prompt on every launch.
+@MainActor
+@Observable
+final class OnboardingStore {
+    /// nil until the check completes, so the caller can hold the dashboard back instead of
+    /// flashing it and then covering it with the prompt.
+    private(set) var isNeeded: Bool?
+    private(set) var isSaving = false
+    private(set) var errorMessage: String?
+
+    private let defaults = UserDefaults.standard
+    private let dismissedKey = "onboarding.dismissed"
+
+    func check() async {
+        if defaults.bool(forKey: dismissedKey) {
+            isNeeded = false
+            return
+        }
+        do {
+            var hasAny = false
+            for mode in GameMode.allCases {
+                let records = try await APIClient.getRecords(mode: mode)
+                if !records.isEmpty {
+                    hasAny = true
+                    break
+                }
+            }
+            isNeeded = !hasAny
+        } catch {
+            // Never let a failed probe block the app — fall through to the dashboard, which
+            // surfaces its own load error if the API is genuinely down.
+            isNeeded = false
+        }
+    }
+
+    /// Persist the totals the user filled in as today's record, one per mode. `values` only
+    /// carries the modes they actually entered — a player who only plays one mode shouldn't
+    /// get a phantom 0 in the other, which would anchor that mode's graph and pace at zero.
+    func save(_ values: [GameMode: Int]) async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+        do {
+            let today = Self.todayString()
+            for (mode, winPoints) in values {
+                _ = try await APIClient.upsertRecord(date: today, winPoints: winPoints, mode: mode)
+            }
+            dismiss()
+        } catch {
+            errorMessage = "Could not save. Please try again."
+        }
+    }
+
+    func skip() {
+        dismiss()
+    }
+
+    private func dismiss() {
+        defaults.set(true, forKey: dismissedKey)
+        isNeeded = false
+    }
+
+    /// Today in the device's local timezone as `YYYY-MM-DD`, matching the date-only wire
+    /// format the server expects (see packages/shared/src/records.ts).
+    private static func todayString() -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+}

--- a/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
@@ -1,14 +1,19 @@
 import Foundation
 import Observation
+import ClerkKit
 
 /// Decides whether to show the first-launch "enter your current totals" prompt, and saves
 /// what the user enters as today's record in each mode.
 ///
 /// A user is considered new when they have no records at all, in either mode — detection is
 /// server-side so it holds across devices and platforms, rather than re-prompting after every
-/// reinstall. `resolvedKey` marks onboarding as settled by any route — saved, skipped, or
+/// reinstall. The resolved flag marks onboarding as settled by any route — saved, skipped, or
 /// found to already have records — so later launches skip the probe entirely instead of
 /// refetching every mode just to rediscover the user isn't new.
+///
+/// That flag is scoped per user id: signing out leaves it behind, so a single global key would
+/// let the first account to resolve onboarding silently suppress it for anyone who signs in on
+/// the device afterwards — dropping a genuinely new user onto a zero graph.
 @MainActor
 @Observable
 final class OnboardingStore {
@@ -19,10 +24,16 @@ final class OnboardingStore {
     private(set) var errorMessage: String?
 
     private let defaults = UserDefaults.standard
-    private let resolvedKey = "onboarding.resolved"
+
+    /// Per-user key, or nil if the signed-in user can't be identified — in which case we
+    /// fail safe by probing rather than trusting a flag that may belong to another account.
+    private var resolvedKey: String? {
+        guard let userId = Clerk.shared.user?.id else { return nil }
+        return "onboarding.resolved.\(userId)"
+    }
 
     func check() async {
-        if defaults.bool(forKey: resolvedKey) {
+        if let key = resolvedKey, defaults.bool(forKey: key) {
             isNeeded = false
             return
         }
@@ -76,7 +87,8 @@ final class OnboardingStore {
     }
 
     private func markResolved() {
-        defaults.set(true, forKey: resolvedKey)
+        guard let key = resolvedKey else { return }
+        defaults.set(true, forKey: key)
     }
 
     /// Today in the device's local timezone as `YYYY-MM-DD`, matching the date-only wire

--- a/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
+++ b/packages/ios/Sources/SeasonSprint/State/OnboardingStore.swift
@@ -6,8 +6,9 @@ import Observation
 ///
 /// A user is considered new when they have no records at all, in either mode — detection is
 /// server-side so it holds across devices and platforms, rather than re-prompting after every
-/// reinstall. `dismissedKey` exists only to stop nagging someone who genuinely has zero points
-/// and chose to skip; they'd otherwise see the prompt on every launch.
+/// reinstall. `resolvedKey` marks onboarding as settled by any route — saved, skipped, or
+/// found to already have records — so later launches skip the probe entirely instead of
+/// refetching every mode just to rediscover the user isn't new.
 @MainActor
 @Observable
 final class OnboardingStore {
@@ -18,10 +19,10 @@ final class OnboardingStore {
     private(set) var errorMessage: String?
 
     private let defaults = UserDefaults.standard
-    private let dismissedKey = "onboarding.dismissed"
+    private let resolvedKey = "onboarding.resolved"
 
     func check() async {
-        if defaults.bool(forKey: dismissedKey) {
+        if defaults.bool(forKey: resolvedKey) {
             isNeeded = false
             return
         }
@@ -35,6 +36,11 @@ final class OnboardingStore {
                 }
             }
             isNeeded = !hasAny
+            if hasAny {
+                // Already has data, so they're settled — record that so later launches
+                // skip this probe instead of re-asking the server every time.
+                markResolved()
+            }
         } catch {
             // Never let a failed probe block the app — fall through to the dashboard, which
             // surfaces its own load error if the API is genuinely down.
@@ -65,8 +71,12 @@ final class OnboardingStore {
     }
 
     private func dismiss() {
-        defaults.set(true, forKey: dismissedKey)
+        markResolved()
         isNeeded = false
+    }
+
+    private func markResolved() {
+        defaults.set(true, forKey: resolvedKey)
     }
 
     /// Today in the device's local timezone as `YYYY-MM-DD`, matching the date-only wire

--- a/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/MainTabView.swift
@@ -3,6 +3,13 @@ import ClerkKit
 
 private let lastModeKey = "ui.lastMode"
 
+/// Composite `task(id:)` key so the records load re-runs both on a mode switch and once
+/// onboarding resolves.
+private struct LoadKey: Equatable {
+    let mode: GameMode
+    let isOnboardingNeeded: Bool?
+}
+
 /// Signed-in root: a mode switcher (World Tour / Ranked) above a Graph/Log/Details tab
 /// view. Both modes get their own `DashboardStore`/`AppSettings` instance (mirroring the
 /// web app's separate WorldTour.vue/Ranked.vue view instances), so each mode keeps its own
@@ -14,6 +21,7 @@ struct MainTabView: View {
     @State private var stores: [GameMode: DashboardStore]
     @State private var settingsByMode: [GameMode: AppSettings]
     @State private var showSettings = false
+    @State private var onboarding = OnboardingStore()
 
     init() {
         let saved = UserDefaults.standard.string(forKey: lastModeKey).flatMap(GameMode.init(rawValue:)) ?? .worldTour
@@ -27,7 +35,13 @@ struct MainTabView: View {
 
     var body: some View {
         Group {
-            if store.hasLoaded {
+            if onboarding.isNeeded == nil {
+                // Hold the dashboard back until we know whether this is a new user, so the
+                // graph doesn't flash into view and then get replaced by the prompt.
+                BrandedLoadingView(message: "Loading your season…")
+            } else if onboarding.isNeeded == true {
+                OnboardingView(store: onboarding)
+            } else if store.hasLoaded {
                 VStack(spacing: 0) {
                     ModeSwitcherView(selected: $mode)
                     TabView {
@@ -44,7 +58,12 @@ struct MainTabView: View {
                 BrandedLoadingView(message: "Loading your season…")
             }
         }
-        .task(id: mode) {
+        .task { await onboarding.check() }
+        // Keyed on the onboarding state as well as the mode so that finishing onboarding
+        // re-runs the load — otherwise the dashboard would show the empty result fetched
+        // before the starting totals were saved.
+        .task(id: LoadKey(mode: mode, isOnboardingNeeded: onboarding.isNeeded)) {
+            guard onboarding.isNeeded == false else { return }
             UserDefaults.standard.set(mode.rawValue, forKey: lastModeKey)
             for (m, s) in stores where m != mode { s.pauseLive() }
             await store.load()

--- a/packages/ios/Sources/SeasonSprint/Views/OnboardingView.swift
+++ b/packages/ios/Sources/SeasonSprint/Views/OnboardingView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// First-launch prompt asking a new user for their current season totals, so their graph
+/// starts from where they actually are instead of zero. Either mode may be left blank.
+struct OnboardingView: View {
+    let store: OnboardingStore
+
+    // Kept as strings so a blank field stays blank ("don't record this mode") rather than
+    // coercing to 0, which would anchor that mode's graph and pace at zero.
+    @State private var entries: [GameMode: String] = [:]
+    @FocusState private var focusedMode: GameMode?
+
+    private var enteredValues: [GameMode: Int] {
+        var result: [GameMode: Int] = [:]
+        for mode in GameMode.allCases {
+            let raw = (entries[mode] ?? "").trimmingCharacters(in: .whitespaces)
+            if !raw.isEmpty, let value = Int(raw) {
+                result[mode] = value
+            }
+        }
+        return result
+    }
+
+    // At least one total is needed — otherwise "Get started" would do nothing that
+    // "Skip for now" doesn't already do.
+    private var canSave: Bool { !enteredValues.isEmpty }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Welcome to Season Sprint")
+                            .font(.title2.bold())
+                        Text("Enter your current total win points so your graph starts from where you actually are. You can leave a mode blank if you don't play it.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    VStack(spacing: 16) {
+                        ForEach(GameMode.allCases, id: \.self) { mode in
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(mode.label.uppercased())
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                                TextField(
+                                    "points",
+                                    text: Binding(
+                                        get: { entries[mode] ?? "" },
+                                        set: { entries[mode] = $0 }
+                                    )
+                                )
+                                .keyboardType(.numberPad)
+                                .textFieldStyle(.roundedBorder)
+                                .focused($focusedMode, equals: mode)
+                            }
+                        }
+                    }
+
+                    if let errorMessage = store.errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.red)
+                    }
+
+                    Text("Saved as today's entry — you can edit it any time.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(24)
+            }
+
+            VStack(spacing: 10) {
+                Button {
+                    Task { await store.save(enteredValues) }
+                } label: {
+                    if store.isSaving {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Get started")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(!canSave || store.isSaving)
+
+                Button("Skip for now") { store.skip() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .disabled(store.isSaving)
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { focusedMode = nil }
+            }
+        }
+    }
+}

--- a/packages/web/src/App.vue
+++ b/packages/web/src/App.vue
@@ -22,7 +22,7 @@
     <ClerkLoaded>
       <SignedIn>
         <main class="container">
-          <router-view />
+          <AppBody />
         </main>
       </SignedIn>
       <SignedOut>
@@ -31,7 +31,7 @@
     </ClerkLoaded>
   </template>
   <main v-else class="container">
-    <router-view />
+    <AppBody />
   </main>
   <footer class="site-footer" role="contentinfo">
     <div>Created by Luke Arthur (Aireal) 2025</div>
@@ -44,6 +44,7 @@ import { watch } from "vue";
 import { useAuth } from "@clerk/vue";
 import HeaderBar from "./components/HeaderBar.vue";
 import SignInView from "./components/SignInView.vue";
+import AppBody from "./components/AppBody.vue";
 import {
   ClerkLoading,
   ClerkLoaded,
@@ -59,6 +60,7 @@ export default {
   components: {
     HeaderBar,
     SignInView,
+    AppBody,
     ClerkLoading,
     ClerkLoaded,
     SignedIn,

--- a/packages/web/src/components/AppBody.vue
+++ b/packages/web/src/components/AppBody.vue
@@ -1,0 +1,42 @@
+<template>
+  <!-- Hold the dashboard back until we know whether this is a new user, so the
+       graph doesn't flash into view and then get replaced by the prompt. -->
+  <div v-if="!isResolved" class="auth-loading" role="status" aria-live="polite">
+    <span class="auth-spinner" aria-hidden="true"></span>
+    <span class="auth-loading-sr">Loading…</span>
+  </div>
+  <OnboardingPrompt
+    v-else-if="needed"
+    :modes="modes"
+    :is-saving="isSaving"
+    :save-error="saveError"
+    @save="save"
+    @skip="skip"
+  />
+  <router-view v-else />
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from "vue";
+import OnboardingPrompt from "./OnboardingPrompt.vue";
+import { useOnboarding } from "@/composables/useOnboarding";
+import { useFlags } from "@/composables/useFlags";
+
+const { flags, loaded, loadFlags } = useFlags();
+const { needed, isResolved, isSaving, saveError, check, save, skip } =
+  useOnboarding();
+
+// Ranked is flag-gated on web, so a user without it is neither asked for a
+// Ranked total nor held in onboarding by Ranked data they can't create.
+// Resolved once, at mount, so the prompt's fields can't change underneath the
+// user mid-entry if flags reload.
+const promptModes = ref(["world-tour"]);
+const modes = computed(() => promptModes.value);
+
+onMounted(async () => {
+  // Shares the in-flight request with the app-level load; safe to call again.
+  if (!loaded.value) await loadFlags();
+  promptModes.value = flags.ranked ? ["world-tour", "ranked"] : ["world-tour"];
+  await check(promptModes.value);
+});
+</script>

--- a/packages/web/src/components/HeaderBar.vue
+++ b/packages/web/src/components/HeaderBar.vue
@@ -4,12 +4,18 @@ import { SignedIn } from "@clerk/vue";
 import UserMenu from "@/components/UserMenu.vue";
 import ModeSwitcher from "@/components/ModeSwitcher.vue";
 import { isClerkEnabled } from "@/services/clerk";
+import { useOnboarding } from "@/composables/useOnboarding";
 
 // The signed-out redirect is handled in App.vue alongside the content gate.
 const clerkEnabled = isClerkEnabled();
 // The mode switcher lives in the title bar, shown only on routes that opt in
 // via `meta.modeSwitcher` (World Tour / Ranked).
 const route = useRoute();
+// ...and only once the dashboard itself is up. While the onboarding prompt or
+// its preceding check is on screen, switching modes would just change the route
+// underneath the prompt without dismissing it. This also keeps the switcher out
+// of the signed-out view, where the shell never mounts.
+const { isDashboardVisible } = useOnboarding();
 </script>
 
 <template>
@@ -18,7 +24,10 @@ const route = useRoute();
       <img src="/logo-transparent.svg" alt="Season Sprint logo" class="brand-logo" />
       <span class="brand-text"><span class="brand-accent">THE</span>&nbsp;FINALS</span> <span class="brand-sep">|</span> <span class="brand-text">Season Sprint</span>
     </router-link>
-    <ModeSwitcher v-if="route.meta.modeSwitcher" class="header-mode" />
+    <ModeSwitcher
+      v-if="route.meta.modeSwitcher && isDashboardVisible"
+      class="header-mode"
+    />
     <div class="user-actions">
       <template v-if="clerkEnabled">
         <SignedIn>

--- a/packages/web/src/components/OnboardingPrompt.vue
+++ b/packages/web/src/components/OnboardingPrompt.vue
@@ -1,0 +1,183 @@
+<template>
+  <section class="onboarding" aria-labelledby="onboarding-title">
+    <div class="ob-card">
+      <h2 id="onboarding-title">Welcome to Season Sprint</h2>
+      <p class="ob-lede">
+        Enter your current total win points so your graph starts from where you
+        actually are. You can leave a mode blank if you don't play it.
+      </p>
+
+      <form class="ob-form" @submit.prevent="onSave">
+        <label class="ob-field">
+          <span class="ob-label">World Tour</span>
+          <input
+            v-model="worldTour"
+            type="number"
+            step="any"
+            inputmode="numeric"
+            placeholder="e.g. 1200"
+            autofocus
+          />
+        </label>
+
+        <label class="ob-field" v-if="showRanked">
+          <span class="ob-label">Ranked</span>
+          <input
+            v-model="ranked"
+            type="number"
+            step="any"
+            inputmode="numeric"
+            placeholder="e.g. 18000"
+          />
+        </label>
+
+        <p v-if="saveError" class="ob-error" role="alert">{{ saveError }}</p>
+
+        <div class="ob-actions">
+          <button type="submit" class="btn-primary" :disabled="!canSave || isSaving">
+            {{ isSaving ? "Saving…" : "Get started" }}
+          </button>
+          <button type="button" class="btn-ghost" :disabled="isSaving" @click="skip">
+            Skip for now
+          </button>
+        </div>
+      </form>
+
+      <p class="ob-note">Saved as today's entry — you can edit it any time.</p>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref } from "vue";
+
+// eslint-disable-next-line no-undef
+const props = defineProps({
+  // Modes to prompt for; Ranked is omitted when the user lacks the flag.
+  modes: { type: Array, required: true },
+  isSaving: { type: Boolean, default: false },
+  saveError: { type: String, default: "" },
+});
+
+// eslint-disable-next-line no-undef
+const emit = defineEmits(["save", "skip"]);
+
+// Kept as strings so a blank field stays blank ("don't record this mode")
+// rather than coercing to 0, which would anchor that mode's graph at zero.
+const worldTour = ref("");
+const ranked = ref("");
+
+const showRanked = computed(() => props.modes.includes("ranked"));
+
+function entered(mode) {
+  const raw = mode === "ranked" ? ranked.value : worldTour.value;
+  return String(raw).trim() !== "" && isFinite(Number(raw));
+}
+
+// At least one total is needed — otherwise "Get started" would do nothing that
+// "Skip for now" doesn't already do.
+const canSave = computed(() => props.modes.some(entered));
+
+function onSave() {
+  if (!canSave.value || props.isSaving) return;
+  const values = {};
+  for (const mode of props.modes) {
+    if (entered(mode)) {
+      values[mode] = Number(mode === "ranked" ? ranked.value : worldTour.value);
+    }
+  }
+  emit("save", values);
+}
+
+function skip() {
+  emit("skip");
+}
+</script>
+
+<style scoped>
+.onboarding {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 24px 16px;
+}
+
+.ob-card {
+  width: 100%;
+  max-width: 440px;
+  text-align: left;
+  padding: 24px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in oklab, var(--primary) 24%, var(--surface));
+  background: color-mix(in oklab, var(--surface) 90%, #000);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+}
+
+.ob-card h2 {
+  margin: 0 0 8px;
+  color: var(--text-strong);
+  font-size: 20px;
+  letter-spacing: 0.02em;
+}
+
+.ob-lede {
+  margin: 0 0 20px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.ob-form {
+  display: grid;
+  gap: 14px;
+}
+
+.ob-field {
+  display: grid;
+  gap: 6px;
+}
+
+.ob-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 900;
+}
+
+.ob-field input {
+  width: 100%;
+  min-width: 0;
+}
+
+.ob-error {
+  margin: 0;
+  color: #ff6b6b;
+  font-size: 13px;
+}
+
+.ob-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.ob-actions .btn-primary {
+  flex: 1 1 auto;
+}
+
+.ob-note {
+  margin: 16px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+@media (max-width: 480px) {
+  .ob-actions button {
+    flex: 1 1 100%;
+    min-height: 44px;
+  }
+}
+</style>

--- a/packages/web/src/composables/useOnboarding.js
+++ b/packages/web/src/composables/useOnboarding.js
@@ -2,17 +2,35 @@ import { computed, ref } from 'vue'
 import { getRecords, upsertRecord, getAuthorizationHeader } from '@/services/api'
 import { formatDate } from '@/utils/date'
 import { primeRecords, clearRecordsCache } from '@/services/recordsCache'
+import { getClerkUserSync, isClerkEnabled } from '@/services/clerk'
 
-// Set once onboarding is settled for this user, by any route: they saved their
+// Set once onboarding is settled for a user, by any route: they saved their
 // totals, they skipped, or the check found they already have records. Detection
 // is server-side, so this is purely a "don't probe again" marker — without it
 // every returning user would refetch their records on every load just to
 // rediscover that they're not new.
-const RESOLVED_KEY = 'onboarding.resolved'
+//
+// Scoped per user id, because browsers are shared. A single global flag would
+// mean the first account to resolve onboarding silently suppresses it for every
+// later account on that browser — a genuinely new user would be dropped
+// straight onto a zero graph, which is the exact thing this prompt exists to
+// prevent.
+const RESOLVED_KEY_PREFIX = 'onboarding.resolved'
 
-function isResolvedLocally() {
+// Dev-auth mode has one fixed user, so a single bucket is correct there.
+const DEV_SCOPE = 'dev'
+
+/** Stable per-user storage scope, or null if we can't identify the user yet. */
+function currentScope() {
+  if (!isClerkEnabled()) return DEV_SCOPE
+  return getClerkUserSync()?.id ?? null
+}
+
+function isResolvedLocally(scope) {
+  // Unknown user — fail safe by probing rather than trusting someone else's flag.
+  if (!scope) return false
   try {
-    return localStorage.getItem(RESOLVED_KEY) === '1'
+    return localStorage.getItem(`${RESOLVED_KEY_PREFIX}.${scope}`) === '1'
   } catch {
     // Private mode / storage disabled — treat as unresolved. Worst case we
     // probe again, which is better than crashing the app shell.
@@ -20,9 +38,10 @@ function isResolvedLocally() {
   }
 }
 
-function markResolved() {
+function markResolved(scope) {
+  if (!scope) return
   try {
-    localStorage.setItem(RESOLVED_KEY, '1')
+    localStorage.setItem(`${RESOLVED_KEY_PREFIX}.${scope}`, '1')
   } catch {
     // Non-fatal; see isResolvedLocally.
   }
@@ -37,6 +56,9 @@ function markResolved() {
 const needed = ref(null)
 const isSaving = ref(false)
 const saveError = ref('')
+
+// Bumped per probe so a superseded one can't overwrite newer state.
+let checkGeneration = 0
 
 const isResolved = computed(() => needed.value !== null)
 
@@ -54,20 +76,35 @@ const isDashboardVisible = computed(() => needed.value === false)
  */
 export function useOnboarding() {
   async function check(modes) {
-    if (isResolvedLocally()) {
-      needed.value = false
+    // The shell remounts when the signed-in account changes. Reset rather than
+    // inheriting the previous user's answer, which would otherwise render the
+    // dashboard for the new account while their probe is still in flight — and
+    // discard any records cached for the previous account, so the dashboard
+    // can't be handed someone else's data.
+    const generation = ++checkGeneration
+    const isCurrent = () => generation === checkGeneration
+    needed.value = null
+    clearRecordsCache()
+
+    const scope = currentScope()
+    if (isResolvedLocally(scope)) {
+      if (isCurrent()) needed.value = false
       return
     }
     try {
       const authHeader = await getAuthorizationHeader()
       if (!authHeader) {
         // Signed out — the auth gate handles this; nothing to onboard.
-        needed.value = false
+        if (isCurrent()) needed.value = false
         return
       }
       const results = await Promise.all(
         modes.map((mode) => getRecords(authHeader, mode))
       )
+      // A newer probe started while we were awaiting — its account's state is
+      // the truth now, so drop this result instead of overwriting it.
+      if (!isCurrent()) return
+
       needed.value = results.every((records) => !records.length)
       // The dashboard is about to load these same records; hand them over
       // rather than making it fetch them again. Accurate whichever way the
@@ -76,13 +113,13 @@ export function useOnboarding() {
       if (!needed.value) {
         // They already have data, so they're settled — record that locally so
         // later loads skip this probe entirely instead of re-asking the server.
-        markResolved()
+        markResolved(scope)
       }
     } catch (e) {
       // Never let a failed probe block the app — fall through to the dashboard,
       // which surfaces its own load error if the API is genuinely down.
       console.warn('Failed to determine onboarding state', e)
-      needed.value = false
+      if (isCurrent()) needed.value = false
     }
   }
 
@@ -105,7 +142,7 @@ export function useOnboarding() {
       // We just wrote records, so anything the check cached is now stale — the
       // dashboard must fetch fresh or it would render the pre-save empty state.
       clearRecordsCache()
-      markResolved()
+      markResolved(currentScope())
       needed.value = false
       return true
     } catch (e) {
@@ -120,7 +157,7 @@ export function useOnboarding() {
   function skip() {
     // Nothing was written, so whatever the check cached is still accurate and
     // the dashboard can use it.
-    markResolved()
+    markResolved(currentScope())
     needed.value = false
   }
 

--- a/packages/web/src/composables/useOnboarding.js
+++ b/packages/web/src/composables/useOnboarding.js
@@ -1,0 +1,128 @@
+import { computed, ref } from 'vue'
+import { getRecords, upsertRecord, getAuthorizationHeader } from '@/services/api'
+import { formatDate } from '@/utils/date'
+
+// Set once the user has either saved their starting totals or skipped the
+// prompt. Detection is server-side (no records in any prompted mode), so this
+// flag exists only to stop nagging someone who genuinely has zero points and
+// chose to skip — they'd otherwise see the prompt on every launch.
+const DISMISSED_KEY = 'onboarding.dismissed'
+
+function isDismissed() {
+  try {
+    return localStorage.getItem(DISMISSED_KEY) === '1'
+  } catch {
+    // Private mode / storage disabled — treat as not dismissed. Worst case the
+    // prompt reappears, which is better than crashing the app shell.
+    return false
+  }
+}
+
+function markDismissed() {
+  try {
+    localStorage.setItem(DISMISSED_KEY, '1')
+  } catch {
+    // Non-fatal; see isDismissed.
+  }
+}
+
+// Module-level singleton (same pattern as useFlags) so the app shell and the
+// header share one resolved state — the header needs it to hide the mode
+// switcher while onboarding is up, and it sits outside the shell's subtree.
+//
+// null = not yet determined, so callers can hold the UI back instead of
+// flashing the dashboard and then covering it with the prompt.
+const needed = ref(null)
+const isSaving = ref(false)
+const saveError = ref('')
+
+const isResolved = computed(() => needed.value !== null)
+
+/** True only once we know the user is past onboarding and the dashboard is up. */
+const isDashboardVisible = computed(() => needed.value === false)
+
+/**
+ * Decides whether to show the first-launch "enter your current totals" prompt,
+ * and saves what the user enters as today's record in each mode.
+ *
+ * A user is considered new when they have no records at all in any of the modes
+ * we'd prompt for. `modes` is passed in rather than hardcoded because Ranked is
+ * behind a feature flag on web — a user without it should neither be asked for
+ * a Ranked total nor kept out of the app by Ranked data they can't create.
+ */
+export function useOnboarding() {
+  async function check(modes) {
+    if (isDismissed()) {
+      needed.value = false
+      return
+    }
+    try {
+      const authHeader = await getAuthorizationHeader()
+      if (!authHeader) {
+        // Signed out — the auth gate handles this; nothing to onboard.
+        needed.value = false
+        return
+      }
+      const results = await Promise.all(
+        modes.map((mode) => getRecords(authHeader, mode))
+      )
+      needed.value = results.every((records) => !records.length)
+    } catch (e) {
+      // Never let a failed probe block the app — fall through to the dashboard,
+      // which surfaces its own load error if the API is genuinely down.
+      console.warn('Failed to determine onboarding state', e)
+      needed.value = false
+    }
+  }
+
+  /**
+   * Persist the totals the user filled in as today's record, one per mode.
+   * `values` only carries the modes they actually entered — a player who only
+   * plays one mode shouldn't get a phantom 0 in the other, which would anchor
+   * that mode's graph and pace at zero.
+   */
+  async function save(values) {
+    isSaving.value = true
+    saveError.value = ''
+    try {
+      const authHeader = await getAuthorizationHeader()
+      if (!authHeader) throw new Error('Not signed in')
+      const today = formatDate(new Date())
+      for (const [mode, winPoints] of Object.entries(values)) {
+        await upsertRecord(today, Number(winPoints), authHeader, mode)
+      }
+      markDismissed()
+      needed.value = false
+      return true
+    } catch (e) {
+      console.error('Failed to save starting totals', e)
+      saveError.value = 'Could not save. Please try again.'
+      return false
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  function skip() {
+    markDismissed()
+    needed.value = false
+  }
+
+  return {
+    needed,
+    isResolved,
+    isDashboardVisible,
+    isSaving,
+    saveError,
+    check,
+    save,
+    skip,
+  }
+}
+
+/** Test-only: clear the module singleton so specs don't leak state into each other. */
+export function resetOnboardingStateForTests() {
+  needed.value = null
+  isSaving.value = false
+  saveError.value = ''
+}

--- a/packages/web/src/composables/useOnboarding.js
+++ b/packages/web/src/composables/useOnboarding.js
@@ -1,28 +1,30 @@
 import { computed, ref } from 'vue'
 import { getRecords, upsertRecord, getAuthorizationHeader } from '@/services/api'
 import { formatDate } from '@/utils/date'
+import { primeRecords, clearRecordsCache } from '@/services/recordsCache'
 
-// Set once the user has either saved their starting totals or skipped the
-// prompt. Detection is server-side (no records in any prompted mode), so this
-// flag exists only to stop nagging someone who genuinely has zero points and
-// chose to skip — they'd otherwise see the prompt on every launch.
-const DISMISSED_KEY = 'onboarding.dismissed'
+// Set once onboarding is settled for this user, by any route: they saved their
+// totals, they skipped, or the check found they already have records. Detection
+// is server-side, so this is purely a "don't probe again" marker — without it
+// every returning user would refetch their records on every load just to
+// rediscover that they're not new.
+const RESOLVED_KEY = 'onboarding.resolved'
 
-function isDismissed() {
+function isResolvedLocally() {
   try {
-    return localStorage.getItem(DISMISSED_KEY) === '1'
+    return localStorage.getItem(RESOLVED_KEY) === '1'
   } catch {
-    // Private mode / storage disabled — treat as not dismissed. Worst case the
-    // prompt reappears, which is better than crashing the app shell.
+    // Private mode / storage disabled — treat as unresolved. Worst case we
+    // probe again, which is better than crashing the app shell.
     return false
   }
 }
 
-function markDismissed() {
+function markResolved() {
   try {
-    localStorage.setItem(DISMISSED_KEY, '1')
+    localStorage.setItem(RESOLVED_KEY, '1')
   } catch {
-    // Non-fatal; see isDismissed.
+    // Non-fatal; see isResolvedLocally.
   }
 }
 
@@ -52,7 +54,7 @@ const isDashboardVisible = computed(() => needed.value === false)
  */
 export function useOnboarding() {
   async function check(modes) {
-    if (isDismissed()) {
+    if (isResolvedLocally()) {
       needed.value = false
       return
     }
@@ -67,6 +69,15 @@ export function useOnboarding() {
         modes.map((mode) => getRecords(authHeader, mode))
       )
       needed.value = results.every((records) => !records.length)
+      // The dashboard is about to load these same records; hand them over
+      // rather than making it fetch them again. Accurate whichever way the
+      // check went — `save` clears the cache, since it makes them stale.
+      modes.forEach((mode, i) => primeRecords(mode, results[i]))
+      if (!needed.value) {
+        // They already have data, so they're settled — record that locally so
+        // later loads skip this probe entirely instead of re-asking the server.
+        markResolved()
+      }
     } catch (e) {
       // Never let a failed probe block the app — fall through to the dashboard,
       // which surfaces its own load error if the API is genuinely down.
@@ -91,7 +102,10 @@ export function useOnboarding() {
       for (const [mode, winPoints] of Object.entries(values)) {
         await upsertRecord(today, Number(winPoints), authHeader, mode)
       }
-      markDismissed()
+      // We just wrote records, so anything the check cached is now stale — the
+      // dashboard must fetch fresh or it would render the pre-save empty state.
+      clearRecordsCache()
+      markResolved()
       needed.value = false
       return true
     } catch (e) {
@@ -104,7 +118,9 @@ export function useOnboarding() {
   }
 
   function skip() {
-    markDismissed()
+    // Nothing was written, so whatever the check cached is still accurate and
+    // the dashboard can use it.
+    markResolved()
     needed.value = false
   }
 

--- a/packages/web/src/composables/usePointsData.js
+++ b/packages/web/src/composables/usePointsData.js
@@ -9,6 +9,7 @@ import {
   getAuthorizationHeader,
 } from '@/services/api'
 import { connectLiveUpdates } from '@/services/liveUpdates'
+import { takeRecords } from '@/services/recordsCache'
 
 /**
  * Manages the points array and all API-backed CRUD operations.
@@ -121,13 +122,21 @@ export function usePointsData({ isSeasonValid, seasonStart, seasonEnd, autoSetSe
     isLoading.value = true
     loadError.value = ''
     try {
-      const authHeader = await getAuthorizationHeader()
-      if (!authHeader) {
-        isAuthenticated.value = false
-        return
+      // The onboarding check fetches records moments before the dashboard
+      // mounts; take those rather than asking for them a second time. Reaching
+      // them means we were authenticated, since the check needed a token too.
+      let records = takeRecords(mode)
+      if (records) {
+        isAuthenticated.value = true
+      } else {
+        const authHeader = await getAuthorizationHeader()
+        if (!authHeader) {
+          isAuthenticated.value = false
+          return
+        }
+        isAuthenticated.value = true
+        records = await getRecords(authHeader, mode)
       }
-      isAuthenticated.value = true
-      const records = await getRecords(authHeader, mode)
       const mapped = records.map((r) => ({
         remoteId: r.id,
         date: typeof r.date === 'string' ? r.date.slice(0, 10) : '',

--- a/packages/web/src/services/recordsCache.js
+++ b/packages/web/src/services/recordsCache.js
@@ -1,0 +1,27 @@
+// Records fetched by the onboarding check, handed to the dashboard so its first
+// load doesn't refetch what we pulled moments earlier. Entries are single-use
+// and short-lived: this exists to bridge one app-boot handoff, not to be a
+// general cache. Anything that misses simply fetches as normal.
+
+const entries = new Map()
+
+// Long enough to cover the gap between the check resolving and the dashboard
+// mounting; short enough that a mode the user opens later still refetches.
+const MAX_AGE_MS = 30_000
+
+export function primeRecords(mode, records) {
+  entries.set(mode, { records, at: Date.now() })
+}
+
+/** Returns the cached records for `mode` and drops them, or null if absent/stale. */
+export function takeRecords(mode) {
+  const entry = entries.get(mode)
+  if (!entry) return null
+  entries.delete(mode)
+  if (Date.now() - entry.at > MAX_AGE_MS) return null
+  return entry.records
+}
+
+export function clearRecordsCache() {
+  entries.clear()
+}

--- a/packages/web/tests/recordsCache.spec.js
+++ b/packages/web/tests/recordsCache.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  primeRecords,
+  takeRecords,
+  clearRecordsCache,
+} from '@/services/recordsCache'
+
+// The onboarding check and the dashboard's first load would otherwise fetch the
+// same records back to back. The cache bridges that one handoff.
+describe('recordsCache', () => {
+  beforeEach(() => {
+    clearRecordsCache()
+  })
+
+  it('hands primed records to the matching mode', () => {
+    const records = [{ id: 'r1', winPoints: 100 }]
+    primeRecords('world-tour', records)
+
+    expect(takeRecords('world-tour')).toEqual(records)
+  })
+
+  it('is single-use, so a later reload fetches fresh', () => {
+    primeRecords('world-tour', [{ id: 'r1' }])
+
+    expect(takeRecords('world-tour')).not.toBe(null)
+    expect(takeRecords('world-tour')).toBe(null)
+  })
+
+  it('keeps modes separate', () => {
+    primeRecords('ranked', [{ id: 'r1' }])
+
+    expect(takeRecords('world-tour')).toBe(null)
+    expect(takeRecords('ranked')).not.toBe(null)
+  })
+
+  it('returns null for a mode that was never primed', () => {
+    expect(takeRecords('world-tour')).toBe(null)
+  })
+
+  describe('staleness', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('serves records within the handoff window', () => {
+      primeRecords('world-tour', [{ id: 'r1' }])
+      vi.advanceTimersByTime(5_000)
+
+      expect(takeRecords('world-tour')).not.toBe(null)
+    })
+
+    it('drops records the user only reaches much later', () => {
+      // e.g. primed for Ranked at boot, but they open Ranked minutes later —
+      // that data is no longer trustworthy, so refetch.
+      primeRecords('ranked', [{ id: 'r1' }])
+      vi.advanceTimersByTime(60_000)
+
+      expect(takeRecords('ranked')).toBe(null)
+    })
+  })
+
+  it('clears everything on demand', () => {
+    primeRecords('world-tour', [{ id: 'r1' }])
+    primeRecords('ranked', [{ id: 'r2' }])
+    clearRecordsCache()
+
+    expect(takeRecords('world-tour')).toBe(null)
+    expect(takeRecords('ranked')).toBe(null)
+  })
+})

--- a/packages/web/tests/useOnboarding.spec.js
+++ b/packages/web/tests/useOnboarding.spec.js
@@ -10,6 +10,13 @@ vi.mock('@/services/api', () => ({
   getAuthorizationHeader: (...args) => getAuthorizationHeader(...args),
 }))
 
+// The resolved flag is scoped per user id, so specs control who is signed in.
+let currentUser = { id: 'user_a' }
+vi.mock('@/services/clerk', () => ({
+  isClerkEnabled: () => true,
+  getClerkUserSync: () => currentUser,
+}))
+
 const store = new Map()
 vi.stubGlobal('localStorage', {
   getItem: (k) => (store.has(k) ? store.get(k) : null),
@@ -32,6 +39,7 @@ describe('useOnboarding', () => {
     resetOnboardingStateForTests()
     clearRecordsCache()
     store.clear()
+    currentUser = { id: 'user_a' }
     getRecords.mockReset()
     upsertRecord.mockReset().mockResolvedValue({ record: { id: 'r1' } })
     getAuthorizationHeader.mockReset().mockResolvedValue('Bearer token')
@@ -135,6 +143,102 @@ describe('useOnboarding', () => {
 
       expect(needed.value).toBe(false)
       expect(getRecords).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('account switching on a shared browser', () => {
+    it('still onboards a new user after a different account resolved it here', async () => {
+      // A single global flag would let the first account silently suppress the
+      // prompt for everyone who signs in afterwards — dropping a genuinely new
+      // user onto a zero graph, the exact thing this prompt exists to prevent.
+      getRecords.mockResolvedValue([{ id: 'r1', winPoints: 100 }])
+      const settled = useOnboarding()
+      await settled.check(BOTH)
+      expect(settled.needed.value).toBe(false)
+
+      currentUser = { id: 'user_b' }
+      resetOnboardingStateForTests()
+      getRecords.mockResolvedValue([])
+      const newcomer = useOnboarding()
+      await newcomer.check(BOTH)
+
+      expect(newcomer.needed.value).toBe(true)
+    })
+
+    it('keeps each account resolved independently', async () => {
+      getRecords.mockResolvedValue([{ id: 'r1' }])
+      await useOnboarding().check(BOTH)
+
+      currentUser = { id: 'user_b' }
+      resetOnboardingStateForTests()
+      getRecords.mockResolvedValue([])
+      const b = useOnboarding()
+      await b.check(BOTH)
+      b.skip()
+
+      // Returning to A must not re-probe: their flag is still set.
+      currentUser = { id: 'user_a' }
+      resetOnboardingStateForTests()
+      getRecords.mockClear()
+      const a = useOnboarding()
+      await a.check(BOTH)
+
+      expect(a.needed.value).toBe(false)
+      expect(getRecords).not.toHaveBeenCalled()
+    })
+
+    it('probes rather than trusting a flag when the user is unidentifiable', async () => {
+      getRecords.mockResolvedValue([{ id: 'r1' }])
+      await useOnboarding().check(BOTH)
+
+      currentUser = null
+      resetOnboardingStateForTests()
+      getRecords.mockClear().mockResolvedValue([])
+      const unknown = useOnboarding()
+      await unknown.check(BOTH)
+
+      expect(getRecords).toHaveBeenCalled()
+      expect(unknown.needed.value).toBe(true)
+    })
+
+    it('clears state and cached records when a new probe starts', async () => {
+      // A remount must not render the dashboard for the new account off the
+      // previous one's answer, nor hand it the previous one's records.
+      getRecords.mockResolvedValue([{ id: 'r1', winPoints: 100 }])
+      const first = useOnboarding()
+      await first.check(BOTH)
+      expect(first.needed.value).toBe(false)
+
+      currentUser = { id: 'user_b' }
+      getRecords.mockResolvedValue([])
+      const second = useOnboarding()
+      const inFlight = second.check(BOTH)
+      expect(second.needed.value).toBe(null)
+      expect(takeRecords(WT)).toBe(null)
+
+      await inFlight
+      expect(second.needed.value).toBe(true)
+    })
+
+    it('lets a newer probe win when two overlap', async () => {
+      // Account A's slow probe must not overwrite account B's newer result.
+      let resolveSlow
+      getRecords.mockImplementationOnce(
+        () => new Promise((r) => { resolveSlow = () => r([{ id: 'r1' }]) })
+      )
+      const { check, needed } = useOnboarding()
+      const slow = check([WT])
+
+      getRecords.mockResolvedValue([])
+      currentUser = { id: 'user_b' }
+      await check([WT])
+      expect(needed.value).toBe(true)
+
+      resolveSlow()
+      await slow
+
+      // The stale probe found records, but it's superseded — B is still new.
+      expect(needed.value).toBe(true)
     })
   })
 
@@ -285,7 +389,7 @@ describe('useOnboarding', () => {
       expect(ok).toBe(false)
       expect(needed.value).toBe(true)
       expect(saveError.value).toBeTruthy()
-      expect(localStorage.getItem('onboarding.resolved')).toBe(null)
+      expect(localStorage.getItem('onboarding.resolved.user_a')).toBe(null)
     })
   })
 })

--- a/packages/web/tests/useOnboarding.spec.js
+++ b/packages/web/tests/useOnboarding.spec.js
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const getRecords = vi.fn()
+const upsertRecord = vi.fn()
+const getAuthorizationHeader = vi.fn()
+
+vi.mock('@/services/api', () => ({
+  getRecords: (...args) => getRecords(...args),
+  upsertRecord: (...args) => upsertRecord(...args),
+  getAuthorizationHeader: (...args) => getAuthorizationHeader(...args),
+}))
+
+const store = new Map()
+vi.stubGlobal('localStorage', {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+})
+
+const { useOnboarding, resetOnboardingStateForTests } = await import(
+  '@/composables/useOnboarding'
+)
+
+const WT = 'world-tour'
+const BOTH = [WT, 'ranked']
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    // State is a module singleton (the header and app shell share it), so it
+    // must be cleared between specs.
+    resetOnboardingStateForTests()
+    store.clear()
+    getRecords.mockReset()
+    upsertRecord.mockReset().mockResolvedValue({ record: { id: 'r1' } })
+    getAuthorizationHeader.mockReset().mockResolvedValue('Bearer token')
+  })
+
+  describe('check', () => {
+    it('prompts a user with no records in any mode', async () => {
+      getRecords.mockResolvedValue([])
+      const { needed, isResolved, check } = useOnboarding()
+
+      expect(isResolved.value).toBe(false)
+      await check(BOTH)
+
+      expect(needed.value).toBe(true)
+      expect(isResolved.value).toBe(true)
+    })
+
+    it('does not prompt when any prompted mode already has records', async () => {
+      getRecords.mockImplementation((_auth, mode) =>
+        Promise.resolve(mode === 'ranked' ? [{ id: 'r1', winPoints: 18000 }] : [])
+      )
+      const { needed, check } = useOnboarding()
+      await check(BOTH)
+
+      expect(needed.value).toBe(false)
+    })
+
+    it('only checks the modes it would prompt for', async () => {
+      // Ranked is flag-gated on web: a user without the flag shouldn't be held in
+      // onboarding by Ranked data, nor probed for it.
+      getRecords.mockResolvedValue([])
+      const { needed, check } = useOnboarding()
+      await check([WT])
+
+      expect(needed.value).toBe(true)
+      expect(getRecords).toHaveBeenCalledTimes(1)
+      expect(getRecords).toHaveBeenCalledWith('Bearer token', WT)
+    })
+
+    it('does not prompt again once dismissed', async () => {
+      getRecords.mockResolvedValue([])
+      const first = useOnboarding()
+      await first.check(BOTH)
+      first.skip()
+
+      // Simulate a fresh page load: in-memory state is gone, the flag persists.
+      resetOnboardingStateForTests()
+      const second = useOnboarding()
+      getRecords.mockClear()
+      await second.check(BOTH)
+
+      expect(second.needed.value).toBe(false)
+      expect(getRecords).not.toHaveBeenCalled()
+    })
+
+    it('falls through to the app when the probe fails', async () => {
+      getRecords.mockRejectedValue(new Error('network down'))
+      const { needed, check } = useOnboarding()
+      await check(BOTH)
+
+      expect(needed.value).toBe(false)
+    })
+
+    it('does not prompt when signed out', async () => {
+      getAuthorizationHeader.mockResolvedValue(null)
+      const { needed, check } = useOnboarding()
+      await check(BOTH)
+
+      expect(needed.value).toBe(false)
+      expect(getRecords).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('isDashboardVisible', () => {
+    // Drives whether the header shows the mode switcher: switching modes behind
+    // the prompt would change the route without dismissing it.
+    it('is false while the check is still in flight', () => {
+      const { isDashboardVisible } = useOnboarding()
+      expect(isDashboardVisible.value).toBe(false)
+    })
+
+    it('stays false while the prompt is up', async () => {
+      getRecords.mockResolvedValue([])
+      const { isDashboardVisible, check } = useOnboarding()
+      await check(BOTH)
+
+      expect(isDashboardVisible.value).toBe(false)
+    })
+
+    it('becomes true once onboarding resolves as not needed', async () => {
+      getRecords.mockResolvedValue([{ id: 'r1', winPoints: 100 }])
+      const { isDashboardVisible, check } = useOnboarding()
+      await check(BOTH)
+
+      expect(isDashboardVisible.value).toBe(true)
+    })
+
+    it('becomes true after the user saves', async () => {
+      getRecords.mockResolvedValue([])
+      const { isDashboardVisible, check, save } = useOnboarding()
+      await check(BOTH)
+      await save({ [WT]: 1200 })
+
+      expect(isDashboardVisible.value).toBe(true)
+    })
+
+    it('becomes true after the user skips', async () => {
+      getRecords.mockResolvedValue([])
+      const { isDashboardVisible, check, skip } = useOnboarding()
+      await check(BOTH)
+      skip()
+
+      expect(isDashboardVisible.value).toBe(true)
+    })
+
+    it('is shared across call sites', async () => {
+      // The header and the app shell each call useOnboarding() separately.
+      getRecords.mockResolvedValue([])
+      const shell = useOnboarding()
+      const header = useOnboarding()
+
+      await shell.check(BOTH)
+      expect(header.isDashboardVisible.value).toBe(false)
+
+      shell.skip()
+      expect(header.isDashboardVisible.value).toBe(true)
+    })
+  })
+
+  describe('save', () => {
+    it("writes each entered total as today's record in its own mode", async () => {
+      const { needed, save } = useOnboarding()
+      const ok = await save({ [WT]: 1200, ranked: 18000 })
+
+      expect(ok).toBe(true)
+      expect(needed.value).toBe(false)
+      expect(upsertRecord).toHaveBeenCalledTimes(2)
+
+      const today = new Date()
+      const expectedDate = [
+        today.getFullYear(),
+        String(today.getMonth() + 1).padStart(2, '0'),
+        String(today.getDate()).padStart(2, '0'),
+      ].join('-')
+
+      expect(upsertRecord).toHaveBeenCalledWith(expectedDate, 1200, 'Bearer token', WT)
+      expect(upsertRecord).toHaveBeenCalledWith(expectedDate, 18000, 'Bearer token', 'ranked')
+    })
+
+    it('does not write a mode the user left blank', async () => {
+      // A phantom 0 would anchor that mode's graph and pace at zero.
+      const { save } = useOnboarding()
+      await save({ [WT]: 1200 })
+
+      expect(upsertRecord).toHaveBeenCalledTimes(1)
+      expect(upsertRecord).toHaveBeenCalledWith(expect.any(String), 1200, 'Bearer token', WT)
+    })
+
+    it('keeps the prompt up and surfaces an error when saving fails', async () => {
+      upsertRecord.mockRejectedValue(new Error('500'))
+      const { needed, saveError, save, check } = useOnboarding()
+      getRecords.mockResolvedValue([])
+      await check(BOTH)
+
+      const ok = await save({ [WT]: 1200 })
+
+      expect(ok).toBe(false)
+      expect(needed.value).toBe(true)
+      expect(saveError.value).toBeTruthy()
+      expect(localStorage.getItem('onboarding.dismissed')).toBe(null)
+    })
+  })
+})

--- a/packages/web/tests/useOnboarding.spec.js
+++ b/packages/web/tests/useOnboarding.spec.js
@@ -20,6 +20,7 @@ vi.stubGlobal('localStorage', {
 const { useOnboarding, resetOnboardingStateForTests } = await import(
   '@/composables/useOnboarding'
 )
+const { takeRecords, clearRecordsCache } = await import('@/services/recordsCache')
 
 const WT = 'world-tour'
 const BOTH = [WT, 'ranked']
@@ -29,6 +30,7 @@ describe('useOnboarding', () => {
     // State is a module singleton (the header and app shell share it), so it
     // must be cleared between specs.
     resetOnboardingStateForTests()
+    clearRecordsCache()
     store.clear()
     getRecords.mockReset()
     upsertRecord.mockReset().mockResolvedValue({ record: { id: 'r1' } })
@@ -69,6 +71,39 @@ describe('useOnboarding', () => {
       expect(getRecords).toHaveBeenCalledWith('Bearer token', WT)
     })
 
+    it('never probes again for a user who already has records', async () => {
+      // Otherwise every returning user refetches every mode on every load just
+      // to rediscover they aren't new.
+      getRecords.mockResolvedValue([{ id: 'r1', winPoints: 100 }])
+      const first = useOnboarding()
+      await first.check(BOTH)
+      expect(getRecords).toHaveBeenCalledTimes(2)
+
+      resetOnboardingStateForTests()
+      getRecords.mockClear()
+      const second = useOnboarding()
+      await second.check(BOTH)
+
+      expect(second.needed.value).toBe(false)
+      expect(getRecords).not.toHaveBeenCalled()
+    })
+
+    it('does prompt again if the user closed the tab without answering', async () => {
+      // Nothing was settled, so the probe must run again next load.
+      getRecords.mockResolvedValue([])
+      const first = useOnboarding()
+      await first.check(BOTH)
+      expect(first.needed.value).toBe(true)
+
+      resetOnboardingStateForTests()
+      getRecords.mockClear()
+      const second = useOnboarding()
+      await second.check(BOTH)
+
+      expect(second.needed.value).toBe(true)
+      expect(getRecords).toHaveBeenCalled()
+    })
+
     it('does not prompt again once dismissed', async () => {
       getRecords.mockResolvedValue([])
       const first = useOnboarding()
@@ -100,6 +135,57 @@ describe('useOnboarding', () => {
 
       expect(needed.value).toBe(false)
       expect(getRecords).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('records handoff', () => {
+    it('hands the fetched records to the dashboard instead of making it refetch', async () => {
+      const wtRecords = [{ id: 'r1', winPoints: 100 }]
+      const rkRecords = [{ id: 'r2', winPoints: 18000 }]
+      getRecords.mockImplementation((_auth, mode) =>
+        Promise.resolve(mode === 'ranked' ? rkRecords : wtRecords)
+      )
+      const { check } = useOnboarding()
+      await check(BOTH)
+
+      expect(takeRecords(WT)).toEqual(wtRecords)
+      expect(takeRecords('ranked')).toEqual(rkRecords)
+    })
+
+    it('hands over the empty result too, for a user who skips', async () => {
+      getRecords.mockResolvedValue([])
+      const { check, skip } = useOnboarding()
+      await check(BOTH)
+      skip()
+
+      // Nothing was written, so the empty result is still accurate.
+      expect(takeRecords(WT)).toEqual([])
+    })
+
+    it('invalidates the handoff after saving, since it is now stale', async () => {
+      // The cached result predates the write; serving it would render the
+      // dashboard empty despite the user having just entered a total.
+      getRecords.mockResolvedValue([])
+      const { check, save } = useOnboarding()
+      await check(BOTH)
+      await save({ [WT]: 1200 })
+
+      expect(takeRecords(WT)).toBe(null)
+      expect(takeRecords('ranked')).toBe(null)
+    })
+
+    it('caches nothing when the probe is skipped entirely', async () => {
+      getRecords.mockResolvedValue([{ id: 'r1' }])
+      const first = useOnboarding()
+      await first.check(BOTH)
+      clearRecordsCache()
+
+      resetOnboardingStateForTests()
+      const second = useOnboarding()
+      await second.check(BOTH)
+
+      // Resolved locally, so no fetch happened and there's nothing to hand over.
+      expect(takeRecords(WT)).toBe(null)
     })
   })
 
@@ -199,7 +285,7 @@ describe('useOnboarding', () => {
       expect(ok).toBe(false)
       expect(needed.value).toBe(true)
       expect(saveError.value).toBeTruthy()
-      expect(localStorage.getItem('onboarding.dismissed')).toBe(null)
+      expect(localStorage.getItem('onboarding.resolved')).toBe(null)
     })
   })
 })


### PR DESCRIPTION
## What

A brand-new user's graph started at zero regardless of where they actually were in the season. This prompts them once, on first launch, for their current World Tour and Ranked totals — on web, iOS, and Android.

## How it works

A user is treated as new when the server reports **no records in any prompted mode**. That's checked at the app shell before the dashboard renders, so the graph never flashes in and then gets covered by the prompt. Detection is server-side, so it holds across devices and reinstalls; a local `onboarding.resolved` flag records that the question is settled so later loads don't re-ask.

Entering totals writes one record per mode dated **today**. Blank fields are skipped rather than written as `0` — a phantom zero would anchor that mode's graph and pace at zero for a player who only plays one mode.

## Per platform

- **Web** — `useOnboarding.js` + `OnboardingPrompt.vue`, gated by a new `AppBody.vue` wrapping `<router-view>` in both the Clerk and dev-auth branches of `App.vue`. Ranked is flag-gated here, so a user without the `ranked` flag is neither asked for a Ranked total nor held in onboarding by data they can't create.
- **iOS** — `OnboardingStore.swift` + `OnboardingView.swift`, gated in `MainTabView`.
- **Android** — `OnboardingViewModel.kt` + `OnboardingScreen.kt`, gated in `MainScreen`. `WinPointsField` gained an optional `label` param so it could be reused per mode.

Two details worth a reviewer's attention:

- `useOnboarding` is a **module-level singleton** (matching the existing `useFlags` pattern) so `HeaderBar` — which sits outside the shell's subtree — can hide the mode switcher until the dashboard is up. Switching modes behind the prompt would otherwise change the route without dismissing it. This also keeps the switcher out of the signed-out view, where it previously rendered behind the sign-in screen.
- On iOS and Android the records load is **keyed on the onboarding state as well as the mode**, so finishing onboarding re-runs it. Without that the dashboard would render the empty result fetched before the starting totals were saved.

## Second commit: the check was costing every user, every load

The first commit shipped the check in a form that only short-circuited on the local flag — and that flag was written solely on save/skip. An existing user therefore resolved to "not new" but **never recorded it**, so every returning user refetched *every mode* on *every load* just to rediscover they weren't new. Three record fetches per load, indefinitely.

`87d57b6` fixes that two ways:

1. **Mark onboarding resolved whenever the check settles it**, including when it finds existing records, so returning users skip the probe entirely. The flag was renamed `onboarding.dismissed` -> `onboarding.resolved` on all three clients, since it no longer means "the user dismissed it".
2. **Hand the fetched records to the dashboard** through a short-lived single-use cache (`recordsCache.js`) rather than refetching the same rows. Entries expire after 30s so a mode opened later still refetches, and `save` clears the cache — serving it after a write would render the dashboard empty right after the user entered a total.

Measured in a browser, `GET /me/records` per page load:

| Scenario | Before | After |
|---|---|---|
| new user, first load | 3 | **2** (probe; dashboard reuses it) |
| after saving totals | 1 | 1 (cache invalidated, as intended) |
| returning user | 3 | **1** (no probe at all) |
| existing user at rollout | 3 every load | **2** first load, **1** after |

The mark-resolved fix landed on all three clients. The records handoff is **web-only** — mobile still does one duplicate fetch on the single probing launch, left alone rather than shipping cache plumbing to two platforms that can't be runtime-verified here.

## Verification

Driven end-to-end in a browser against a local worker (real time, no virtual-time fast-forward):

| Check | Result |
|---|---|
| existing user (has records) | dashboard renders, no prompt |
| new user (zero records both modes) | prompt appears with both fields |
| "Get started" with both fields blank | disabled |
| after entering World Tour only | enabled |
| after save | prompt gone, dashboard rendered, resolved flag set |
| records written | exactly one: `world-tour` / `1450` / today |
| ranked (left blank) | still empty — no phantom `0` |
| mode switcher during check + prompt | hidden |
| mode switcher after onboarding | visible with dashboard |
| request counts | per the table above, incl. correct value after save and across reloads |

Also: 152 web tests pass (21 onboarding, 7 records-cache), lint and production build clean, Android `compileDebugKotlin` + `testDebugUnitTest` pass, iOS `xtool dev build` succeeds.

**iOS and Android are compile-verified only** — their prompts haven't been driven in a simulator or emulator. Worth a manual pass with a fresh account before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
